### PR TITLE
fix(core): path parameters default values

### DIFF
--- a/src/core/getters/params.ts
+++ b/src/core/getters/params.ts
@@ -1,6 +1,6 @@
 import { ContextSpecs } from '../../types';
 import { GetterParameters, GetterParams } from '../../types/getters';
-import { sanitize } from '../../utils/string';
+import { sanitize, stringify } from '../../utils/string';
 import { resolveValue } from '../resolvers/value';
 
 /**
@@ -23,20 +23,6 @@ export const getParamsInPath = (path: string) => {
   }
 
   return output;
-};
-
-/**
- * objToString handles the rendering for specific types
- * 
- * @param obj
- */
-const objToString = (obj: any): string => {
-  switch (typeof obj) {
-    case 'string':
-      return `'${obj}'`;
-    default:
-      return `${obj}`;
-  }
 };
 
 export const getParams = ({
@@ -103,7 +89,7 @@ export const getParams = ({
       }${
         !resolvedValue.originalSchema!.default
           ? `: ${resolvedValue.value}`
-          : `= ${objToString(resolvedValue.originalSchema!.default)}`
+          : `= ${stringify(resolvedValue.originalSchema!.default)}`
       }`;
 
       return {

--- a/src/core/getters/params.ts
+++ b/src/core/getters/params.ts
@@ -25,6 +25,20 @@ export const getParamsInPath = (path: string) => {
   return output;
 };
 
+/**
+ * objToString handles the rendering for specific types
+ * 
+ * @param obj
+ */
+const objToString = (obj: any): string => {
+  switch (typeof obj) {
+    case 'string':
+      return `'${obj}'`;
+    default:
+      return `${obj}`;
+  }
+};
+
 export const getParams = ({
   route,
   pathParams = [],
@@ -89,7 +103,7 @@ export const getParams = ({
       }${
         !resolvedValue.originalSchema!.default
           ? `: ${resolvedValue.value}`
-          : `= ${resolvedValue.originalSchema!.default}`
+          : `= ${objToString(resolvedValue.originalSchema!.default)}`
       }`;
 
       return {

--- a/tests/configs/default.config.ts
+++ b/tests/configs/default.config.ts
@@ -27,4 +27,12 @@ export default defineConfig({
       tslint: true
     },
   },
+  'endpointParameters': {
+    input: '../specifications/parameters.yaml',
+    output: {
+      target: '../generated/default/endpointParameters/endpoints.ts',
+      schemas: '../generated/react-query/endpointParameters/model',
+      mock: true,
+    },
+  },
 });

--- a/tests/specifications/parameters.yaml
+++ b/tests/specifications/parameters.yaml
@@ -1,0 +1,131 @@
+openapi: '3.0.3'
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  '/pets-by-country/{country}':
+    parameters:
+      - name: country # Test that default values are displayed correctly
+        in: path
+        description: Filter by country
+        required: true
+        schema:
+          $ref: '#/components/schemas/CountryCode'
+    get:
+      summary: List all pets by country
+      operationId: listPetsByCountry
+      tags:
+        - pets
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          schema:
+            type: string
+      responses:
+        '200':
+          description: A paged array of pets
+          headers:
+            x-next:
+              description: A link to the next page of responses
+              schema:
+                type: string
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/Pets'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  '/pets-by-age/{age}':
+    parameters:
+      - name: age # Test that default values are displayed correctly
+        description: Filter by age
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int32
+          default: 5
+    get:
+      summary: List all pets by age
+      operationId: listPetsByAge
+      tags:
+        - pets
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          schema:
+            type: string
+      responses:
+        '200':
+          description: A paged array of pets
+          headers:
+            x-next:
+              description: A link to the next page of responses
+              schema:
+                type: string
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/Pets'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        '@id':
+          type: string
+          format: iri-reference
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        tag:
+          type: string
+        age:
+          type: integer
+          format: int32
+        countryCode:
+          $ref: '#/components/schemas/CountryCode'
+    Pets:
+      type: array
+      items:
+        $ref: '#/components/schemas/Pet'
+    Error:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string
+    CountryCode:
+      type: string
+      enum:
+        - CN
+        - UY
+      default: UY


### PR DESCRIPTION
## Status
<!--- **READY/WIP/HOLD** --->
**READY**

## Description
Default string values were rendered without quotes.
Before:
```typescript
export const listPetsByCountry = <TData = AxiosResponse<Pets>>(
  params?: ListPetsByCountryParams,
  country = UY, // <---
  options?: AxiosRequestConfig,
): Promise<TData> => {
  return axios.get(`/pets-by-country/${country}`, {
    params,
    ...options,
  });
};
```
After:
```typescript
export const listPetsByCountry = <TData = AxiosResponse<Pets>>(
  params?: ListPetsByCountryParams,
  country = 'UY', // <---
  options?: AxiosRequestConfig,
): Promise<TData> => {
  return axios.get(`/pets-by-country/${country}`, {
    params,
    ...options,
  });
};
```

I implemented it in a separate function so that it can be expanded if other types need special formatting.
The tests cover strings (as enums) and integers and use a separate definition.
## Related PRs
## Todos
- [x] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce
1.
```bash
> git fetch --all
> git checkout endpoint-parameters
> yarn; yarn build
> cd tests
> yarn; yarn generate
```
2. Check `tests/generated/default/endpointParameters/endpoints.ts`