### PR TITLE
fix(getters): allow object additional properties along with properties

### DIFF
--- a/src/core/getters/object.ts
+++ b/src/core/getters/object.ts
@@ -117,6 +117,19 @@ export const getObject = async ({
           acc.value += '\n}';
         }
 
+        if (item.additionalProperties) {
+          if (isBoolean(item.additionalProperties)) {
+            acc.value += ` & { [key: string]: any }`
+          } else {
+            const resolvedValue = await resolveValue({
+              schema: item.additionalProperties,
+              name,
+              context,
+            });
+            acc.value += ` & {[key: string]: ${resolvedValue.value}}`
+          }
+        }
+
         return acc;
       },
       {


### PR DESCRIPTION
## Status
<!--- **READY/WIP/HOLD** --->
**READY**

## Description
When passing `additionalProperties` along with `properties`, the first is not taken into account due to an early return for `properties`

So, using a schema like
```json
{
  "type": "object",
  "additionalProperties": false,
  "required": ["data"],
  "properties": {
    "data": {
      "type": "object",
      "additionalProperties": {
        "type": "array",
        "items": {
          "type": "string"
        }
      },
      "properties": {
        "base": {
          "type": "array",
          "items": {
            "type": "string"
          }
        }
      }
    }
  }
}
```

is currently resulting to the type:
```ts
export type DemoTypeData = {
  base?: string[]
}

export type DemoType = {
  data: DemoTypeData
}
```

instead of 
```ts
export type DemoTypeData = {
  base?: string[]
} & { [key: string]: string[] }

export type DemoType = {
  data: DemoTypeData
}
```

This PR fixes that issue.