### PR TITLE
fix: additional properties of the objects should have any type

### DIFF
--- a/src/core/getters/object.ts
+++ b/src/core/getters/object.ts
@@ -107,7 +107,7 @@ export const getObject = async ({
   if (item.additionalProperties) {
     if (isBoolean(item.additionalProperties)) {
       return {
-        value: `{[key: string]: object}`,
+        value: `{ [key: string]: any }`,
         imports: [],
         schemas: [],
         isEnum: false,


### PR DESCRIPTION
## Status
<!--- **READY/WIP/HOLD** --->
**READY**

## Description
Setting each property of an object with `additionalProperties: true` to have `object` type is wrong. It enforces all other properties to have the object type.   
I've changed it to `any`.

```ts
{
  type: 'object'
  properties: {
    foo: string;
  }
  additionalProperties: true;
}
```
For the above schema output would be.

### before

```ts
interface ObjectWithAdditionalProps {
  foo: string; // typescript error: Property 'foo' of type 'string' is not assignable to string index type 'object'
  [key: string]: object;
}
```

### after
I used any as there is no way to predict what types would a user use in their additional properties.

```ts
interface ObjectWithAdditionalProps {
  foo: string;
  [key: string]: any;
}
```

@anymaniax 

## Todos
- [X] Tests
- [X] Documentation
- [X] Changelog Entry (unreleased)

