### PR TITLE
fix(imports): return empty string when no imports needed.

### DIFF
--- a/src/core/generators/imports.ts
+++ b/src/core/generators/imports.ts
@@ -5,6 +5,9 @@ export const generateImports = (
   path: string = '.',
   pathOnly: boolean = false,
 ) => {
+  if (!imports.length) {
+    return '';
+  }
   if (pathOnly) {
     return `import {\n  ${imports
       .sort()


### PR DESCRIPTION
## Status
**READY**

## Description
When an output file doesn't require imports, it sometimes breaks due to an extra comma leading to a syntax error. Solution is to not generate the imports if the array is empty.
