### PR TITLE
fix(generators): swr compatible with eslint "semi: error" rule

### DIFF
--- a/src/core/generators/swr.ts
+++ b/src/core/generators/swr.ts
@@ -167,7 +167,7 @@ const generateSwrArguments = ({
       : isMutatorHasSecondArg
       ? `request?: SecondParameter<typeof ${mutator.name}>`
       : ''
-  }}\n`;
+  } }\n`;
 };
 
 const generateSwrImplementation = ({


### PR DESCRIPTION
## Status
<!--- **READY/WIP/HOLD** --->
**READY**

## Description
Fixes an issue where swr generated code was incompatible with this eslint config:

```js
{
  parser: '@typescript-eslint/parser',
  extends: ['plugin:@typescript-eslint/recommended', 'plugin:prettier/recommended', 'prettier'],
  rules: {
    semi: ['error', 'never'],
  },
}
```

We where using eslint 8.7.0 which produced the following error when running eslint on code:

```
/driftiCoreAPI.ts
  152:37  error  Parsing error: '>' expected

✖ 1 problem (1 error, 0 warnings)
```

If I removed `semi: ['error', 'never'],` it worked fine 🤔 

Generated code which eslint complained about was:

```ts
export const useGetAccount = <TError = GetAccount422 | GetAccount4xx | GetAccount5xx>(
  options?: { swr?:SWRConfiguration<AsyncReturnType<typeof getAccount>, TError> & {swrKey: Key}, request?: SecondParameter<typeof customInstance>}

  ) => {

  const {swr: swrOptions, request: requestOptions} = options || {}

  // more generated code code
```

However, if code was like the following example eslint no longer
complained. Note the space added after customInstance> on line 2.

```ts
export const useGetAccount = <TError = GetAccount422 | GetAccount4xx | GetAccount5xx>(
  options?: { swr?:SWRConfiguration<AsyncReturnType<typeof getAccount>, TError> & {swrKey: Key}, request?: SecondParameter<typeof customInstance> }

  ) => {

  const {swr: swrOptions, request: requestOptions} = options || {}

  // more generated code code
```

So that was kind of a strange one. Providing a PR in case of anyone else encounters this.

## Todos
- [x] Tests
- [x] Documentation
- [x] Changelog Entry (unreleased)
