### PR TITLE
feat(linter) ESlint as default linter w/ TSlint as optional switch

### DIFF
--- a/docs/src/pages/reference/cli.md
+++ b/docs/src/pages/reference/cli.md
@@ -81,10 +81,10 @@ The `--prettier`, can be used to prettier generated files. You need to have pret
 $ orval --prettier
 ```
 
-### Eslint
+### tslint
 
-The `--eslint`, can be used to specify `eslint` as typescript linter instead of `tslint`. You need to have eslint & typescript presets in your dependencies.
+The `--tslint`, can be used to specify `tslint` ([TSLint is deprecated in favour of eslint + plugins](https://github.com/palantir/tslint#tslint)) as typescript linter instead of `eslint`. You need to have tslint in your dependencies.
 
 ```bash
-$ orval --eslint
+$ orval --tslint
 ```

--- a/docs/src/pages/reference/cli.md
+++ b/docs/src/pages/reference/cli.md
@@ -80,3 +80,11 @@ The `--prettier`, can be used to prettier generated files. You need to have pret
 ```bash
 $ orval --prettier
 ```
+
+### Eslint
+
+The `--eslint`, can be used to specify `eslint` as typescript linter instead of `tslint`. You need to have eslint & typescript presets in your dependencies.
+
+```bash
+$ orval --eslint
+```

--- a/docs/src/pages/reference/configuration/output.md
+++ b/docs/src/pages/reference/configuration/output.md
@@ -263,13 +263,13 @@ Default Value: `false`.
 
 Can be used to prettier generated files. You need to have prettier in your dependencies.
 
-### eslint
+### tslint
 
 Type: `Boolean`.
 
 Default Value: `false`.
 
-Can be used to specify `eslint` as typescript linter instead of `tslint`. You need to have eslint & typescript presets in your dependencies.
+Can be used to specify `tslint` ([TSLint is deprecated in favour of eslint + plugins](https://github.com/palantir/tslint#tslint)) as typescript linter instead of `eslint`. You need to have tslint in your dependencies.
 
 ### override
 

--- a/docs/src/pages/reference/configuration/output.md
+++ b/docs/src/pages/reference/configuration/output.md
@@ -263,6 +263,14 @@ Default Value: `false`.
 
 Can be used to prettier generated files. You need to have prettier in your dependencies.
 
+### eslint
+
+Type: `Boolean`.
+
+Default Value: `false`.
+
+Can be used to specify `eslint` as typescript linter instead of `tslint`. You need to have eslint & typescript presets in your dependencies.
+
 ### override
 
 Type: `Object`.

--- a/src/bin/orval.ts
+++ b/src/bin/orval.ts
@@ -39,6 +39,7 @@ cli
   )
   .option('--clean [path]', 'Clean output directory')
   .option('--prettier [path]', 'Prettier generated files')
+  .option('--eslint [path]', 'Eslint generated files')
   .action(async (paths, cmd) => {
     if (isString(cmd.input) && isString(cmd.output)) {
       const normalizedOptions = await normalizeOptions({
@@ -47,6 +48,7 @@ cli
           target: cmd.output,
           clean: cmd.clean,
           prettier: cmd.prettier,
+          eslint: cmd.eslint,
           mock: cmd.mock,
           client: cmd.client,
           mode: cmd.mode,
@@ -78,6 +80,7 @@ cli
         watch: cmd.watch,
         clean: cmd.clean,
         prettier: cmd.prettier,
+        eslint: cmd.eslint,
         mock: cmd.mock,
         client: cmd.client,
         mode: cmd.mode,

--- a/src/bin/orval.ts
+++ b/src/bin/orval.ts
@@ -39,7 +39,7 @@ cli
   )
   .option('--clean [path]', 'Clean output directory')
   .option('--prettier [path]', 'Prettier generated files')
-  .option('--eslint [path]', 'Eslint generated files')
+  .option('--tslint [path]', 'tslint generated files')
   .action(async (paths, cmd) => {
     if (isString(cmd.input) && isString(cmd.output)) {
       const normalizedOptions = await normalizeOptions({
@@ -48,7 +48,7 @@ cli
           target: cmd.output,
           clean: cmd.clean,
           prettier: cmd.prettier,
-          eslint: cmd.eslint,
+          tslint: cmd.tslint,
           mock: cmd.mock,
           client: cmd.client,
           mode: cmd.mode,
@@ -80,7 +80,7 @@ cli
         watch: cmd.watch,
         clean: cmd.clean,
         prettier: cmd.prettier,
-        eslint: cmd.eslint,
+        tslint: cmd.tslint,
         mock: cmd.mock,
         client: cmd.client,
         mode: cmd.mode,

--- a/src/core/generators/interface.ts
+++ b/src/core/generators/interface.ts
@@ -34,10 +34,10 @@ export const generateInterface = async ({
   model += jsDoc(schema);
 
   if (isEmptyObject) {
-    if (context.eslint) {
-      model += '// eslint-disable-next-line @typescript-eslint/no-empty-interface\n';
-    } else {
+    if (context.tslint) {
       model += '// tslint:disable-next-line:no-empty-interface\n';
+    } else {
+      model += '// eslint-disable-next-line @typescript-eslint/no-empty-interface\n';
     }
   }
 

--- a/src/core/generators/interface.ts
+++ b/src/core/generators/interface.ts
@@ -6,7 +6,7 @@ import { getScalar } from '../getters/scalar';
 
 /**
  * Generate the interface string
- * A tslint comment is insert if the resulted object is empty
+ * A eslint|tslint comment is insert if the resulted object is empty
  *
  * @param name interface name
  * @param schema
@@ -34,7 +34,11 @@ export const generateInterface = async ({
   model += jsDoc(schema);
 
   if (isEmptyObject) {
-    model += '// tslint:disable-next-line:no-empty-interface\n';
+    if (context.eslint) {
+      model += '// eslint-disable-next-line @typescript-eslint/no-empty-interface\n';
+    } else {
+      model += '// tslint:disable-next-line:no-empty-interface\n';
+    }
   }
 
   if (!generalJSTypesWithArray.includes(scalar.value)) {

--- a/src/core/importers/openApi.ts
+++ b/src/core/importers/openApi.ts
@@ -59,7 +59,13 @@ export const importOpenApi = async ({
   const schemas = await asyncReduce(
     Object.entries(specs),
     async (acc, [specKey, spec]) => {
-      const context = { specKey, workspace, specs, override: output.override };
+      const context = {
+        specKey,
+        workspace,
+        specs,
+        override: output.override,
+        eslint: output.eslint,
+      };
       const schemaDefinition = await generateSchemasDefinition(
         spec.components?.schemas,
         context,
@@ -99,7 +105,7 @@ export const importOpenApi = async ({
 
   const api = await generateApi({
     output,
-    context: { specKey: path, workspace, specs, override: output.override },
+    context: { specKey: path, workspace, specs, override: output.override, eslint: output.eslint },
   });
 
   return {

--- a/src/core/importers/openApi.ts
+++ b/src/core/importers/openApi.ts
@@ -64,7 +64,7 @@ export const importOpenApi = async ({
         workspace,
         specs,
         override: output.override,
-        eslint: output.eslint,
+        tslint: output.tslint,
       };
       const schemaDefinition = await generateSchemasDefinition(
         spec.components?.schemas,
@@ -105,7 +105,7 @@ export const importOpenApi = async ({
 
   const api = await generateApi({
     output,
-    context: { specKey: path, workspace, specs, override: output.override, eslint: output.eslint },
+    context: { specKey: path, workspace, specs, override: output.override, tslint: output.tslint },
   });
 
   return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ const generate = async (
     watch?: boolean | string | (string | boolean)[];
     clean?: boolean | string[];
     prettier?: boolean;
+    eslint?: boolean;
   },
 ) => {
   if (!optionsExport || isString(optionsExport)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ const generate = async (
     watch?: boolean | string | (string | boolean)[];
     clean?: boolean | string[];
     prettier?: boolean;
-    eslint?: boolean;
+    tslint?: boolean;
   },
 ) => {
   if (!optionsExport || isString(optionsExport)) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -42,7 +42,7 @@ export type NormalizedOutputOptions = {
   client: OutputClient | OutputClientFunc;
   clean: boolean | string[];
   prettier: boolean;
-  eslint: boolean;
+  tslint: boolean;
 };
 
 export type NormalizedOverrideOutput = {
@@ -130,7 +130,7 @@ export type OutputOptions = {
   client?: OutputClient | OutputClientFunc;
   clean?: boolean | string[];
   prettier?: boolean;
-  eslint?: boolean;
+  tslint?: boolean;
 };
 
 export type SwaggerParserOptions = Omit<SwaggerParser.Options, 'validate'> & {
@@ -293,7 +293,7 @@ export type ImportOpenApi = {
 export interface ContextSpecs {
   specKey: string;
   workspace: string;
-  eslint: boolean;
+  tslint: boolean;
   specs: Record<string, OpenAPIObject>;
   override: NormalizedOverrideOutput;
 }
@@ -303,7 +303,7 @@ export interface GlobalOptions {
   watch?: boolean | string | (string | boolean)[];
   clean?: boolean | string[];
   prettier?: boolean;
-  eslint?: boolean;
+  tslint?: boolean;
   mock?: boolean;
   client?: OutputClient;
   mode?: OutputMode;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -42,6 +42,7 @@ export type NormalizedOutputOptions = {
   client: OutputClient | OutputClientFunc;
   clean: boolean | string[];
   prettier: boolean;
+  eslint: boolean;
 };
 
 export type NormalizedOverrideOutput = {
@@ -129,6 +130,7 @@ export type OutputOptions = {
   client?: OutputClient | OutputClientFunc;
   clean?: boolean | string[];
   prettier?: boolean;
+  eslint?: boolean;
 };
 
 export type SwaggerParserOptions = Omit<SwaggerParser.Options, 'validate'> & {
@@ -291,6 +293,7 @@ export type ImportOpenApi = {
 export interface ContextSpecs {
   specKey: string;
   workspace: string;
+  eslint: boolean;
   specs: Record<string, OpenAPIObject>;
   override: NormalizedOverrideOutput;
 }
@@ -300,6 +303,7 @@ export interface GlobalOptions {
   watch?: boolean | string | (string | boolean)[];
   clean?: boolean | string[];
   prettier?: boolean;
+  eslint?: boolean;
   mock?: boolean;
   client?: OutputClient;
   mode?: OutputMode;

--- a/src/utils/options.ts
+++ b/src/utils/options.ts
@@ -60,7 +60,7 @@ export const normalizeOptions = async (
     workspace,
   );
 
-  const { clean, prettier, client, mode, mock } = globalOptions;
+  const { clean, prettier, client, mode, mock, eslint } = globalOptions;
 
   const normalizedOptions: NormalizedOptions = {
     input: {
@@ -87,6 +87,7 @@ export const normalizeOptions = async (
       mock: outputOptions.mock ?? mock ?? false,
       clean: outputOptions.clean ?? clean ?? false,
       prettier: outputOptions.prettier ?? prettier ?? false,
+      eslint: outputOptions.eslint ?? eslint ?? false,
       override: {
         ...outputOptions.override,
         operations: normalizeOperationsAndTags(

--- a/src/utils/options.ts
+++ b/src/utils/options.ts
@@ -60,7 +60,7 @@ export const normalizeOptions = async (
     workspace,
   );
 
-  const { clean, prettier, client, mode, mock, eslint } = globalOptions;
+  const { clean, prettier, client, mode, mock, tslint } = globalOptions;
 
   const normalizedOptions: NormalizedOptions = {
     input: {
@@ -87,7 +87,7 @@ export const normalizeOptions = async (
       mock: outputOptions.mock ?? mock ?? false,
       clean: outputOptions.clean ?? clean ?? false,
       prettier: outputOptions.prettier ?? prettier ?? false,
-      eslint: outputOptions.eslint ?? eslint ?? false,
+      tslint: outputOptions.tslint ?? tslint ?? false,
       override: {
         ...outputOptions.override,
         operations: normalizeOperationsAndTags(

--- a/tests/configs/default.config.ts
+++ b/tests/configs/default.config.ts
@@ -19,4 +19,12 @@ export default defineConfig({
       },
     },
   },
+  'petstore-eslint': {
+    input: '../specifications/petstore.yaml',
+    output: {
+      target: '../generated/default/petstore-eslint/endpoints.ts',
+      schemas: '../generated/default/petstore-eslint/model',
+      eslint: true
+    },
+  },
 });

--- a/tests/configs/default.config.ts
+++ b/tests/configs/default.config.ts
@@ -19,12 +19,12 @@ export default defineConfig({
       },
     },
   },
-  'petstore-eslint': {
+  'petstore-tslint': {
     input: '../specifications/petstore.yaml',
     output: {
-      target: '../generated/default/petstore-eslint/endpoints.ts',
-      schemas: '../generated/default/petstore-eslint/model',
-      eslint: true
+      target: '../generated/default/petstore-tslint/endpoints.ts',
+      schemas: '../generated/default/petstore-tslint/model',
+      tslint: true
     },
   },
 });

--- a/tests/specifications/petstore.yaml
+++ b/tests/specifications/petstore.yaml
@@ -89,6 +89,13 @@ paths:
           description: The id of the pet to retrieve
           schema:
             type: string
+      requestBody:
+        description: Expected content to be different
+        content: 
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Insect'
+        
       responses:
         '200':
           description: Expected response to a valid request
@@ -133,6 +140,8 @@ components:
       type: array
       items:
         $ref: '#/components/schemas/Pet'
+    Insect:
+      type: object
     Error:
       type: object
       required:


### PR DESCRIPTION
## Status
**READY**

## Description
Specify `tslint` (deprecated) as linter instead of default `eslint` to manage typescript.

Empty interface is the only linter entrypoint at the moment but it has a real impact regarding some externally written API definitions.

### Usage

- `--tslint` cli option
- `tslint: true` in global configuration
- `output.tslint: true` in specific configuration

## Todos
- [x] Tests
- [x] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce
Cf. tests/specifications/petstore.yaml
