### PR TITLE
fix(types): remove generic from axios query function generator (#284)

### DIFF
--- a/samples/react-app/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
+++ b/samples/react-app/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
@@ -18,18 +18,18 @@ export const getListPetsMock = () => ([...Array(faker.datatype.number({min: 1, m
 export const getShowPetByIdMock = () => ((()=>({id:faker.datatype.number({min:1,max:99}),name:faker.name.firstName(),tag:faker.helpers.randomize([faker.random.word(),void 0])}))())
 
 export const getSwaggerPetstoreMSW = () => [
-rest.get('*/v:version/pets', (req, res, ctx) => {
+rest.get('*/v:version/pets', (_req, res, ctx) => {
         return res(
           ctx.delay(1000),
           ctx.status(200, 'Mocked status'),
 ctx.json(getListPetsMock()),
         )
-      }),rest.post('*/v:version/pets', (req, res, ctx) => {
+      }),rest.post('*/v:version/pets', (_req, res, ctx) => {
         return res(
           ctx.delay(1000),
           ctx.status(200, 'Mocked status'),
         )
-      }),rest.get('*/v:version/pets/:petId', (req, res, ctx) => {
+      }),rest.get('*/v:version/pets/:petId', (_req, res, ctx) => {
         return res(
           ctx.delay(1000),
           ctx.status(200, 'Mocked status'),

--- a/samples/react-app/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/react-app/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -16,11 +16,11 @@ import { customInstance } from '../mutator/custom-instance'
   /**
  * @summary List all pets
  */
-export const listPets = <TData = Pets>(
+export const listPets = (
     params?: ListPetsParams,
     version= 1,
  ) => {
-      return customInstance<TData>(
+      return customInstance<Pets>(
       {url: `/v${version}/pets`, method: 'get',
         params,
     },
@@ -30,11 +30,11 @@ export const listPets = <TData = Pets>(
 /**
  * @summary Create a pet
  */
-export const createPets = <TData = void>(
+export const createPets = (
     createPetsBody: CreatePetsBody,
     version= 1,
  ) => {
-      return customInstance<TData>(
+      return customInstance<void>(
       {url: `/v${version}/pets`, method: 'post',
       data: createPetsBody
     },
@@ -44,11 +44,11 @@ export const createPets = <TData = void>(
 /**
  * @summary Info for a specific pet
  */
-export const showPetById = <TData = Pet>(
+export const showPetById = (
     petId: string,
     version= 1,
  ) => {
-      return customInstance<TData>(
+      return customInstance<Pet>(
       {url: `/v${version}/pets/${petId}`, method: 'get'
     },
       );

--- a/src/core/generators/axios.ts
+++ b/src/core/generators/axios.ts
@@ -83,7 +83,7 @@ const generateAxiosImplementation = (
         )
       : '';
 
-    return `const ${operationName} = ${toObjectString(
+    return `const ${operationName} = (\n    ${toObjectString(
       props,
       'implementation',
     )}\n ${


### PR DESCRIPTION
Ooops, the opening bracket were lost in `src/core/generators/axios.ts` file. Fix this.