### PR TITLE
fix(generators): fixed generation when using hooks and forms

### DIFF
--- a/src/core/generators/query.ts
+++ b/src/core/generators/query.ts
@@ -157,7 +157,7 @@ const generateQueryRequestFunction = (
       mutator?.name.startsWith('use') && !mutator.mutatorFn.length;
 
     if (isMutatorHook) {
-      return `export const use${pascal(operationName)}Hook = () => {${bodyForm}
+      return `export const use${pascal(operationName)}Hook = () => {
         const ${operationName} = ${mutator.name}<${
         response.definition.success || 'unknown'
       }>();
@@ -166,9 +166,11 @@ const generateQueryRequestFunction = (
         isRequestOptions && isMutatorHasSecondArg
           ? `options?: SecondParameter<typeof ${mutator.name}>`
           : ''
-      }) => ${operationName}(
+      }) => {${bodyForm}
+        return ${operationName}(
           ${mutatorConfig},
-          ${requestOptions})
+          ${requestOptions});
+        }
       }
     `;
     }

--- a/tests/configs/react-query.config.ts
+++ b/tests/configs/react-query.config.ts
@@ -95,6 +95,23 @@ export default defineConfig({
       target: '../specifications/form-data.yaml',
     },
   },
+  formDataWithHook: {
+    output: {
+      target: '../generated/react-query/formDataWithHook/endpoints.ts',
+      schemas: '../generated/react-query/formDataWithHook/model',
+      client: 'react-query',
+      mock: true,
+      override: {
+        mutator: {
+          path: '../mutators/use-custom-instance.ts',
+          name: 'useCustomInstance',
+        },
+      },
+    },
+    input: {
+      target: '../specifications/form-data.yaml',
+    },
+  },
   formDataMutator: {
     output: {
       target: '../generated/react-query/form-data/endpoints.ts',


### PR DESCRIPTION
## Status
<!--- **READY/WIP/HOLD** --->
**READY**

## Description
When generating React Hooks containing forms data, the generated file wouldn't compile.

## Related PRs

## Todos
- [x] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce
1.
```bash
> git fetch --all
> git checkout fix-use-custom-instance-with-form
> yarn; yarn build
> cd tests
> yarn; yarn generate
```
2. Check `tests/generated/react-query/formDataWithHook/endpoints.ts`
