### PR TITLE
fix: implement & use relativeSafe to keep leading ./ in import paths

### DIFF
--- a/src/core/generators/mutator.ts
+++ b/src/core/generators/mutator.ts
@@ -1,7 +1,7 @@
-import { relative } from 'upath';
 import { Mutator } from '../../types';
 import { getFileInfo } from '../../utils/file';
 import { isString } from '../../utils/is';
+import { relativeSafe } from '../../utils/path';
 
 const getImport = (output: string, mutator: Mutator) => {
   const outputFileInfo = getFileInfo(output);
@@ -9,7 +9,7 @@ const getImport = (output: string, mutator: Mutator) => {
     isString(mutator) ? mutator : mutator.path,
   );
   const { pathWithoutExtension } = getFileInfo(
-    relative(outputFileInfo.dirname, mutatorFileInfo.path),
+    relativeSafe(outputFileInfo.dirname, mutatorFileInfo.path),
   );
   return pathWithoutExtension;
 };

--- a/src/core/writers/singleMode.ts
+++ b/src/core/writers/singleMode.ts
@@ -1,10 +1,11 @@
 import { outputFile } from 'fs-extra';
-import { join, relative } from 'upath';
+import { join } from 'upath';
 import { WriteModeProps } from '../../types/writers';
 import { camel } from '../../utils/case';
 import { getFileInfo } from '../../utils/file';
 import { isObject, isString } from '../../utils/is';
 import { getFilesHeader } from '../../utils/messages/inline';
+import { relativeSafe } from '../../utils/path';
 import { generateClientImports } from '../generators/client';
 import { generateMutatorImports } from '../generators/imports';
 import { generateModelsInline } from '../generators/modelsInline';
@@ -36,7 +37,7 @@ export const writeSingleMode = async ({
     let data = getFilesHeader(info);
 
     if (isObject(output) && output.schemas) {
-      const schemasPath = relative(
+      const schemasPath = relativeSafe(
         dirname,
         getFileInfo(join(workspace, output.schemas)).dirname,
       );

--- a/src/core/writers/splitMode.ts
+++ b/src/core/writers/splitMode.ts
@@ -1,10 +1,11 @@
 import { outputFile } from 'fs-extra';
-import { join, relative } from 'upath';
+import { join } from 'upath';
 import { OutputClient } from '../../types';
 import { WriteModeProps } from '../../types/writers';
 import { camel } from '../../utils/case';
 import { getFileInfo } from '../../utils/file';
 import { getFilesHeader } from '../../utils/messages/inline';
+import { relativeSafe } from '../../utils/path';
 import { generateClientImports } from '../generators/client';
 import { generateMutatorImports } from '../generators/imports';
 import { generateModelsInline } from '../generators/modelsInline';
@@ -39,7 +40,7 @@ export const writeSplitMode = async ({
     let mswData = header;
 
     if (output.schemas) {
-      const schemasPath = relative(
+      const schemasPath = relativeSafe(
         dirname,
         getFileInfo(join(workspace, output.schemas)).dirname,
       );

--- a/src/core/writers/tagsMode.ts
+++ b/src/core/writers/tagsMode.ts
@@ -1,10 +1,11 @@
 import { outputFile } from 'fs-extra';
-import { join, relative } from 'upath';
+import { join } from 'upath';
 import { WriteModeProps } from '../../types/writers';
 import { camel, kebab } from '../../utils/case';
 import { getFileInfo } from '../../utils/file';
 import { isObject } from '../../utils/is';
 import { getFilesHeader } from '../../utils/messages/inline';
+import { relativeSafe } from '../../utils/path';
 import { generateClientImports } from '../generators/client';
 import { generateMutatorImports } from '../generators/imports';
 import { generateModelsInline } from '../generators/modelsInline';
@@ -40,7 +41,7 @@ export const writeTagsMode = ({
         let data = header;
 
         if (isObject(output) && output.schemas) {
-          const schemasPath = relative(
+          const schemasPath = relativeSafe(
             dirname,
             getFileInfo(join(workspace, output.schemas)).dirname,
           );

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -1,0 +1,18 @@
+import {
+  normalizeSafe,
+  relative as normalizedRelative,
+  sep as seperator,
+} from 'upath';
+
+/**
+ * Behaves exactly like `path.relative(from, to)`, but keeps the first meaningful "./"
+ */
+export const relativeSafe = (from: string, to: string) => {
+  const normalizedRelativePath = normalizedRelative(from, to);
+  /**
+   * Prepend "./" to every path and then use normalizeSafe method to normalize it
+   * normalizeSafe doesn't remove meaningful leading "./"
+   */
+  const relativePath = normalizeSafe(`.${seperator}${normalizedRelativePath}`);
+  return relativePath;
+};


### PR DESCRIPTION
## Status
<!--- **READY/WIP/HOLD** --->
**READY**

## Description
Resolves #120 By introducing a new function named `relativeSafe` and resolve the import path using it. `relativeSafe` is the `path.relative` doppelganger that respects the meaningful leading "./"