### PR TITLE
fix(config): fix operationName bug not changing models naming

### DIFF
--- a/src/core/generators/verbsOptions.ts
+++ b/src/core/generators/verbsOptions.ts
@@ -79,9 +79,9 @@ const generateVerbOptions = async ({
     ? overrideOperationName(operation, route, verb)
     : camel(operationId);
 
-  const response = await getResponse(responses, operationId!, context);
+  const response = await getResponse(responses, operationName, context);
 
-  const body = await getBody(requestBody!, operationId!, context);
+  const body = await getBody(requestBody!, operationName, context);
   const parameters = await getParameters({
     parameters: [...verbParameters, ...(operationParameters || [])],
     context,

--- a/src/core/getters/body.ts
+++ b/src/core/getters/body.ts
@@ -1,19 +1,18 @@
 import { ReferenceObject, RequestBodyObject } from 'openapi3-ts';
 import { generalJSTypesWithArray } from '../../constants';
 import { ContextSpecs } from '../../types';
-import { GeneratorImport, GeneratorSchema } from '../../types/generator';
 import { GetterBody } from '../../types/getters';
 import { camel } from '../../utils/case';
 import { getResReqTypes } from './resReqTypes';
 
 export const getBody = async (
   requestBody: ReferenceObject | RequestBodyObject,
-  operationId: string,
+  operationName: string,
   context: ContextSpecs,
 ): Promise<GetterBody> => {
   const allBodyTypes = await getResReqTypes(
     [[context.override.components.requestBodies.suffix, requestBody]],
-    operationId,
+    operationName,
     context,
   );
 
@@ -25,7 +24,7 @@ export const getBody = async (
   const implementation =
     generalJSTypesWithArray.includes(definition.toLowerCase()) ||
     allBodyTypes.length > 1
-      ? camel(operationId) + context.override.components.requestBodies.suffix
+      ? camel(operationName) + context.override.components.requestBodies.suffix
       : camel(definition);
   const formData =
     allBodyTypes.length === 1 ? allBodyTypes[0].formData : undefined;

--- a/src/core/getters/response.ts
+++ b/src/core/getters/response.ts
@@ -1,13 +1,12 @@
 import { ResponsesObject } from 'openapi3-ts';
 import { ContextSpecs } from '../../types';
-import { GeneratorImport, GeneratorSchema } from '../../types/generator';
 import { GetterResponse } from '../../types/getters';
 import { ResReqTypesValue } from '../../types/resolvers';
 import { getResReqTypes } from './resReqTypes';
 
 export const getResponse = async (
   responses: ResponsesObject,
-  operationId: string,
+  operationName: string,
   context: ContextSpecs,
 ): Promise<GetterResponse> => {
   if (!responses) {
@@ -26,7 +25,7 @@ export const getResponse = async (
 
   const types = await getResReqTypes(
     Object.entries(responses),
-    operationId,
+    operationName,
     context,
     'void',
   );


### PR DESCRIPTION
## Status
<!--- **READY/WIP/HOLD** --->
**READY**

## Description
Close  #311 since that  was actually a bug with `operationName` config.
