### PR TITLE
Fix the link to configuration

### DIFF
--- a/docs/src/pages/guides/angular.md
+++ b/docs/src/pages/guides/angular.md
@@ -24,7 +24,7 @@ module.exports = {
 };
 ```
 
-Checkout the [orval config](../reference/orval-config) reference to see all available options.
+Checkout the [orval config](../reference/configuration/full-example) reference to see all available options.
 
 The Angular mode will generate automatically two classes. One abstract with the definition and a service with the implementation. You should add the service inside a module and use it where you want.
 

--- a/docs/src/pages/overview.md
+++ b/docs/src/pages/overview.md
@@ -7,7 +7,7 @@ title: Overview
 
 ## Motivation
 
-I often use a swagger as contract between the frontend and backend team. And before Orval, I used the <a href="editor.swagger.io" target="_blank">swagger editor</a> or <a href="https://swagger.io/tools/swagger-codegen" target="_blank">swagger codegen</a> but that wasn't enough for my need. That's why I started Orval.
+I often use a swagger as contract between the frontend and backend team. And before Orval, I used the <a href="https://editor.swagger.io" target="_blank">swagger editor</a> or <a href="https://swagger.io/tools/swagger-codegen" target="_blank">swagger codegen</a> but that wasn't enough for my need. That's why I started Orval.
 
 Main goals:
 


### PR DESCRIPTION
## Description
This fixes the link to configuration on Guides/Angular page. The current link leads to a 404 page.