### PR TITLE
feat(query): generate query return type along with hooks

### DIFF
--- a/src/core/generators/angular.ts
+++ b/src/core/generators/angular.ts
@@ -35,6 +35,8 @@ const ANGULAR_DEPENDENCIES: GeneratorDependency[] = [
   },
 ];
 
+const returnTypesToWrite: string[] = [];
+
 export const getAngularDependencies = () => ANGULAR_DEPENDENCIES;
 
 export const generateAngularTitle = (title: string) => {
@@ -98,7 +100,8 @@ export class ${title} {
     private http: HttpClient,
   ) {}`;
 
-export const generateAngularFooter = () => '};\n';
+export const generateAngularFooter = () =>
+  `};\n${returnTypesToWrite.join('\n')}`;
 
 const generateImplementation = (
   {
@@ -127,6 +130,14 @@ const generateImplementation = (
     isFormUrlEncoded,
   });
 
+  const dataType = response.definition.success || 'unknown';
+
+  returnTypesToWrite.push(
+    `export type ${pascal(
+      operationName,
+    )}ClientResult = NonNullable<${dataType}>`,
+  );
+
   if (mutator) {
     const mutatorConfig = generateMutatorConfig({
       route,
@@ -145,9 +156,10 @@ const generateImplementation = (
         )
       : '';
 
-    return ` ${operationName}<TData = ${
-      response.definition.success || 'unknown'
-    }>(\n    ${toObjectString(props, 'implementation')}\n ${
+    return ` ${operationName}<TData = ${dataType}>(\n    ${toObjectString(
+      props,
+      'implementation',
+    )}\n ${
       isRequestOptions && mutator.hasThirdArg
         ? `options?: ThirdParameter<typeof ${mutator.name}>`
         : ''
@@ -172,9 +184,10 @@ const generateImplementation = (
     isAngular: true,
   });
 
-  return ` ${operationName}<TData = ${
-    response.definition.success || 'unknown'
-  }>(\n    ${toObjectString(props, 'implementation')} ${
+  return ` ${operationName}<TData = ${dataType}>(\n    ${toObjectString(
+    props,
+    'implementation',
+  )} ${
     isRequestOptions ? `options?: HttpClientOptions\n` : ''
   }  ): Observable<TData>  {${bodyForm}
     return this.http.${verb}<TData>(${options});

--- a/src/core/generators/angular.ts
+++ b/src/core/generators/angular.ts
@@ -101,7 +101,7 @@ export class ${title} {
   ) {}`;
 
 export const generateAngularFooter = () =>
-  `};\n${returnTypesToWrite.join('\n')}`;
+  `};\n\n${returnTypesToWrite.join('\n')}`;
 
 const generateImplementation = (
   {

--- a/src/core/generators/axios.ts
+++ b/src/core/generators/axios.ts
@@ -84,7 +84,12 @@ const generateAxiosImplementation = (
         )
       : '';
 
-    return `const ${operationName} = (\n    ${toObjectString(
+    return `
+    export type ${pascal(
+      operationName,
+    )}Result = NonNullable<AsyncReturnType<typeof ${operationName}>>
+
+    const ${operationName} = (\n    ${toObjectString(
       props,
       'implementation',
     )}\n ${
@@ -110,7 +115,12 @@ const generateAxiosImplementation = (
     isFormUrlEncoded,
   });
 
-  return `const ${operationName} = <TData = AxiosResponse<${
+  return `
+  export type ${pascal(
+    operationName,
+  )}Result = AsyncReturnType<typeof ${operationName}>
+
+  const ${operationName} = <TData = AxiosResponse<${
     response.definition.success || 'unknown'
   }>>(\n    ${toObjectString(props, 'implementation')} ${
     isRequestOptions ? `options?: AxiosRequestConfig\n` : ''
@@ -137,7 +147,12 @@ export const generateAxiosHeader = ({
   isRequestOptions: boolean;
   isMutator: boolean;
   noFunction?: boolean;
-}) => `${
+}) => `
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AsyncReturnType<
+T extends (...args: any) => Promise<any>
+> = T extends (...args: any) => Promise<infer R> ? R : any;\n\n
+${
   isRequestOptions && isMutator
     ? `// eslint-disable-next-line @typescript-eslint/no-explicit-any
   type SecondParameter<T extends (...args: any) => any> = T extends (

--- a/src/core/generators/axios.ts
+++ b/src/core/generators/axios.ts
@@ -1,4 +1,5 @@
 import {
+  ClientFooterBuilder,
   GeneratorClient,
   GeneratorDependency,
   GeneratorOptions,
@@ -174,20 +175,16 @@ export const generateAxiosHeader = ({
 }
   ${!noFunction ? `export const ${title} = () => {\n` : ''}`;
 
-export const generateAxiosFooter = ({
-  operationNames = [],
-  noFunction,
+export const generateAxiosFooter: ClientFooterBuilder = ({
+  operationNames,
   title,
-}: {
-  operationNames?: string[];
-  noFunction?: boolean;
-  title: string;
+  noFunction,
 }) => {
   const functionFooter = `return {${operationNames.join(',')}}};\n`;
   const returnTypesArr = operationNames
     .map((n) => {
       return returnTypesToWrite.has(n)
-        ? returnTypesToWrite.get(n)?.(noFunction ? undefined : title)
+        ? returnTypesToWrite.get(n)?.(noFunction || !title ? undefined : title)
         : '';
     })
     .filter(Boolean);

--- a/src/core/generators/client.ts
+++ b/src/core/generators/client.ts
@@ -69,7 +69,8 @@ export const GENERATOR_CLIENT: GeneratorClients = {
       isRequestOptions: boolean;
     }) => generateAxiosHeader({ ...options, noFunction: true }),
     dependencies: getAxiosDependencies,
-    footer: () => '',
+    footer: ({operationNames, title }) =>
+      generateAxiosFooter({ operationNames, title, noFunction: true }),
     title: generateAxiosTitle,
   },
   angular: {
@@ -177,13 +178,21 @@ export const generateClientHeader = ({
   };
 };
 
-export const generateClientFooter = (
-  outputClient: OutputClient | OutputClientFunc = DEFAULT_CLIENT,
-  operationNames: string[],
-): GeneratorClientExtra => {
+export const generateClientFooter = ({
+  outputClient = DEFAULT_CLIENT,
+  operationNames,
+  title,
+  customTitleFunc,
+}: {
+  outputClient: OutputClient | OutputClientFunc;
+  operationNames: string[];
+  title: string;
+  customTitleFunc?: (title: string) => string;
+}): GeneratorClientExtra => {
+  const titles = generateClientTitle(outputClient, title, customTitleFunc);
   const { footer } = getGeneratorClient(outputClient);
   return {
-    implementation: footer(operationNames),
+    implementation: footer({ operationNames, title: titles.implementation }),
     implementationMSW: `]\n`,
   };
 };

--- a/src/core/generators/client.ts
+++ b/src/core/generators/client.ts
@@ -69,8 +69,7 @@ export const GENERATOR_CLIENT: GeneratorClients = {
       isRequestOptions: boolean;
     }) => generateAxiosHeader({ ...options, noFunction: true }),
     dependencies: getAxiosDependencies,
-    footer: ({operationNames, title }) =>
-      generateAxiosFooter({ operationNames, title, noFunction: true }),
+    footer: (options) => generateAxiosFooter({ ...options, noFunction: true }),
     title: generateAxiosTitle,
   },
   angular: {
@@ -191,8 +190,23 @@ export const generateClientFooter = ({
 }): GeneratorClientExtra => {
   const titles = generateClientTitle(outputClient, title, customTitleFunc);
   const { footer } = getGeneratorClient(outputClient);
+  let implementation: string;
+  try {
+    if (isFunction(outputClient)) {
+      implementation = (footer as (operationNames: any) => string)(operationNames);
+      // being here means that the previous call worked
+      console.warn(
+        '[WARN] Passing an array of strings for operations names to the footer function is deprecated and will be removed in a future major release. Please pass them in an object instead: { operationNames: string[] }.',
+      );
+    } else {
+      implementation = footer({ operationNames, title: titles.implementation });
+    }
+  } catch (e) {
+    implementation = footer({ operationNames, title: titles.implementation });
+  }
+
   return {
-    implementation: footer({ operationNames, title: titles.implementation }),
+    implementation,
     implementationMSW: `]\n`,
   };
 };

--- a/src/core/generators/query.ts
+++ b/src/core/generators/query.ts
@@ -552,7 +552,16 @@ const generateQueryHook = (
       : response.definition.errors || 'unknown';
   }
 
+  const dataType = mutator?.isHook
+    ? `ReturnType<typeof use${pascal(operationName)}Hook>`
+    : `typeof ${operationName}`;
+
   return `
+    export type ${pascal(
+      operationName,
+    )}QueryData = NonNullable<AsyncReturnType<${dataType}>>
+    export type ${pascal(operationName)}QueryError = ${errorType}
+
     export const ${camel(`use-${operationName}`)} = <TError = ${errorType},
     ${!definitions ? `TVariables = void,` : ''}
     TContext = unknown>(${generateQueryArguments({
@@ -580,13 +589,9 @@ const generateQueryHook = (
       }
 
 
-      const mutationFn: MutationFunction<AsyncReturnType<${
-        mutator?.isHook
-          ? `ReturnType<typeof use${pascal(operationName)}Hook>`
-          : `typeof ${operationName}`
-      }>, ${definitions ? `{${definitions}}` : 'TVariables'}> = (${
-    properties ? 'props' : ''
-  }) => {
+      const mutationFn: MutationFunction<AsyncReturnType<${dataType}>, ${
+    definitions ? `{${definitions}}` : 'TVariables'
+  }> = (${properties ? 'props' : ''}) => {
           ${properties ? `const {${properties}} = props || {}` : ''};
 
           return  ${operationName}(${properties}${properties ? ',' : ''}${

--- a/src/core/generators/query.ts
+++ b/src/core/generators/query.ts
@@ -381,7 +381,7 @@ const generateQueryImplementation = ({
     : `typeof ${operationName}`;
 
   return `
-export type ${pascal(name)}QueryData = NonNullable<AsyncReturnType<${dataType}>>
+export type ${pascal(name)}QueryResult = NonNullable<AsyncReturnType<${dataType}>>
 export type ${pascal(name)}QueryError = ${errorType}
 
 export const ${camel(
@@ -559,7 +559,7 @@ const generateQueryHook = (
   return `
     export type ${pascal(
       operationName,
-    )}MutationData = NonNullable<AsyncReturnType<${dataType}>>
+    )}MutationResult = NonNullable<AsyncReturnType<${dataType}>>
     export type ${pascal(operationName)}MutationError = ${errorType}
 
     export const ${camel(`use-${operationName}`)} = <TError = ${errorType},

--- a/src/core/generators/query.ts
+++ b/src/core/generators/query.ts
@@ -376,18 +376,25 @@ const generateQueryImplementation = ({
       : response.definition.errors || 'unknown';
   }
 
+  const dataType = mutator?.isHook
+    ? `ReturnType<typeof use${pascal(operationName)}Hook>`
+    : `typeof ${operationName}`;
+
   return `
-export const ${camel(`use-${name}`)} = <TData = AsyncReturnType<${
-    mutator?.isHook
-      ? `ReturnType<typeof use${pascal(operationName)}Hook>`
-      : `typeof ${operationName}`
-  }>, TError = ${errorType}>(\n ${queryProps} ${generateQueryArguments({
-    operationName,
-    definitions: '',
-    mutator,
-    isRequestOptions,
-    type,
-  })}\n  ): ${returnType} & { queryKey: QueryKey } => {
+export type ${pascal(name)}QueryData = AsyncReturnType<${dataType}>
+export type ${pascal(name)}QueryError = ${errorType}
+
+export const ${camel(
+    `use-${name}`,
+  )} = <TData = AsyncReturnType<${dataType}>, TError = ${errorType}>(\n ${queryProps} ${generateQueryArguments(
+    {
+      operationName,
+      definitions: '',
+      mutator,
+      isRequestOptions,
+      type,
+    },
+  )}\n  ): ${returnType} & { queryKey: QueryKey } => {
 
   ${
     isRequestOptions

--- a/src/core/generators/query.ts
+++ b/src/core/generators/query.ts
@@ -559,8 +559,8 @@ const generateQueryHook = (
   return `
     export type ${pascal(
       operationName,
-    )}QueryData = NonNullable<AsyncReturnType<${dataType}>>
-    export type ${pascal(operationName)}QueryError = ${errorType}
+    )}MutationData = NonNullable<AsyncReturnType<${dataType}>>
+    export type ${pascal(operationName)}MutationError = ${errorType}
 
     export const ${camel(`use-${operationName}`)} = <TError = ${errorType},
     ${!definitions ? `TVariables = void,` : ''}

--- a/src/core/generators/query.ts
+++ b/src/core/generators/query.ts
@@ -381,7 +381,7 @@ const generateQueryImplementation = ({
     : `typeof ${operationName}`;
 
   return `
-export type ${pascal(name)}QueryData = AsyncReturnType<${dataType}>
+export type ${pascal(name)}QueryData = NonNullable<AsyncReturnType<${dataType}>>
 export type ${pascal(name)}QueryError = ${errorType}
 
 export const ${camel(

--- a/src/core/generators/swr.ts
+++ b/src/core/generators/swr.ts
@@ -11,7 +11,7 @@ import {
   GetterPropType,
   GetterResponse,
 } from '../../types/getters';
-import { camel } from '../../utils/case';
+import { camel, pascal } from '../../utils/case';
 import { toObjectString } from '../../utils/string';
 import { isSyntheticDefaultImportsAllow } from '../../utils/tsconfig';
 import { generateVerbImports } from './imports';
@@ -205,6 +205,11 @@ const generateSwrImplementation = ({
   }
 
   return `
+  export type ${pascal(
+    operationName,
+  )}QueryResult = NonNullable<AsyncReturnType<typeof ${operationName}>>
+  export type ${pascal(operationName)}QueryError = ${errorType}
+
 export const ${camel(
     `use-${operationName}`,
   )} = <TError = ${errorType}>(\n ${swrProps} ${generateSwrArguments({

--- a/src/core/writers/target.ts
+++ b/src/core/writers/target.ts
@@ -58,7 +58,11 @@ export const generateTarget = (
         acc.implementationMSW.handler =
           header.implementationMSW + acc.implementationMSW.handler;
 
-        const footer = generateClientFooter(options?.client, operationNames);
+        const footer = generateClientFooter({
+          outputClient: options?.client,
+          operationNames,
+          title: pascal(info.title),
+        });
         acc.implementation += footer.implementation;
         acc.implementationMSW.handler += footer.implementationMSW;
       }

--- a/src/core/writers/targetTags.ts
+++ b/src/core/writers/targetTags.ts
@@ -91,7 +91,11 @@ export const generateTargetForTags = (
           const operationNames = Object.values(operations)
             .filter(({ tags }) => tags.includes(tag))
             .map(({ operationName }) => operationName);
-          const footer = generateClientFooter(options?.client, operationNames);
+          const footer = generateClientFooter({
+            outputClient: options?.client,
+            operationNames,
+            title: pascal(tag),
+          });
           const header = generateClientHeader({
             outputClient: options.client,
             isRequestOptions: options.override.requestOptions !== false,

--- a/src/types/generator.ts
+++ b/src/types/generator.ts
@@ -147,7 +147,11 @@ export type ClientHeaderBuilder = (params: {
   provideIn: boolean | 'root' | 'any';
 }) => string;
 
-export type ClientFooterBuilder = (operationIds?: string[]) => string;
+export type ClientFooterBuilder = (options: {
+  operationNames?: string[];
+  noFunction?: boolean;
+  title: string;
+}) => string;
 
 export type ClientTitleBuilder = (title: string) => string;
 

--- a/src/types/generator.ts
+++ b/src/types/generator.ts
@@ -147,11 +147,13 @@ export type ClientHeaderBuilder = (params: {
   provideIn: boolean | 'root' | 'any';
 }) => string;
 
-export type ClientFooterBuilder = (options: {
-  operationNames?: string[];
-  noFunction?: boolean;
-  title: string;
-}) => string;
+export type ClientFooterBuilder = (
+  params: {
+    noFunction?: boolean | undefined;
+    operationNames: string[];
+    title?: string;
+  },
+) => string;
 
 export type ClientTitleBuilder = (title: string) => string;
 


### PR DESCRIPTION
## Status
<!--- **READY/WIP/HOLD** --->
**READY**

## Description
When dealing with hooks generated using `react-query`, it's currently difficult to get the actual return types from the queries (not those from the schemas).
In a case where we process the data from the API (changing the case for example) using a custom client, we can't directly rely on the schemas types that have been generated, we have to get the response type from the queries generated instead.
This PR exported those new types for each functions in order to use them in components that used data from those, looking like:
```typescript
export type GetDemoQueryResult = NonNullable<AsyncReturnType<typeof getDemo>>
export type GetDemoQueryError = ErrorType<GetDemo400>

// Then we can use like
type MyComponentPropsType = {
  foo: GetDemoQueryResult["foo"]
  bar: GetDemoQueryResult["bar"]
}
```

Note: We have to use `NonNullable` for some cases when the client can return `undefined` (201 requests) and avoid type with `| undefined`. In that case, the final type will be `never`.

Wdyt?
I guess it could be considered as a breaking change, should we maybe put this behind a config property and make it optional?