### PR TITLE
Replace AsyncReturnType with Awaited<ReturnType<>>

### DIFF
--- a/src/core/generators/axios.ts
+++ b/src/core/generators/axios.ts
@@ -92,11 +92,11 @@ const generateAxiosImplementation = (
       (title?: string) =>
         `export type ${pascal(
           operationName,
-        )}Result = NonNullable<AsyncReturnType<${
+        )}Result = NonNullable<Awaited<ReturnType<${
           title
             ? `ReturnType<typeof ${title}>['${operationName}']`
             : `typeof ${operationName}`
-        }>>`,
+        }>>>`,
     );
 
     return `const ${operationName} = (\n    ${toObjectString(
@@ -177,7 +177,6 @@ export const generateAxiosFooter: ClientFooterBuilder = ({
   operationNames,
   title,
   noFunction,
-  hasMutator,
 }) => {
   const functionFooter = `return {${operationNames.join(',')}}};\n`;
   const returnTypesArr = operationNames
@@ -187,13 +186,7 @@ export const generateAxiosFooter: ClientFooterBuilder = ({
         : '';
     })
     .filter(Boolean);
-  let returnTypes = hasMutator
-    ? `\n// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type AsyncReturnType<
-T extends (...args: any) => Promise<any>
-> = T extends (...args: any) => Promise<infer R> ? R : any;
-\n`
-    : '';
+  let returnTypes = '';
 
   if (returnTypesArr.length) {
     returnTypes += returnTypesArr.join('\n');

--- a/src/core/generators/client.ts
+++ b/src/core/generators/client.ts
@@ -182,13 +182,11 @@ export const generateClientFooter = ({
   operationNames,
   title,
   customTitleFunc,
-  hasMutator,
 }: {
   outputClient: OutputClient | OutputClientFunc;
   operationNames: string[];
   title: string;
   customTitleFunc?: (title: string) => string;
-  hasMutator: boolean;
 }): GeneratorClientExtra => {
   const titles = generateClientTitle(outputClient, title, customTitleFunc);
   const { footer } = getGeneratorClient(outputClient);
@@ -203,10 +201,10 @@ export const generateClientFooter = ({
         '[WARN] Passing an array of strings for operations names to the footer function is deprecated and will be removed in a future major release. Please pass them in an object instead: { operationNames: string[] }.',
       );
     } else {
-      implementation = footer({ operationNames, title: titles.implementation, hasMutator });
+      implementation = footer({ operationNames, title: titles.implementation });
     }
   } catch (e) {
-    implementation = footer({ operationNames, title: titles.implementation, hasMutator });
+    implementation = footer({ operationNames, title: titles.implementation });
   }
 
   return {

--- a/src/core/writers/target.ts
+++ b/src/core/writers/target.ts
@@ -63,7 +63,6 @@ export const generateTarget = (
           operationNames,
           title: pascal(info.title),
           customTitleFunc: options.override.title,
-          hasMutator: !!acc.mutators.length,
         });
         acc.implementation += footer.implementation;
         acc.implementationMSW.handler += footer.implementationMSW;

--- a/src/core/writers/targetTags.ts
+++ b/src/core/writers/targetTags.ts
@@ -96,7 +96,6 @@ export const generateTargetForTags = (
             operationNames,
             title: pascal(tag),
             customTitleFunc: options.override.title,
-            hasMutator: !!target.mutators?.length,
           });
 
           const header = generateClientHeader({

--- a/src/types/generator.ts
+++ b/src/types/generator.ts
@@ -152,7 +152,6 @@ export type ClientFooterBuilder = (params: {
   noFunction?: boolean | undefined;
   operationNames: string[];
   title?: string;
-  hasMutator: boolean;
 }) => string;
 
 export type ClientTitleBuilder = (title: string) => string;


### PR DESCRIPTION
## Status
<!--- **READY** --->
**READY**

## Description
If a custom mutator function returns a non-promise, `AsyncReturnType` breaks.
This removes `AsyncReturnType` and just uses `Awaited<ReturnType<>>` in its place which:
- Doesn't break with sync functions
- Relies on internal Typescript functionality, and thus should be more stable

Additionally the footer generation function no longer needs `hasMutator` so it has been removed.

This was built off of v6.7.1 so I could test locally as `master` had issues with generating my output.

## Todos
- [X] Tests
- [X] Documentation
- [ ] Changelog Entry (unreleased)
