### PR TITLE
fix: ensure no closing comments in JSDoc

### DIFF
--- a/src/utils/doc.ts
+++ b/src/utils/doc.ts
@@ -10,7 +10,9 @@ export function jsDoc(
   },
   tryOneLine = false,
 ): string {
-  const lines = Array.isArray(description) ? description : [description];
+  // Ensure there aren't any comment terminations in doc
+  const lines = (Array.isArray(description) ? description : [description])
+    .map(line => line.replace('*/', '*\\/'));
 
   const count = [description, deprecated, summary].reduce(
     (acc, it) => (it ? acc + 1 : acc),


### PR DESCRIPTION
## Status
<!--- **READY/WIP/HOLD** --->
**(READY)/~~WIP~~/~~HOLD~~**

## Description
#137

Replaces end comments that could appear in JSDoc with escaped slashed version: `*/` -> `*\/`

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)
