### PR TITLE
fixes for tags mode

### DIFF
--- a/src/core/writers/tagsMode.ts
+++ b/src/core/writers/tagsMode.ts
@@ -21,6 +21,11 @@ import { generateImports } from '../generators/imports';
 import { generateModelsInline } from '../generators/modelsInline';
 import { resolvePath } from '../resolvers/path';
 
+const addDefaultTagIfEmpty = (operation: GeneratorOperation) => ({
+  ...operation,
+  tags: operation.tags.length ? operation.tags : ['default'],
+});
+
 const generateTargetTags = (
   currentAcc: { [key: string]: GeneratorTarget },
   operation: GeneratorOperation,
@@ -64,28 +69,30 @@ export const generateTarget = (
   operations: GeneratorOperations,
   info: InfoObject,
 ) =>
-  Object.values(operations).reduce((acc, operation, index, arr) => {
-    const targetTags = generateTargetTags(acc, operation, info);
+  Object.values(operations)
+    .map(addDefaultTagIfEmpty)
+    .reduce((acc, operation, index, arr) => {
+      const targetTags = generateTargetTags(acc, operation, info);
 
-    if (index === arr.length - 1) {
-      const footer = generateClientFooter();
+      if (index === arr.length - 1) {
+        const footer = generateClientFooter();
 
-      return Object.entries(targetTags).reduce((acc, [tag, target]) => {
-        return {
-          ...acc,
-          [tag]: {
-            definition: target.definition + footer.definition,
-            implementation: target.implementation + footer.implementation,
-            implementationMocks:
-              target.implementationMocks + footer.implementationMock,
-            imports: generalTypesFilter(target.imports),
-          },
-        };
-      }, {});
-    }
+        return Object.entries(targetTags).reduce((acc, [tag, target]) => {
+          return {
+            ...acc,
+            [tag]: {
+              definition: target.definition + footer.definition,
+              implementation: target.implementation + footer.implementation,
+              implementationMocks:
+                target.implementationMocks + footer.implementationMock,
+              imports: generalTypesFilter(target.imports),
+            },
+          };
+        }, {});
+      }
 
-    return targetTags;
-  }, {} as { [key: string]: GeneratorTarget });
+      return targetTags;
+    }, {} as { [key: string]: GeneratorTarget });
 
 export const writeTagsMode = ({
   operations,

--- a/src/core/writers/tagsMode.ts
+++ b/src/core/writers/tagsMode.ts
@@ -29,7 +29,7 @@ const generateTargetTags = (
   operation.tags.reduce((acc, tag) => {
     const currentOperation = acc[tag];
     if (!currentOperation) {
-      const header = generateClientHeader(pascal(info.title + tag));
+      const header = generateClientHeader(pascal(`${info.title} ${tag}`));
 
       return {
         ...acc,


### PR DESCRIPTION
## Status
**READY**

## Description
- Interface name was not properly pascal cased (the tag part was lowercase due to being concatenated before going into `pascal()` function)
- The tags mode didn't generate any output for operations that had no tag. This is changed by adding the `"default"` tag on such operations.
