### PR TITLE
fix(config): allow to pass an operationId modifier in config

### DIFF
--- a/docs/src/pages/reference/configuration/output.md
+++ b/docs/src/pages/reference/configuration/output.md
@@ -732,6 +732,42 @@ Type: `Object`.
 
 Exactly the same as the `override.operations` but this time you can do it by <a href="https://swagger.io/docs/specification/grouping-operations-with-tags/" target="_blank">tags</a>
 
+#### operationId
+
+Type: `Function`.
+
+Function to override the generate operation id. The id is then used to generate all types and functions names.
+You can see <a href="https://github.com/anymaniax/orval/blob/next/src/core/getters/operation.ts" target="_blank">here</a> how we compute that id by default (`getOperationId`).
+
+**Important notice:** The id returned here should always be unique by route and verb otherwise you'll get naming conflicts when generating types/functions.
+
+
+```ts
+// type signature
+(operation: OperationObject, route: string, verb: Verbs) => string;
+// Example
+import { capitalize, camelCase } from 'lodash';
+const sanitizeId = (str) =>
+  str.replace(/[^\w{}]/g, '').replace(/{(\w+)}/g, 'By-$1');
+
+module.exports = {
+  petstore: {
+    output: {
+      override: {
+        // From: /api/endpoint/objects/{id}/index
+        // To: <verb>ApiEndpointObjectsByIdIndex
+        opearationId: (operation, route, verb) => {
+          return capitalize(
+            camelCase(
+              [verb, ...route.split('/').map((p) => sanitizeId(p))].join('-'),
+            ),
+          );
+        },
+      },
+    },
+  },
+};
+```
 #### operationName
 
 Type: `Function`.
@@ -741,7 +777,7 @@ Type: `Function`.
 (operation: OperationObject, route: string, verb: Verbs) => string;
 ```
 
-Function to override the generate operation name.
+Function to override the generate operation name. This will affect only the hook/client functions name.
 
 #### requestOptions
 

--- a/src/core/generators/verbsOptions.ts
+++ b/src/core/generators/verbsOptions.ts
@@ -56,7 +56,10 @@ const generateVerbOptions = async ({
     summary,
   } = operation;
 
-  const operationId = getOperationId(operation, route, verb);
+  const overrideOperationId = output.override?.operationId;
+  const operationId = overrideOperationId
+    ? overrideOperationId(operation, route, verb)
+    : getOperationId(route, verb);
 
   const overrideOperation = output.override.operations[operation.operationId!];
   const overrideTag = Object.entries(

--- a/src/core/getters/operation.ts
+++ b/src/core/getters/operation.ts
@@ -1,16 +1,7 @@
-import { OperationObject } from 'openapi3-ts';
 import { Verbs } from '../../types';
 import { pascal } from '../../utils/case';
 import { sanitize } from '../../utils/string';
 
-export const getOperationId = (
-  operation: OperationObject,
-  route: string,
-  verb: Verbs,
-): string => {
-  if (operation.operationId) {
-    return operation.operationId;
-  }
-
+export const getOperationId = (route: string, verb: Verbs): string => {
   return pascal([verb, ...route.split('/').map((p) => sanitize(p))].join('-'));
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -82,6 +82,11 @@ export type NormalizedOverrideOutput = {
     route: string,
     verb: Verbs,
   ) => string;
+  operationId?: (
+    operation: OperationObject,
+    route: string,
+    verb: Verbs,
+  ) => string;
   requestOptions: Record<string, any> | boolean;
   useDates?: boolean;
 };


### PR DESCRIPTION
## Status
<!--- **READY/WIP/HOLD** --->
**READY**

## Description
Like we allow to set `operationName`, we should be able to customize the way that `operationId` are generated from the endpoint path.

I use the v6.4.3 codebase since te 6.5 doesn't work on my side due to [that issue](https://github.com/anymaniax/orval/issues/301)

## Todos
- [ ] Tests: I don't see any tests about the config, is there any?
- [x] Documentation
- [ ] Changelog Entry (unreleased) Where is it?

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.
```bash
> git pull --prune
> git checkout <branch>
> grunt jasmine
```
1.
