### PR TITLE
fix: Add types for pageParam when useInfiniteQueryParam is specified

### DIFF
--- a/src/core/generators/query.ts
+++ b/src/core/generators/query.ts
@@ -344,7 +344,7 @@ export const ${camel(
   const queryKey = queryOptions?.queryKey ?? ${queryKeyFnName}(${properties});
   const queryFn = (${
     queryParam && props.some(({ type }) => type === 'queryParam')
-      ? `{ pageParam }`
+      ? `{ pageParam }: { pageParam?: string }`
       : ''
   }) => ${operationName}(${httpFunctionProps}${httpFunctionProps ? ', ' : ''}${
     isRequestOptions


### PR DESCRIPTION
## Status
<!--- **READY** --->
**READY**

## Description
When `useInfiniteQueryParam` is specified in the Orval config, `pageParam` has an implicit `any` type:

<img width="862" alt="Screen Shot 2021-09-28 at 3 49 48 PM" src="https://user-images.githubusercontent.com/6894781/135179369-f71c4330-e13e-44fe-9468-62c6356cbf32.png">
<img width="1044" alt="Screen Shot 2021-09-28 at 3 50 01 PM" src="https://user-images.githubusercontent.com/6894781/135179371-383344b7-5f40-4c21-9cd0-c2776b068e18.png">

I addressed this by adding an inline type to the query generator: `{ pageParam?: string }`

**Note:** I noticed the sample config for react-query has `useInfinite` and `useInfiniteQueryParam` defined: https://github.com/anymaniax/orval/blob/master/samples/react-app-with-react-query/orval.config.ts#L43. However, the generated endpoint file doesn't have any `useInfinite` hooks: https://github.com/anymaniax/orval/blob/master/samples/react-app-with-react-query/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts. Should we address that first? Does the `petstore.yaml` file need to be updated?

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)
