### PR TITLE
Fix of undefined case of definition in react-query.ts

### DIFF
--- a/src/core/generators/react-query.ts
+++ b/src/core/generators/react-query.ts
@@ -27,9 +27,7 @@ const REACT_QUERY_DEPENDENCIES: GeneratorDependency[] = [
       { name: 'useInfiniteQuery', values: true },
       { name: 'useMutation', values: true },
       { name: 'UseQueryOptions' },
-      {
-        name: 'UseInfiniteQueryOptions',
-      },
+      { name: 'UseInfiniteQueryOptions' },
       { name: 'UseMutationOptions' },
     ],
     dependency: 'react-query',
@@ -69,7 +67,9 @@ const generateAxiosFunction = (
           )?.slice(1, -1)} ...options}`
         : '// eslint-disable-next-line\n// @ts-ignore\n options'
       : '';
-
+   
+    const mutatorTyping = `<Data extends unknown ? ${ response.definition || 'Data' } : Data>`;
+    
     return `export const ${operationName} = <Data = unknown>(\n    ${toObjectString(
       props,
       'implementation',
@@ -78,9 +78,7 @@ const generateAxiosFunction = (
         ? `options?: SecondParameter<typeof ${mutator.name}>`
         : ''
     }) => {
-      return ${mutator.name}<Data extends unknown ? ${
-      response.definition
-    } : Data>(
+      return ${mutator.name}${mutatorTyping}(
       ${mutatorConfig},
       ${requestOptions});
     }

--- a/src/core/generators/react-query.ts
+++ b/src/core/generators/react-query.ts
@@ -68,7 +68,7 @@ const generateAxiosFunction = (
         : '// eslint-disable-next-line\n// @ts-ignore\n options'
       : '';
    
-    const mutatorTyping = `<Data extends unknown ? ${ response.definition || 'Data' } : Data>`;
+    const mutatorTyping = response.definition ? `<Data extends unknown ? ${ response.definition} : Data>` : '<Data>';
     
     return `export const ${operationName} = <Data = unknown>(\n    ${toObjectString(
       props,


### PR DESCRIPTION
## Status
**READY**

## Description
Fixes little bug here: https://github.com/anymaniax/orval/issues/132#issuecomment-846464157

> this line produces incorrect code if definition is undefined
https://github.com/anymaniax/orval/blob/master/src/core/generators/react-query.ts#L82