### PR TITLE
fix(writers): include workspace index.ts to be formatted using prettier

### DIFF
--- a/src/core/writers/specs.ts
+++ b/src/core/writers/specs.ts
@@ -127,7 +127,9 @@ export const writeSpecs = async (
       )}';`;
     }
 
-    await outputFile(join(workspacePath, '/index.ts'), imports);
+    const indexFile = join(workspacePath, '/index.ts');
+    await outputFile(indexFile, imports);
+    implementationPaths = [indexFile, ...implementationPaths];
   }
 
   if (output.prettier) {

--- a/src/core/writers/specs.ts
+++ b/src/core/writers/specs.ts
@@ -1,3 +1,4 @@
+import uniq from 'lodash.uniq';
 import chalk from 'chalk';
 import { log } from 'console';
 import execa from 'execa';
@@ -117,18 +118,17 @@ export const writeSpecs = async (
             workspacePath,
             getFileInfo(path).pathWithoutExtension,
           )}';`,
-      )
-      .join('\n');
+      );
 
     if (output.schemas) {
-      imports += `\nexport * from '${relativeSafe(
+      imports.push(`export * from '${relativeSafe(
         workspacePath,
         getFileInfo(output.schemas).dirname,
-      )}';`;
+      )}';`);
     }
 
     const indexFile = join(workspacePath, '/index.ts');
-    await outputFile(indexFile, imports);
+    await outputFile(indexFile, uniq(imports).join('\n'));
     implementationPaths = [indexFile, ...implementationPaths];
   }
 


### PR DESCRIPTION
## Status
<!--- **READY/WIP/HOLD** --->
**READY**

## Description

When using `workspaces` and `tags-split` mode, discovered that the generated `index.ts` file was constantly being modified by prettier husky hooks - remove/add a newline at EOF.

Discovered that `index.ts` wasn't included to be fixed by `prettier`.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

From [67e583](https://github.com/anymaniax/orval/commit/67e583e9eee1593d866f5740cd11169e7fb02f2e) with the following config.

```
'test-api': {
  input: {
    target: './src/api/test-api.spec.json',
  },
  output: {
    mode: 'tags-split',
    workspace: 'src/api/test-api',
    target: './test-api.ts',
    prettier: true,
  },
}
```
