### PR TITLE
fix(scalar): default 'type' to array when 'items' is defined on a schema

### DIFF
--- a/src/core/getters/scalar.ts
+++ b/src/core/getters/scalar.ts
@@ -12,6 +12,10 @@ import { getObject } from './object';
 export const getScalar = (item: SchemaObject, name?: string): ResolverValue => {
   const nullable = item.nullable ? ' | null' : '';
 
+  if (!item.type && item.items) {
+    item.type = 'array';
+  }
+
   switch (item.type) {
     case 'int32':
     case 'int64':


### PR DESCRIPTION
## Status
READY

## Description
A schema can sometimes be a valid array schema by just defining the 'items' prop. In such a scenario, the generated type was 'unknown'. This fixes it by applying the correct array logic to such definitions. (NestJS swagger plugin generates swagger-json with 'type' not always set for arrays) 
