### PR TITLE
fix(sanitize): allow `.` character in paths

### DIFF
--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -53,7 +53,7 @@ export const sanitize = (
   },
 ) => {
   const { whitespace = '', underscore = '' } = options || {};
-  let newValue = value.replace(/[^\w\s]/g, '');
+  let newValue = value.replace(/[^\w\s.]/g, '');
 
   if (whitespace !== true) {
     newValue = newValue.replace(/[\s]/g, whitespace);

--- a/tests/configs/default.config.ts
+++ b/tests/configs/default.config.ts
@@ -35,4 +35,11 @@ export default defineConfig({
       mock: true,
     },
   },
+  translation: {
+    input: '../specifications/translation.yaml',
+    output: {
+      target: '../generated/default/translation/endpoints.ts',
+      schemas: '../generated/default/translation/model'
+    },
+  },
 });

--- a/tests/specifications/translation.yaml
+++ b/tests/specifications/translation.yaml
@@ -1,0 +1,34 @@
+openapi: 3.0.3
+info:
+  title: Translation API
+  description: 'Translation APIs'
+  license:
+    name: MIT
+  version: 1.0.0
+tags:
+  - name: translation
+    description: Everything about Translation
+servers:
+  - url: http://localhost
+paths:
+  /{locale}.js:
+    get:
+      tags:
+        - translation
+      summary: Retrieve Translations
+      operationId: retrieveTranslations
+      parameters:
+        - name: locale
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: Successful Operation
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: string


### PR DESCRIPTION
## Status
<!--- **READY/WIP/HOLD** --->
**READY**

## Description
The goal is to allow the dot character in paths. For example when loading a file

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.
```bash
yarn build && cd tests/ && yarn generate:default && cd ..
```
