### PR TITLE
feat(generator): cast return type of queries

### DIFF
--- a/samples/react-query/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/react-query/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -9,6 +9,9 @@ import {
   useInfiniteQuery,
   useMutation,
   UseQueryOptions,
+  UseQueryResult,
+  UseInfiniteQueryResult,
+  QueryKey,
   UseInfiniteQueryOptions,
   UseMutationOptions,
   QueryFunction,
@@ -66,7 +69,7 @@ export const useListPetsInfinite = <TData = AsyncReturnType<typeof listPets>, TE
   return {
     queryKey,
     ...query
-  }
+  } as UseInfiniteQueryResult<TData, TError> & { queryKey: QueryKey }
 }
 
 export const useListPets = <TData = AsyncReturnType<typeof listPets>, TError = Error>(
@@ -88,7 +91,7 @@ export const useListPets = <TData = AsyncReturnType<typeof listPets>, TError = E
   return {
     queryKey,
     ...query
-  }
+  } as UseQueryResult<TData, TError> & { queryKey: QueryKey }
 }
 
 
@@ -163,7 +166,7 @@ export const useShowPetByIdInfinite = <TData = AsyncReturnType<typeof showPetByI
   return {
     queryKey,
     ...query
-  }
+  } as UseInfiniteQueryResult<TData, TError> & { queryKey: QueryKey }
 }
 
 export const useShowPetById = <TData = AsyncReturnType<typeof showPetById>, TError = Error>(
@@ -185,7 +188,7 @@ export const useShowPetById = <TData = AsyncReturnType<typeof showPetById>, TErr
   return {
     queryKey,
     ...query
-  }
+  } as UseQueryResult<TData, TError> & { queryKey: QueryKey }
 }
 
 

--- a/src/core/generators/query.ts
+++ b/src/core/generators/query.ts
@@ -65,6 +65,9 @@ const REACT_QUERY_DEPENDENCIES: GeneratorDependency[] = [
       { name: 'useInfiniteQuery', values: true },
       { name: 'useMutation', values: true },
       { name: 'UseQueryOptions' },
+      { name: 'UseQueryResult' },
+      { name: 'UseInfiniteQueryResult' },
+      { name: 'QueryKey' },
       { name: 'UseInfiniteQueryOptions' },
       { name: 'UseMutationOptions' },
       { name: 'QueryFunction' },
@@ -404,7 +407,7 @@ export const ${camel(`use-${name}`)} = <TData = AsyncReturnType<${
   return {
     queryKey,
     ...query
-  }
+  } as Use${pascal(type)}Result<TData, TError> & { queryKey: QueryKey }
 }\n`;
 };
 


### PR DESCRIPTION

## Status
<!--- **READY/WIP/HOLD** --->
**READY**

## Description
Typescript currently doesn't know how to make sense of the type that results from:
```tsx
{
  ...query,
  queryKey
}
```

intellisense in many cases thinks that it's not assignable to `UseQueryResult`. an explicit cast fixes this.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce
before: the return type is a union of tons of different objects.

![Screen Shot 2021-11-18 at 5 27 34 PM](https://user-images.githubusercontent.com/11509865/142537568-51fc7230-f8b6-4661-bac7-a6b6d432cc4a.png)

after: the return type is `useQueryResult` | `useInfiniteQueryResult`
![Screen Shot 2021-11-18 at 5 28 14 PM](https://user-images.githubusercontent.com/11509865/142537608-b78f33d8-7a78-43fd-b101-b04e18516607.png)


