### PR TITLE
fix(generator): pathOnly generation with only 1 element in imports

### DIFF
--- a/src/utils/generators/generateImports.ts
+++ b/src/utils/generators/generateImports.ts
@@ -2,16 +2,7 @@ import { camel } from "case";
 
 export const generateImports = (imports: string[] = [], path: string = '.', pathOnly: boolean = false) => {
   if (pathOnly) {
-    return imports.sort().reduce((acc, imp, index) => {
-      if (!acc) {
-        return `import { ${imp},\n`;
-      }
-      if (imports.length - 1 === index) {
-        return acc + `  ${imp},\n} from \'${path}\'; \n`;
-      }
-
-      return acc + `  ${imp},\n`;
-    }, '');
+    return `import {\n  ${imports.sort().join(',\n  ')}\n} from \'${path}\';\n`;
   }
-  return imports.sort().reduce((acc, imp) => acc + `import { ${imp} } from \'${path}/${camel(imp)}\'; \n`, '');
+  return imports.sort().map((imp) => `import { ${imp} } from \'${path}/${camel(imp)}\';\n`).join('');
 };


### PR DESCRIPTION
The reduce didn't add the `...} from '...';` if only 1 element inside `imports`.

Additionally, I rewrote the other line to make it cleaner (`reduce` should in general be avoided, for lack of clarity) 