### PR TITLE
fix: fix the orval bin path in sample projects

### DIFF
--- a/samples/angular-app/package.json
+++ b/samples/angular-app/package.json
@@ -6,7 +6,7 @@
     "start": "ng serve",
     "build": "ng build",
     "lint": "ng lint",
-    "generate-api": "node ../../lib/bin/orval.js --config ./orval.config.js"
+    "generate-api": "node ../../dist/bin/orval.js --config ./orval.config.js"
   },
   "private": true,
   "dependencies": {

--- a/samples/basic/package.json
+++ b/samples/basic/package.json
@@ -5,8 +5,8 @@
   "main": "index.html",
   "scripts": {
     "example": "run-p example:*",
-    "example:basic": "node ../../lib/bin/orval.js --input ./petstore.yaml --output ./api/endpoints/petstoreFromFileSpec.ts",
-    "example:config": "node ../../lib/bin/orval.js"
+    "example:basic": "node ../../dist/bin/orval.js --input ./petstore.yaml --output ./api/endpoints/petstoreFromFileSpec.ts",
+    "example:config": "node ../../dist/bin/orval.js"
   },
   "author": "Victor Bury",
   "license": "ISC",

--- a/samples/react-app-with-react-query/package.json
+++ b/samples/react-app-with-react-query/package.json
@@ -19,7 +19,7 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "eject": "react-scripts eject",
-    "generate-api": "node ../../lib/bin/orval.js --config ./orval.config.js"
+    "generate-api": "node ../../dist/bin/orval.js --config ./orval.config.js"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/samples/react-app/package.json
+++ b/samples/react-app/package.json
@@ -18,7 +18,7 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "eject": "react-scripts eject",
-    "generate-api": "node ../../lib/bin/orval.js --config ./orval.config.js"
+    "generate-api": "node ../../dist/bin/orval.js --config ./orval.config.js"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/samples/svelte-query/package.json
+++ b/samples/svelte-query/package.json
@@ -7,7 +7,7 @@
     "start": "svelte-kit start",
     "lint": "prettier --check . && eslint --ignore-path .gitignore .",
     "format": "prettier --write .",
-    "generate-api": "node ../../lib/bin/orval.js --config ./orval.config.cjs"
+    "generate-api": "node ../../dist/bin/orval.js --config ./orval.config.cjs"
   },
   "devDependencies": {
     "@sveltejs/adapter-node": "next",


### PR DESCRIPTION
## Status
<!--- **READY/WIP/HOLD** --->
**READY**

## Description
Fix the orval bin path in sample projects
    
They have been left behind when the orval bin has moved from `/lib` to `/dist`
