### PR TITLE
fix(schema): generate 'any' instead of '{}'

### DIFF
--- a/src/core/generators/schemaDefinition.ts
+++ b/src/core/generators/schemaDefinition.ts
@@ -71,7 +71,8 @@ export const generateSchemasDefinition = async (
           );
 
           if (!imp) {
-            output += `export type ${schemaName} = ${resolvedValue.value};\n`;
+            const outputValue = resolvedValue.value === '{}' ? 'any' : resolvedValue.value;
+            output += `export type ${schemaName} = ${outputValue};\n`;
           } else {
             const alias = imp?.specKey
               ? `${pascal(getSpecName(imp.specKey, context.specKey))}${
@@ -86,7 +87,8 @@ export const generateSchemasDefinition = async (
             );
           }
         } else {
-          output += `export type ${schemaName} = ${resolvedValue.value};\n`;
+          const outputValue = resolvedValue.value === '{}' ? 'any' : resolvedValue.value;
+          output += `export type ${schemaName} = ${outputValue};\n`;
         }
 
         acc.push(...resolvedValue.schemas, {


### PR DESCRIPTION
## Status
**READY**

Fix #321 

## Description
Instead of generating an empty type like...

```ts
export type Health200 = {};
```

it generates it as an ANY

```ts
export type Health200 = any;
```


@CPatchane @anymaniax Can you review this it looks to me like the first `if` and the last `else` were doing the exact same thing so I simplified the logic "I think".