### PR TITLE
fix(code): reducers speed & memory optimisation

### DIFF
--- a/samples/react-query/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
+++ b/samples/react-query/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
@@ -20,19 +20,19 @@ export const getCreatePetsMock = () => ({'@id': faker.helpers.randomize([faker.r
 export const getShowPetByIdMock = () => ((()=>({id:faker.random.number({min:1,max:99}),name:faker.name.firstName(),tag:faker.helpers.randomize([faker.random.word(),void 0])}))())
 
 export const getSwaggerPetstoreMSW = () => [
-rest.get('*/v:version/pets', (req, res, ctx) => {
+rest.get('*/v:version/pets', (_req, res, ctx) => {
         return res(
           ctx.delay(1000),
           ctx.status(200, 'Mocked status'),
 ctx.json(getListPetsMock()),
         )
-      }),rest.post('*/v:version/pets', (req, res, ctx) => {
+      }),rest.post('*/v:version/pets', (_req, res, ctx) => {
         return res(
           ctx.delay(1000),
           ctx.status(200, 'Mocked status'),
 ctx.json(getCreatePetsMock()),
         )
-      }),rest.get('*/v:version/pets/:petId', (req, res, ctx) => {
+      }),rest.get('*/v:version/pets/:petId', (_req, res, ctx) => {
         return res(
           ctx.delay(1000),
           ctx.status(200, 'Mocked status'),

--- a/samples/react-query/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/react-query/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -26,6 +26,7 @@ import type {
 } from '../model'
 import { customInstance, ErrorType } from '../mutator/custom-instance'
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AsyncReturnType<
 T extends (...args: any) => Promise<any>
 > = T extends (...args: any) => Promise<infer R> ? R : any;

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -11,7 +11,11 @@ export const generalJSTypes = [
 ];
 
 export const generalJSTypesWithArray = generalJSTypes.reduce<string[]>(
-  (acc, type) => [...acc, type, `Array<${type}>`, `${type}[]`],
+  (acc, type) => {
+    acc.push(type, `Array<${type}>`, `${type}[]`);
+
+    return acc;
+  },
   [],
 );
 

--- a/src/core/generators/angular.ts
+++ b/src/core/generators/angular.ts
@@ -77,7 +77,7 @@ ${
 
 ${
   isRequestOptions && isMutator
-    ? `// eslint-disable-next-line @typescript-eslint/no-explicit-any\n
+    ? `// eslint-disable-next-line @typescript-eslint/no-explicit-any
     type ThirdParameter<T extends (...args: any) => any> = T extends (
   config: any,
   httpClient: any,

--- a/src/core/generators/api.ts
+++ b/src/core/generators/api.ts
@@ -46,12 +46,16 @@ export const generateApi = async ({
       });
 
       const schemas = verbsOptions.reduce<GeneratorSchema[]>(
-        (acc, { queryParams, body, response }) => [
-          ...acc,
-          ...(queryParams ? [queryParams.schema, ...queryParams.deps] : []),
-          ...body.schemas,
-          ...response.schemas,
-        ],
+        (acc, { queryParams, body, response }) => {
+          if (queryParams) {
+            acc.push(queryParams.schema, ...queryParams.deps);
+          }
+
+          acc.push(...body.schemas);
+          acc.push(...response.schemas);
+
+          return acc;
+        },
         [],
       );
 
@@ -63,10 +67,10 @@ export const generateApi = async ({
         mock: !!output.mock,
       });
 
-      return {
-        schemas: [...acc.schemas, ...schemas],
-        operations: { ...acc.operations, ...client },
-      };
+      acc.schemas.push(...schemas);
+      acc.operations = { ...acc.operations, ...client };
+
+      return acc;
     },
     {
       operations: {},

--- a/src/core/generators/axios.ts
+++ b/src/core/generators/axios.ts
@@ -138,7 +138,7 @@ export const generateAxiosHeader = ({
   noFunction?: boolean;
 }) => `${
   isRequestOptions && isMutator
-    ? `// eslint-disable-next-line @typescript-eslint/no-explicit-any\n
+    ? `// eslint-disable-next-line @typescript-eslint/no-explicit-any
   type SecondParameter<T extends (...args: any) => any> = T extends (
   config: any,
   args: infer P,

--- a/src/core/generators/client.ts
+++ b/src/core/generators/client.ts
@@ -239,20 +239,19 @@ export const generateClient = (
       const client = generatorClient(verbOption, options, outputClient);
       const msw = await generateMock(verbOption, options);
 
-      return {
-        ...acc,
-        [verbOption.operationId]: {
-          implementation: verbOption.doc + client.implementation,
-          imports: client.imports,
-          implementationMSW: msw.implementation,
-          importsMSW: msw.imports,
-          tags: verbOption.tags,
-          mutator: verbOption.mutator,
-          formData: verbOption.formData,
-          formUrlEncoded: verbOption.formUrlEncoded,
-          operationName: verbOption.operationName,
-        },
+      acc[verbOption.operationId] = {
+        implementation: verbOption.doc + client.implementation,
+        imports: client.imports,
+        implementationMSW: msw.implementation,
+        importsMSW: msw.imports,
+        tags: verbOption.tags,
+        mutator: verbOption.mutator,
+        formData: verbOption.formData,
+        formUrlEncoded: verbOption.formUrlEncoded,
+        operationName: verbOption.operationName,
       };
+
+      return acc;
     },
     {} as GeneratorOperations,
   );

--- a/src/core/generators/componentDefinition.ts
+++ b/src/core/generators/componentDefinition.ts
@@ -40,12 +40,20 @@ export const generateComponentDefinition = (
       );
 
       const imports = allResponseTypes.reduce<GeneratorImport[]>(
-        (acc, { imports = [] }) => [...acc, ...imports],
+        (acc, { imports = [] }) => {
+          acc.push(...imports);
+
+          return acc;
+        },
         [],
       );
 
       const schemas = allResponseTypes.reduce<GeneratorSchema[]>(
-        (acc, { schemas = [] }) => [...acc, ...schemas],
+        (acc, { schemas = [] }) => {
+          acc.push(...schemas);
+
+          return acc;
+        },
         [],
       );
 
@@ -55,19 +63,17 @@ export const generateComponentDefinition = (
       const doc = jsDoc(response as ResponseObject | RequestBodyObject);
       const model = `${doc}export type ${modelName} = ${type || 'unknown'};\n`;
 
-      return [
-        ...acc,
-        ...schemas,
-        ...(modelName !== type
-          ? [
-              {
-                name: modelName,
-                model,
-                imports,
-              },
-            ]
-          : []),
-      ];
+      acc.push(...schemas);
+
+      if (modelName !== type) {
+        acc.push({
+          name: modelName,
+          model,
+          imports,
+        });
+      }
+
+      return acc;
     },
     [] as GeneratorSchema[],
   );

--- a/src/core/generators/componentDefinition.ts
+++ b/src/core/generators/componentDefinition.ts
@@ -39,23 +39,8 @@ export const generateComponentDefinition = (
         'void',
       );
 
-      const imports = allResponseTypes.reduce<GeneratorImport[]>(
-        (acc, { imports = [] }) => {
-          acc.push(...imports);
-
-          return acc;
-        },
-        [],
-      );
-
-      const schemas = allResponseTypes.reduce<GeneratorSchema[]>(
-        (acc, { schemas = [] }) => {
-          acc.push(...schemas);
-
-          return acc;
-        },
-        [],
-      );
+      const imports = allResponseTypes.flatMap(({ imports }) => imports);
+      const schemas = allResponseTypes.flatMap(({ schemas }) => schemas);
 
       const type = allResponseTypes.map(({ value }) => value).join(' | ');
 

--- a/src/core/generators/imports.ts
+++ b/src/core/generators/imports.ts
@@ -107,17 +107,16 @@ export const addDependency = ({
   >((acc, dep) => {
     const key = hasSchemaDir && dep.specKey ? dep.specKey : 'default';
 
-    return {
-      ...acc,
-      [key]: {
-        values:
-          acc[key]?.values ||
-          (dep.values &&
-            (isAllowSyntheticDefaultImports || !dep.syntheticDefaultImport)) ||
-          false,
-        deps: [...(acc[key]?.deps || []), dep],
-      },
+    acc[key] = {
+      values:
+        acc[key]?.values ||
+        (dep.values &&
+          (isAllowSyntheticDefaultImports || !dep.syntheticDefaultImport)) ||
+        false,
+      deps: [...(acc[key]?.deps || []), dep],
     };
+
+    return acc;
   }, {});
 
   return Object.entries(groupedBySpecKey)
@@ -195,9 +194,6 @@ export const generateVerbImports = ({
 }: GeneratorVerbOptions): GeneratorImport[] => [
   ...response.imports,
   ...body.imports,
-  ...params.reduce<GeneratorImport[]>(
-    (acc, param) => [...acc, ...param.imports],
-    [],
-  ),
   ...(queryParams ? [{ name: queryParams.schema.name }] : []),
+  ...params.flatMap<GeneratorImport>(({ imports }) => imports),
 ];

--- a/src/core/generators/modelsInline.ts
+++ b/src/core/generators/modelsInline.ts
@@ -7,7 +7,11 @@ export const generateModelsInline = (
   obj: Record<string, GeneratorSchema[]>,
 ): string => {
   const schemas = Object.values(obj)
-    .reduce((acc, it) => [...acc, ...it], [])
+    .reduce((acc, it) => {
+      acc.push(...it);
+
+      return acc;
+    }, [])
     .sort((a, b) => (a.imports.some((i) => i.name === b.name) ? 1 : -1));
 
   return schemas.reduce(

--- a/src/core/generators/modelsInline.ts
+++ b/src/core/generators/modelsInline.ts
@@ -6,12 +6,7 @@ export const generateModelInline = (acc: string, model: string): string =>
 export const generateModelsInline = (
   obj: Record<string, GeneratorSchema[]>,
 ): string => {
-  const schemas = Object.values(obj)
-    .reduce((acc, it) => {
-      acc.push(...it);
-
-      return acc;
-    }, [])
+  const schemas = Object.values(obj).flatMap((it) => it)
     .sort((a, b) => (a.imports.some((i) => i.name === b.name) ? 1 : -1));
 
   return schemas.reduce(

--- a/src/core/generators/parameterDefinition.ts
+++ b/src/core/generators/parameterDefinition.ts
@@ -26,24 +26,23 @@ export const generateParameterDefinition = (
       }
 
       if (!schema.schema || imports.length) {
-        return [
-          ...acc,
-          {
-            name: modelName,
-            imports: imports.length
-              ? [
-                  {
-                    name: imports[0].name,
-                    specKey: imports[0].specKey,
-                    schemaName: imports[0].schemaName,
-                  },
-                ]
-              : [],
-            model: `export type ${modelName} = ${
-              imports.length ? imports[0].name : 'unknown'
-            };\n`,
-          },
-        ];
+        acc.push({
+          name: modelName,
+          imports: imports.length
+            ? [
+                {
+                  name: imports[0].name,
+                  specKey: imports[0].specKey,
+                  schemaName: imports[0].schemaName,
+                },
+              ]
+            : [],
+          model: `export type ${modelName} = ${
+            imports.length ? imports[0].name : 'unknown'
+          };\n`,
+        });
+
+        return acc;
       }
 
       const resolvedObject = await resolveObject({
@@ -58,19 +57,17 @@ export const generateParameterDefinition = (
         resolvedObject.value || 'unknown'
       };\n`;
 
-      return [
-        ...acc,
-        ...resolvedObject.schemas,
-        ...(modelName !== resolvedObject.value
-          ? [
-              {
-                name: modelName,
-                model,
-                imports: resolvedObject.imports,
-              },
-            ]
-          : []),
-      ];
+      acc.push(...resolvedObject.schemas);
+
+      if (modelName !== resolvedObject.value) {
+        acc.push({
+          name: modelName,
+          model,
+          imports: resolvedObject.imports,
+        });
+      }
+
+      return acc;
     },
     [] as GeneratorSchema[],
   );

--- a/src/core/generators/query.ts
+++ b/src/core/generators/query.ts
@@ -618,13 +618,13 @@ export const generateQueryHeader = ({
 }: {
   isRequestOptions: boolean;
   isMutator: boolean;
-}) => `// eslint-disable-next-line @typescript-eslint/no-explicit-any\n
+}) => `// eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AsyncReturnType<
 T extends (...args: any) => Promise<any>
 > = T extends (...args: any) => Promise<infer R> ? R : any;\n\n
 ${
   isRequestOptions && isMutator
-    ? `// eslint-disable-next-line @typescript-eslint/no-explicit-any\n
+    ? `// eslint-disable-next-line @typescript-eslint/no-explicit-any
   type SecondParameter<T extends (...args: any) => any> = T extends (
   config: any,
   args: infer P,

--- a/src/core/generators/schemaDefinition.ts
+++ b/src/core/generators/schemaDefinition.ts
@@ -36,15 +36,16 @@ export const generateSchemasDefinition = async (
         !isReference(schema) &&
         !schema.nullable
       ) {
-        return [
-          ...acc,
+        acc.push(
           ...(await generateInterface({
             name: schemaName,
             schema,
             context,
             suffix,
           })),
-        ];
+        );
+
+        return acc;
       } else {
         const resolvedValue = await resolveValue({
           schema,
@@ -88,15 +89,13 @@ export const generateSchemasDefinition = async (
           output += `export type ${schemaName} = ${resolvedValue.value};\n`;
         }
 
-        return [
-          ...acc,
-          ...resolvedValue.schemas,
-          {
-            name: schemaName,
-            model: output,
-            imports,
-          },
-        ];
+        acc.push(...resolvedValue.schemas, {
+          name: schemaName,
+          model: output,
+          imports,
+        });
+
+        return acc;
       }
     },
     [] as GeneratorSchema[],

--- a/src/core/generators/swr.ts
+++ b/src/core/generators/swr.ts
@@ -305,13 +305,13 @@ export const generateSwrHeader = ({
 }: {
   isRequestOptions: boolean;
   isMutator: boolean;
-}) => `// eslint-disable-next-line @typescript-eslint/no-explicit-any\n
+}) => `// eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AsyncReturnType<
 T extends (...args: any) => Promise<any>
 > = T extends (...args: any) => Promise<infer R> ? R : any;\n\n
 ${
   isRequestOptions && isMutator
-    ? `// eslint-disable-next-line @typescript-eslint/no-explicit-any\n
+    ? `// eslint-disable-next-line @typescript-eslint/no-explicit-any
   type SecondParameter<T extends (...args: any) => any> = T extends (
   config: any,
   args: infer P,

--- a/src/core/generators/verbsOptions.ts
+++ b/src/core/generators/verbsOptions.ts
@@ -174,20 +174,20 @@ export const generateVerbsOptions = ({
   asyncReduce(
     Object.entries(verbs),
     async (acc, [verb, operation]: [string, OperationObject]) => {
-      if (!isVerb(verb)) {
-        return acc;
+      if (isVerb(verb)) {
+        const verbOptions = await generateVerbOptions({
+          verb,
+          output,
+          verbParameters: verbs.parameters,
+          route,
+          operation,
+          context,
+        });
+
+        acc.push(verbOptions);
       }
 
-      const verbOptions = await generateVerbOptions({
-        verb,
-        output,
-        verbParameters: verbs.parameters,
-        route,
-        operation,
-        context,
-      });
-
-      return [...acc, verbOptions];
+      return acc;
     },
     [] as GeneratorVerbsOptions,
   );

--- a/src/core/getters/body.ts
+++ b/src/core/getters/body.ts
@@ -18,11 +18,19 @@ export const getBody = async (
   );
 
   const imports = allBodyTypes.reduce<GeneratorImport[]>(
-    (acc, { imports = [] }) => [...acc, ...imports],
+    (acc, { imports = [] }) => {
+      acc.push(...imports);
+
+      return acc;
+    },
     [],
   );
   const schemas = allBodyTypes.reduce<GeneratorSchema[]>(
-    (acc, { schemas = [] }) => [...acc, ...schemas],
+    (acc, { schemas = [] }) => {
+      acc.push(...schemas);
+
+      return acc;
+    },
     [],
   );
 

--- a/src/core/getters/body.ts
+++ b/src/core/getters/body.ts
@@ -17,22 +17,8 @@ export const getBody = async (
     context,
   );
 
-  const imports = allBodyTypes.reduce<GeneratorImport[]>(
-    (acc, { imports = [] }) => {
-      acc.push(...imports);
-
-      return acc;
-    },
-    [],
-  );
-  const schemas = allBodyTypes.reduce<GeneratorSchema[]>(
-    (acc, { schemas = [] }) => {
-      acc.push(...schemas);
-
-      return acc;
-    },
-    [],
-  );
+  const imports = allBodyTypes.flatMap(({ imports }) => imports);
+  const schemas = allBodyTypes.flatMap(({ schemas }) => schemas)
 
   const definition = allBodyTypes.map(({ value }) => value).join(' | ');
 

--- a/src/core/getters/combine.ts
+++ b/src/core/getters/combine.ts
@@ -41,15 +41,14 @@ export const combineSchemas = async ({
         context,
       });
 
-      return {
-        ...acc,
-        values: [...acc.values, resolvedValue.value],
-        imports: [...acc.imports, ...resolvedValue.imports],
-        schemas: [...acc.schemas, ...resolvedValue.schemas],
-        isEnum: [...acc.isEnum, resolvedValue.isEnum],
-        types: [...acc.types, resolvedValue.type],
-        isRef: [...acc.isRef, resolvedValue.isRef],
-      };
+      acc.values.push(resolvedValue.value);
+      acc.imports.push(...resolvedValue.imports);
+      acc.schemas.push(...resolvedValue.schemas);
+      acc.isEnum.push(resolvedValue.isEnum);
+      acc.types.push(resolvedValue.type);
+      acc.isRef.push(resolvedValue.isRef);
+
+      return acc;
     },
     {
       values: [],

--- a/src/core/getters/object.ts
+++ b/src/core/getters/object.ts
@@ -107,11 +107,11 @@ export const getObject = async ({
 
         const doc = jsDoc(schema as SchemaObject, true);
 
-        acc.imports = [...acc.imports, ...resolvedValue.imports];
+        acc.imports.push(...resolvedValue.imports);
         acc.value += `\n  ${doc ? `${doc}  ` : ''}${
           isReadOnly ? 'readonly ' : ''
         }${getKey(key)}${isRequired ? '' : '?'}: ${resolvedValue.value};`;
-        acc.schemas = [...acc.schemas, ...resolvedValue.schemas];
+        acc.schemas.push(...resolvedValue.schemas);
 
         if (arr.length - 1 === index) {
           acc.value += '\n}';

--- a/src/core/getters/parameters.ts
+++ b/src/core/getters/parameters.ts
@@ -20,22 +20,15 @@ export const getParameters = async ({
           await resolveRef<ParameterObject>(p, context);
 
         if (parameter.in === 'path' || parameter.in === 'query') {
-          return {
-            ...acc,
-            [parameter.in]: [...acc[parameter.in], { parameter, imports }],
-          };
+          acc[parameter.in].push({ parameter, imports });
         }
-
-        return acc;
       } else {
-        if (p.in !== 'query' && p.in !== 'path') {
-          return acc;
+        if (p.in === 'query' || p.in === 'path') {
+          acc[p.in].push({ parameter: p, imports: [] });
         }
-        return {
-          ...acc,
-          [p.in]: [...acc[p.in], { parameter: p, imports: [] }],
-        };
       }
+
+      return acc;
     },
     {
       path: [],

--- a/src/core/getters/queryParams.ts
+++ b/src/core/getters/queryParams.ts
@@ -87,16 +87,8 @@ export const getQueryParams = async ({
     return;
   }
   const types = await getQueryParamsTypes(queryParams, operationName, context);
-  const imports = types.reduce<GeneratorImport[]>((acc, { imports = [] }) => {
-    acc.push(...imports);
-
-    return acc;
-  }, []);
-  const schemas = types.reduce<GeneratorSchema[]>((acc, { schemas = [] }) => {
-    acc.push(...schemas);
-
-    return acc;
-  }, []);
+  const imports = types.flatMap(({ imports }) => imports);
+  const schemas = types.flatMap(({ schemas }) => schemas);
   const name = `${pascal(operationName)}Params`;
 
   const type = types.map(({ definition }) => definition).join('; ');

--- a/src/core/getters/queryParams.ts
+++ b/src/core/getters/queryParams.ts
@@ -87,14 +87,16 @@ export const getQueryParams = async ({
     return;
   }
   const types = await getQueryParamsTypes(queryParams, operationName, context);
-  const imports = types.reduce<GeneratorImport[]>(
-    (acc, { imports = [] }) => [...acc, ...imports],
-    [],
-  );
-  const schemas = types.reduce<GeneratorSchema[]>(
-    (acc, { schemas = [] }) => [...acc, ...schemas],
-    [],
-  );
+  const imports = types.reduce<GeneratorImport[]>((acc, { imports = [] }) => {
+    acc.push(...imports);
+
+    return acc;
+  }, []);
+  const schemas = types.reduce<GeneratorSchema[]>((acc, { schemas = [] }) => {
+    acc.push(...schemas);
+
+    return acc;
+  }, []);
   const name = `${pascal(operationName)}Params`;
 
   const type = types.map(({ definition }) => definition).join('; ');

--- a/src/core/getters/resReqTypes.ts
+++ b/src/core/getters/resReqTypes.ts
@@ -200,7 +200,11 @@ export const getResReqTypes = async (
   );
 
   return uniqBy(
-    typesArray.reduce<ResReqTypesValue[]>((acc, it) => [...acc, ...it], []),
+    typesArray.reduce<ResReqTypesValue[]>((acc, it) => {
+      acc.push(...it);
+
+      return acc;
+    }, []),
     'value',
   );
 };

--- a/src/core/getters/resReqTypes.ts
+++ b/src/core/getters/resReqTypes.ts
@@ -200,11 +200,7 @@ export const getResReqTypes = async (
   );
 
   return uniqBy(
-    typesArray.reduce<ResReqTypesValue[]>((acc, it) => {
-      acc.push(...it);
-
-      return acc;
-    }, []),
+    typesArray.flatMap((it) => it),
     'value',
   );
 };

--- a/src/core/getters/response.ts
+++ b/src/core/getters/response.ts
@@ -46,17 +46,8 @@ export const getResponse = async (
     { success: [], errors: [] },
   );
 
-  const imports = types.reduce<GeneratorImport[]>((acc, { imports = [] }) => {
-    acc.push(...imports);
-
-    return acc;
-  }, []);
-
-  const schemas = types.reduce<GeneratorSchema[]>((acc, { schemas = [] }) => {
-    acc.push(...schemas);
-
-    return acc;
-  }, []);
+  const imports = types.flatMap(({ imports }) => imports);
+  const schemas = types.flatMap(({ schemas }) => schemas);
 
   const contentTypes = [
     ...new Set(types.map(({ contentType }) => contentType)),

--- a/src/core/getters/response.ts
+++ b/src/core/getters/response.ts
@@ -35,22 +35,28 @@ export const getResponse = async (
     success: ResReqTypesValue[];
     errors: ResReqTypesValue[];
   }>(
-    (acc, type) =>
-      type.key.startsWith('2')
-        ? { ...acc, success: [...acc.success, type] }
-        : { ...acc, errors: [...acc.errors, type] },
+    (acc, type) => {
+      if (type.key.startsWith('2')) {
+        acc.success.push(type);
+      } else {
+        acc.errors.push(type);
+      }
+      return acc;
+    },
     { success: [], errors: [] },
   );
 
-  const imports = types.reduce<GeneratorImport[]>(
-    (acc, { imports = [] }) => [...acc, ...imports],
-    [],
-  );
+  const imports = types.reduce<GeneratorImport[]>((acc, { imports = [] }) => {
+    acc.push(...imports);
 
-  const schemas = types.reduce<GeneratorSchema[]>(
-    (acc, { schemas = [] }) => [...acc, ...schemas],
-    [],
-  );
+    return acc;
+  }, []);
+
+  const schemas = types.reduce<GeneratorSchema[]>((acc, { schemas = [] }) => {
+    acc.push(...schemas);
+
+    return acc;
+  }, []);
 
   const contentTypes = [
     ...new Set(types.map(({ contentType }) => contentType)),

--- a/src/core/getters/schema.ts
+++ b/src/core/getters/schema.ts
@@ -9,21 +9,21 @@ export const getSchema = (
 ) => {
   const schemas = Object.entries(
     context.specs[specKey].components?.schemas || [],
-  ).reduce((acc, [name, type]) => ({ ...acc, [name]: type }), {}) as {
-    [key: string]: SchemaObject;
-  };
+  ).reduce<Record<string, SchemaObject>>((acc, [name, type]) => {
+    acc[name] = type;
+
+    return acc;
+  }, {});
 
   const responses = Object.entries(
     context.specs[specKey].components?.responses || [],
-  ).reduce(
-    (acc, [name, type]) => ({
-      ...acc,
-      [name]: isReference(type)
-        ? type
-        : type.content?.['application/json']?.schema,
-    }),
-    {},
-  ) as { [key: string]: SchemaObject };
+  ).reduce<Record<string, SchemaObject | undefined>>((acc, [name, type]) => {
+    acc[name] = isReference(type)
+      ? type
+      : type.content?.['application/json']?.schema;
+
+    return acc;
+  }, {});
 
   const allSchemas = { ...schemas, ...responses };
 

--- a/src/core/importers/openApi.ts
+++ b/src/core/importers/openApi.ts
@@ -40,10 +40,9 @@ const generateInputSpecs = async ({
         await ibmOpenapiValidator(transfomedSchema);
       }
 
-      return {
-        ...acc,
-        [specKey]: transfomedSchema,
-      };
+      acc[specKey] = transfomedSchema;
+
+      return acc;
     },
     {} as Record<string, OpenAPIObject>,
   );
@@ -121,10 +120,9 @@ export const importOpenApi = async ({
         return acc;
       }
 
-      return {
-        ...acc,
-        [specKey]: schemas,
-      };
+      acc[specKey] = schemas;
+
+      return acc;
     },
     {} as Record<string, GeneratorSchema[]>,
   );

--- a/src/core/writers/specs.ts
+++ b/src/core/writers/specs.ts
@@ -27,10 +27,11 @@ export const writeSpecs = async (
 
   const specsName = Object.keys(schemas).reduce((acc, specKey) => {
     const basePath = getSpecName(specKey, target);
-
     const name = basePath.slice(1).split('/').join('-');
 
-    return { ...acc, [specKey]: name };
+    acc[specKey] = name;
+
+    return acc;
   }, {} as Record<keyof typeof schemas, string>);
 
   const header = output.override.header

--- a/src/core/writers/splitTagsMode.ts
+++ b/src/core/writers/splitTagsMode.ts
@@ -126,5 +126,9 @@ export const writeSplitTagsMode = async ({
     }),
   );
 
-  return generatedFilePathsArray.reduce((acc, it) => [...acc, ...it], []);
+  return generatedFilePathsArray.reduce((acc, it) => {
+    acc.push(...it);
+
+    return acc;
+  }, []);
 };

--- a/src/core/writers/splitTagsMode.ts
+++ b/src/core/writers/splitTagsMode.ts
@@ -126,9 +126,5 @@ export const writeSplitTagsMode = async ({
     }),
   );
 
-  return generatedFilePathsArray.reduce((acc, it) => {
-    acc.push(...it);
-
-    return acc;
-  }, []);
+  return generatedFilePathsArray.flatMap((it) => it);
 };

--- a/src/core/writers/tagsMode.ts
+++ b/src/core/writers/tagsMode.ts
@@ -108,9 +108,5 @@ export const writeTagsMode = async ({
     }),
   );
 
-  return generatedFilePathsArray.reduce((acc, it) => {
-    acc.push(...it);
-
-    return acc;
-  }, []);
+  return generatedFilePathsArray.flatMap((it) => it);
 };

--- a/src/core/writers/tagsMode.ts
+++ b/src/core/writers/tagsMode.ts
@@ -108,5 +108,9 @@ export const writeTagsMode = async ({
     }),
   );
 
-  return generatedFilePathsArray.reduce((acc, it) => [...acc, ...it], []);
+  return generatedFilePathsArray.reduce((acc, it) => {
+    acc.push(...it);
+
+    return acc;
+  }, []);
 };

--- a/src/core/writers/target.ts
+++ b/src/core/writers/target.ts
@@ -24,24 +24,24 @@ export const generateTarget = (
 
   const target = Object.values(operations).reduce(
     (acc, operation, index, arr) => {
-      acc.imports = [...acc.imports, ...operation.imports];
-      acc.importsMSW = [...acc.importsMSW, ...operation.importsMSW];
+      acc.imports.push(...operation.imports);
+      acc.importsMSW.push(...operation.importsMSW);
       acc.implementation += operation.implementation + '\n';
       acc.implementationMSW.function += operation.implementationMSW.function;
       acc.implementationMSW.handler += operation.implementationMSW.handler;
       if (operation.mutator) {
-        acc.mutators = [...acc.mutators, operation.mutator];
+        acc.mutators.push(operation.mutator);
       }
 
       if (operation.formData) {
-        acc.formData = [...acc.formData, operation.formData];
+        acc.formData.push(operation.formData);
       }
       if (operation.formUrlEncoded) {
-        acc.formUrlEncoded = [...acc.formUrlEncoded, operation.formUrlEncoded];
+        acc.formUrlEncoded.push(operation.formUrlEncoded);
       }
 
       if (index === arr.length - 1) {
-        const isMutator = !!acc.mutators?.some(
+        const isMutator = acc.mutators.some(
           (mutator) => mutator.mutatorFn.length > (isAngularClient ? 2 : 1),
         );
         const header = generateClientHeader({
@@ -61,7 +61,6 @@ export const generateTarget = (
         const footer = generateClientFooter(options?.client, operationNames);
         acc.implementation += footer.implementation;
         acc.implementationMSW.handler += footer.implementationMSW;
-        acc.imports = acc.imports;
       }
       return acc;
     },

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -100,10 +100,11 @@ export const generateConfig = async (
 
   const normalizedConfig = await asyncReduce(
     Object.entries(config),
-    async (acc, [key, value]) => ({
-      ...acc,
-      [key]: await normalizeOptions(value, workspace, options),
-    }),
+    async (acc, [key, value]) => {
+      acc[key] = await normalizeOptions(value, workspace, options);
+
+      return acc;
+    },
     {} as NormizaledConfig,
   );
 

--- a/src/utils/mergeDeep.ts
+++ b/src/utils/mergeDeep.ts
@@ -12,11 +12,13 @@ export function mergeDeep<T extends Record<string, any>>(
     const sourceValue = acc[key];
 
     if (Array.isArray(sourceValue) && Array.isArray(value)) {
-      return { ...acc, [key]: [...sourceValue, ...value] };
+      (acc[key] as any) = [...sourceValue, ...value];
+    } else if (isObject(sourceValue) && isObject(value)) {
+      (acc[key] as any) = mergeDeep(sourceValue, value);
+    } else {
+      (acc[key] as any) = value;
     }
-    if (isObject(sourceValue) && isObject(value)) {
-      return { ...acc, [key]: mergeDeep(sourceValue, value) };
-    }
-    return { ...acc, [key]: value };
+
+    return acc;
   }, source);
 }


### PR DESCRIPTION
Global refactoring to avoid coping all data on every reducer iteration.

This consumes lots of memory and work as `O(n^2)`. Current optimization increases reducers speed to `O(n)`

Also some TS types were fixed a bit.
