### PR TITLE
fix(getters): enum can contain dashes

### DIFF
--- a/src/core/getters/enum.ts
+++ b/src/core/getters/enum.ts
@@ -26,7 +26,7 @@ export const getEnumImplementation = (
     const key =
       isNumber || isTypeNumber
         ? toNumberKey(isTypeNumber ? val.toString() : val.slice(1, -1))
-        : sanitize(val, { underscore: '_', whitespace: '_' });
+        : sanitize(val, { underscore: '_', whitespace: '_', dash: '-' });
 
     return (
       acc +

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -51,10 +51,11 @@ export const sanitize = (
     whitespace?: string | true;
     underscore?: string | true;
     dot?: string | true;
+    dash?: string | true;
   },
 ) => {
-  const { whitespace = '', underscore = '', dot = '' } = options || {};
-  let newValue = value.replace(/[^\w\s.]/g, '');
+  const { whitespace = '', underscore = '', dot = '', dash = '' } = options || {};
+  let newValue = value.replace(/[^\w\s.-]/g, '');
 
   if (whitespace !== true) {
     newValue = newValue.replace(/[\s]/g, whitespace);
@@ -66,6 +67,10 @@ export const sanitize = (
 
   if (dot !== true) {
     newValue = newValue.replace(/[.]/g, dot);
+  }
+
+  if (dash !== true) {
+    newValue = newValue.replace(/[-]/g, dash);
   }
 
   return newValue;

--- a/tests/specifications/petstore.yaml
+++ b/tests/specifications/petstore.yaml
@@ -20,6 +20,19 @@ paths:
           required: false
           schema:
             type: string
+        - name: sort
+          in: query
+          description: |
+            Which property to sort by?
+            Example: name sorts ASC while -name sorts DESC.
+          required: false
+          schema:
+            type: string
+            enum:
+              - name
+              - -name
+              - email
+              - -email
       responses:
         '200':
           description: A paged array of pets


### PR DESCRIPTION
## Status
<!--- **READY/WIP/HOLD** --->
**READY**

## Description

This PR fixes generated TS code when an enum contains a dash. Example of usage will be query param `sort`: 

```yaml
paths:
  /pets:
    get:
      summary: List all pets
      operationId: listPets
      tags:
        - pets
      parameters:
        - name: limit
          in: query
          description: How many items to return at one time (max 100)
          required: false
          schema:
            type: string
        - name: sort
          in: query
          description: |
            Which property to sort by?
            Example: name sorts ASC while -name sorts DESC.
          required: false
          schema:
            type: string
            enum:
              - name
              - -name
              - email
              - -email
```

### Generated code before

```ts
export const ListPetsSort = {
  name: 'name' as ListPetsSort,
  name: '-name' as ListPetsSort, // Note the duplicated key
  email: 'email' as ListPetsSort,
  email: '-email' as ListPetsSort, // Note the duplicated key
};
```

### Generated code after

```ts
export const ListPetsSort = {
  name: 'name' as ListPetsSort,
  '-name': '-name' as ListPetsSort,
  email: 'email' as ListPetsSort,
  '-email': '-email' as ListPetsSort,
};
```

Which gets us with the desired result:

![image](https://user-images.githubusercontent.com/92300/150294206-ccd511c3-423a-4615-bb29-5204a050290f.png)


## Todos
- [x] Tests
- [x] Documentation
- [x] Changelog Entry (unreleased)
