### PR TITLE
fix(msw): declaration 'req' is exempted from the unused parameter che…

### DIFF
--- a/src/core/generators/msw.ts
+++ b/src/core/generators/msw.ts
@@ -111,7 +111,7 @@ export const generateMSW = async (
         value && value !== 'undefined'
           ? `export const get${pascal(operationId)}Mock = () => (${value})\n\n`
           : '',
-      handler: `rest.${verb}('${route}', (req, res, ctx) => {
+      handler: `rest.${verb}('${route}', (_req, res, ctx) => {
         return res(
           ctx.delay(1000),
           ctx.status(200, 'Mocked status'),${


### PR DESCRIPTION
## Status
READY

## Description
Declaration 'req' is [exempted](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-0.html#flag-unused-declarations-with---nounusedparameters-and---nounusedlocals) from the unused parameter checking in handler.