### PR TITLE
feat: pass recursive: true to all mkdir calls

### DIFF
--- a/src/core/writers/schemas.ts
+++ b/src/core/writers/schemas.ts
@@ -23,7 +23,7 @@ export const writeSchemas = ({
   const schemaPath = join(workspace, output.schemas);
 
   if (!existsSync(schemaPath)) {
-    mkdirSync(schemaPath);
+    mkdirSync(schemaPath, { recursive: true });
   }
 
   if (!existsSync(schemaPath + '/index.ts')) {

--- a/src/core/writers/singleMode.ts
+++ b/src/core/writers/singleMode.ts
@@ -27,7 +27,7 @@ export const writeSingleMode = ({
   );
 
   if (!existsSync(dirname)) {
-    mkdirSync(dirname);
+    mkdirSync(dirname, { recursive: true });
   }
 
   const {

--- a/src/core/writers/splitMode.ts
+++ b/src/core/writers/splitMode.ts
@@ -25,7 +25,7 @@ export const writeSplitMode = ({
   );
 
   if (!existsSync(dirname)) {
-    mkdirSync(dirname);
+    mkdirSync(dirname, { recursive: true });
   }
 
   const {

--- a/src/core/writers/splitTagsMode.ts
+++ b/src/core/writers/splitTagsMode.ts
@@ -25,7 +25,7 @@ export const writeSplitTagsMode = ({
   );
 
   if (!existsSync(dirname)) {
-    mkdirSync(dirname);
+    mkdirSync(dirname, { recursive: true });
   }
 
   const target = generateTargetForTags(operations, output);
@@ -84,7 +84,7 @@ export const writeSplitTagsMode = ({
 
     if (path) {
       if (!existsSync(join(dirname, kebab(tag)))) {
-        mkdirSync(join(dirname, kebab(tag)));
+        mkdirSync(join(dirname, kebab(tag)), { recursive: true });
       }
 
       const implementationFilename =

--- a/src/core/writers/tagsMode.ts
+++ b/src/core/writers/tagsMode.ts
@@ -26,7 +26,7 @@ export const writeTagsMode = ({
   );
 
   if (!existsSync(dirname)) {
-    mkdirSync(dirname);
+    mkdirSync(dirname, { recursive: true });
   }
 
   const target = generateTargetForTags(operations, output);


### PR DESCRIPTION
## Status
<!--- **READY/WIP/HOLD** --->
READY

## Description
Right now if you try to put models into some deep folder, while the parent directories does not exist, you'll see an error. this MR solves that by passing
```ts
mkdirSync(path, { recursive: true });
```
to all of mkdir calls to make sure it will create parent paths as well if they don't exist.