### PR TITLE
fix(query): fix the mutation body using BodyType wrongly replaced

### DIFF
--- a/samples/react-query/custom-client/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/react-query/custom-client/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -119,7 +119,7 @@ export const createPets = (
 
 
     export type CreatePetsMutationResult = NonNullable<AsyncReturnType<typeof createPets>>
-    export type CreatePetsMutationBody = CreatePetsBody
+    export type CreatePetsMutationBody = BodyType<CreatePetsBody>
     export type CreatePetsMutationError = ErrorType<Error>
 
     export const useCreatePets = <TError = ErrorType<Error>,

--- a/src/core/generators/query.ts
+++ b/src/core/generators/query.ts
@@ -162,16 +162,11 @@ const generateQueryRequestFunction = (
       isFormUrlEncoded,
     });
 
-    const propsImplementation = mutator?.bodyTypeName
-      ? toObjectString(props, 'implementation')
-          .replace(
-            new RegExp(`(${verb}\\w*):\\s?(\\w*)`),
-            `$1: ${mutator.bodyTypeName}<$2>`,
-          )
-          .replace(
-            new RegExp(`(\\w*Body):\\s?(\\w*)`),
-            `$1: ${mutator.bodyTypeName}<$2>`,
-          )
+    const propsImplementation = mutator?.bodyTypeName && body.definition
+      ? toObjectString(props, 'implementation').replace(
+          new RegExp(`(\\w*):\\s?${body.definition}`),
+          `$1: ${mutator.bodyTypeName}<${body.definition}>`,
+        )
       : toObjectString(props, 'implementation');
 
     const requestOptions = isRequestOptions
@@ -578,7 +573,9 @@ const generateQueryHook = (
     ${
       body.definition
         ? `export type ${pascal(operationName)}MutationBody = ${
-            body.definition
+            mutator?.bodyTypeName
+              ? `${mutator.bodyTypeName}<${body.definition}>`
+              : body.definition
           }`
         : ''
     }


### PR DESCRIPTION
## Status
<!--- **READY/WIP/HOLD** --->
**READY**

## Description
The mutation body type definition using `BodyType` wasn't working correctly due to a miss for `*MutationBody` types and a wrong replacement.
