### PR TITLE
feat(types): Export transformer function type

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -238,7 +238,7 @@ export type AngularOptions = {
   provideInRoot?: boolean;
 };
 
-type InputTransformerFn = (spec: OpenAPIObject) => OpenAPIObject;
+export type InputTransformerFn = (spec: OpenAPIObject) => OpenAPIObject;
 
 type InputTransformer = string | InputTransformerFn;
 


### PR DESCRIPTION
## Status
**READY**

## Description
- It would be nice to expose the types for the transformer function, so we get proper type-checking if your transformer file is written in TypeScript.

## Proposed Usage
```ts
// transformers/add-version.ts

import type { InputTransformerFn } from "orval";

const addVersion: InputTransformerFn = (inputSchema) => ...

export default addVersion;
```