### PR TITLE
add content-type text/yaml as supported content-type to import

### DIFF
--- a/src/core/importers/specs.ts
+++ b/src/core/importers/specs.ts
@@ -7,6 +7,7 @@ import { getGithubOpenApi } from '../../utils/github';
 import { isObject, isString } from '../../utils/is';
 import { dynamicReader } from '../../utils/reader';
 import { importOpenApi } from './openApi';
+import { ImportOpenApi } from '../../types';
 
 export const importSpecs = async (
   workspace: string,
@@ -24,7 +25,7 @@ export const importSpecs = async (
     throw new Error('You need to provide an output');
   }
 
-  const format = getExtension(path);
+  let format: ImportOpenApi['format'] = getExtension(path);
 
   let data: string | object;
 
@@ -34,13 +35,19 @@ export const importSpecs = async (
     } else {
       try {
         const { headers, data: specification } = await axios.get(path);
+        const isContentTypeYaml = headers['content-type'].includes('text/yaml');
+        const isContentTypeTextPlain = headers['content-type'].includes(
+          'text/plain',
+        );
+        const isContentTypeJson = headers['content-type'].includes(
+          'application/json',
+        );
 
-        if (
-          headers['content-type'] === 'application/json' ||
-          headers['content-type'] === 'text/yaml' ||
-          headers['content-type'].includes('text/plain')
-        ) {
+        if (isContentTypeJson || isContentTypeYaml || isContentTypeTextPlain) {
           data = specification;
+          if (isContentTypeTextPlain && typeof data === 'string') {
+            format = data.startsWith('{') ? 'json' : 'yaml';
+          }
         } else {
           throw 'Oups... 🍻. Unsupported content type';
         }

--- a/src/core/importers/specs.ts
+++ b/src/core/importers/specs.ts
@@ -45,6 +45,12 @@ export const importSpecs = async (
 
         if (isContentTypeJson || isContentTypeYaml || isContentTypeTextPlain) {
           data = specification;
+          if (isContentTypeJson) {
+            format = 'json';
+          }
+          if (isContentTypeYaml) {
+            format = 'yaml';
+          }
           if (isContentTypeTextPlain && typeof data === 'string') {
             format = data.startsWith('{') ? 'json' : 'yaml';
           }

--- a/src/core/importers/specs.ts
+++ b/src/core/importers/specs.ts
@@ -37,6 +37,7 @@ export const importSpecs = async (
 
         if (
           headers['content-type'] === 'application/json' ||
+          headers['content-type'] === 'text/yaml' ||
           headers['content-type'].includes('text/plain')
         ) {
           data = specification;


### PR DESCRIPTION
## Status
<!--- **READY/WIP/HOLD** --->
**READY**

## Description

add content-type text/yaml as supported content-type to import

## Related PRs
https://github.com/anymaniax/orval/discussions/108

branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()

## Todos
- [x] Tests
- [x] Documentation
- [x] Changelog Entry (unreleased)

## Notes

`headers['content-type']` comparison for `text/yaml`, `text/plain` and `application/json` now all in the same way (with `includes())`. Because for instance for `application/json` the actual content-type could be `application/json; charset=utf-8`.
