### PR TITLE
Simplify generated code for MSW

### DIFF
--- a/src/core/generators/msw.ts
+++ b/src/core/generators/msw.ts
@@ -89,7 +89,7 @@ export const generateMSW = async (
   if (mockData) {
     value = mockData;
   } else if (definitions.length > 1) {
-    value = `faker.helpers.randomize(${definition})`;
+    value = `faker.random.arrayElement(${definition})`;
   } else if (definitions[0]) {
     value = definitions[0];
   }

--- a/src/core/getters/combine.mock.ts
+++ b/src/core/getters/combine.mock.ts
@@ -55,9 +55,9 @@ export const combineSchemasMock = async ({
       if (!index && !combine) {
         if (resolvedValue.enums || isOneOf) {
           if (arr.length === 1) {
-            return `faker.helpers.randomize([${resolvedValue.value}])`;
+            return `faker.random.arrayElement([${resolvedValue.value}])`;
           }
-          return `faker.helpers.randomize([${resolvedValue.value},`;
+          return `faker.random.arrayElement([${resolvedValue.value},`;
         }
         if (arr.length === 1) {
           return `{${resolvedValue.value}}`;

--- a/src/core/getters/object.mock.ts
+++ b/src/core/getters/object.mock.ts
@@ -94,7 +94,7 @@ export const getMockObject = async ({
 
             const keyDefinition = getKey(key);
             if (!isRequired && !resolvedValue.overrided) {
-              return `${keyDefinition}: faker.helpers.randomize([${resolvedValue.value}, undefined])`;
+              return `${keyDefinition}: faker.random.arrayElement([${resolvedValue.value}, undefined])`;
             }
 
             return `${keyDefinition}: ${resolvedValue.value}`;

--- a/src/core/getters/scalar.mock.ts
+++ b/src/core/getters/scalar.mock.ts
@@ -125,13 +125,7 @@ export const getMockScalar = async ({
         );
         const enumValue = enumImp?.name || name;
         return {
-          value: `[...Array(faker.datatype.number({min:1, max: ${enums.length}}))].reduce(({values, enums}) => {
-            const newValue = enums[faker.datatype.number({min:0, max: enums.length - 1})];
-            return {
-              values: [...values, newValue],
-              enums: enums.filter((v: ${enumValue}) => newValue !== v)
-            }
-          },{ values: [], enums: Object.values(${enumValue})}).values`,
+          value: `faker.random.arrayElements(Object.values(${enumValue}))`,
           imports: enumImp
             ? [...resolvedImports, { ...enumImp, values: true }]
             : resolvedImports,

--- a/src/core/getters/scalar.mock.ts
+++ b/src/core/getters/scalar.mock.ts
@@ -159,7 +159,7 @@ export const getMockScalar = async ({
           imports = [{ name: item.name, values: true }];
         }
 
-        value = `faker.helpers.randomize(${enumValue})`;
+        value = `faker.random.arrayElement(${enumValue})`;
       }
 
       return {

--- a/src/core/resolvers/value.mock.ts
+++ b/src/core/resolvers/value.mock.ts
@@ -41,7 +41,7 @@ export const resolveMockOverride = (
 };
 
 export const getNullable = (value: string, nullable?: boolean) =>
-  nullable ? `faker.helpers.randomize([${value}, null])` : value;
+  nullable ? `faker.random.arrayElement([${value}, null])` : value;
 
 export const resolveMockValue = async ({
   schema,


### PR DESCRIPTION
## Status
<!--- **READY/WIP/HOLD** --->
**READY**

## Description

This PR introduces two commits:

- replace the now-deprecated `faker.helpers.randomize` (which logs an error when used) with `faker.random.arrayElement`
- simplify the logic for lists of enums using `faker.random.arrayElements` (see here: https://fakerjs.dev/api/random.html#arrayElements)

## Steps to Test or Reproduce

These changes do not introduce any new logic so existing tests should be sufficient.

Note: I deliberately did not update the samples and readme to use faker.random.arrayElement but can do so as well.