### PR TITLE
feat(axios): axios factory function accepts an axios instance

### DIFF
--- a/src/core/generators/axios.ts
+++ b/src/core/generators/axios.ts
@@ -26,6 +26,7 @@ const AXIOS_DEPENDENCIES: GeneratorDependency[] = [
       },
       { name: 'AxiosRequestConfig' },
       { name: 'AxiosResponse' },
+      { name: 'AxiosInstance' },
     ],
     dependency: 'axios',
   },
@@ -46,7 +47,7 @@ const generateAxiosImplementation = (
     formData,
     formUrlEncoded,
   }: GeneratorVerbOptions,
-  { route, context }: GeneratorOptions,
+  { route, context, noFunction }: GeneratorOptions & {noFunction?: boolean},
 ) => {
   const isRequestOptions = override?.requestOptions !== false;
   const isFormData = override?.formData !== false;
@@ -114,7 +115,7 @@ const generateAxiosImplementation = (
   }>>(\n    ${toObjectString(props, 'implementation')} ${
     isRequestOptions ? `options?: AxiosRequestConfig\n` : ''
   } ): Promise<TData> => {${bodyForm}
-    return axios${
+    return ${noFunction === true ? 'axios' : 'localAxios'}${
       !isSyntheticDefaultImportsAllowed ? '.default' : ''
     }.${verb}(${options});
   }
@@ -147,14 +148,14 @@ export const generateAxiosHeader = ({
   : never;\n\n`
     : ''
 }
-  ${!noFunction ? `export const ${title} = () => {\n` : ''}`;
+  ${!noFunction ? `export const ${title} = ({axios: localAxios = axios}: {axios?: AxiosInstance} = {}) => {\n` : ''}`;
 
 export const generateAxiosFooter = (operationNames: string[] = []) =>
   `return {${operationNames.join(',')}}};\n`;
 
 export const generateAxios = (
   verbOptions: GeneratorVerbOptions,
-  options: GeneratorOptions,
+  options: GeneratorOptions & {noFunction?: boolean},
 ): GeneratorClient => {
   const imports = generateVerbImports(verbOptions);
   const implementation = generateAxiosImplementation(verbOptions, options);

--- a/src/core/generators/client.ts
+++ b/src/core/generators/client.ts
@@ -56,7 +56,7 @@ export const GENERATOR_CLIENT: GeneratorClients = {
   },
   'axios-functions': {
     client: (verbOptions: GeneratorVerbOptions, options: GeneratorOptions) => {
-      const { implementation, imports } = generateAxios(verbOptions, options);
+      const { implementation, imports } = generateAxios(verbOptions, {...options, noFunction: true });
 
       return {
         implementation: 'export ' + implementation,


### PR DESCRIPTION
## Status
<!--- **READY/WIP/HOLD** --->
**READY**

## Description

This provides a dynamic alternative to
the configuration option `output.override.mutator`
where we can provide a axios instance to
make http requests through.

Old code generated:

```ts
  export const getSwaggerPetstore = () => {
/**
 * @summary List all pets
 */
const listPets = <TData = AxiosResponse<Pets>>(
    params?: ListPetsParams,
    version= 1, options?: AxiosRequestConfig
 ): Promise<TData> => {
    return axios.get(
      `/v${version}/pets`,{
        params,
    ...options}
    );
  }
```

New code generates:

```ts
  export const getSwaggerPetstore = ({axios: localAxios = axios}: {axios?: AxiosInstance} = {}) => {
/**
 * @summary List all pets
 */
const listPets = <TData = AxiosResponse<Pets>>(
    params?: ListPetsParams,
    version= 1, options?: AxiosRequestConfig
 ): Promise<TData> => {
    return localAxios.get(
      `/v${version}/pets`,{
        params,
    ...options}
    );
  }
```

`localAxios` is set to global axios, so I believe the old behaviour is kept.

## Why?

Be able to do something like this:

```ts
import {getSwaggerPetstore} from 'generated'

export function prepareApi(someArgDictatingAuthStrategyAndOtherAxiosConfigs: any) {
  const axios = Axios.create()

  // Configure axois instance according to someArgDictatingAuthStrategyAndOtherAxiosConfigs

  return getSwaggerPetstore({axios})
}
```

In other words, use a specific Axios instance each time `prepareApi` is called.

## Question

Maybe I have missed something and there is a better way of archiving this?

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)