### PR TITLE
fix: deduplicate enum values

### DIFF
--- a/src/core/getters/enum.ts
+++ b/src/core/getters/enum.ts
@@ -3,7 +3,7 @@ import { sanitize } from '../../utils/string';
 export const getEnum = (value: string, type: string, enumName: string) => {
   let enumValue = `export type ${enumName} = ${value};\n`;
 
-  const implementation = value.split(' | ').reduce((acc, val) => {
+  const implementation = [...new Set(value.split(' | '))].reduce((acc, val) => {
     const isTypeNumber = type === 'number';
     const isNumber = !Number.isNaN(Number(val.slice(1, -1)));
     const key =


### PR DESCRIPTION
## Status

**READY**

## Description

Deduplicate enum values by using a `Set`.

I'm not sure if this PR is OK since the problem is also because the OpenAPI schema is not "right".

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)