### PR TITLE
fix(mocks): fix array enum mock generation when enum is NOT a $ref

### DIFF
--- a/src/core/getters/scalar.mock.ts
+++ b/src/core/getters/scalar.mock.ts
@@ -5,6 +5,7 @@ import { GeneratorImport } from '../../types/generator';
 import { MockDefinition } from '../../types/mocks';
 import { mergeDeep } from '../../utils/mergeDeep';
 import { escape } from '../../utils/string';
+import { isReference } from '../../utils/is';
 import {
   getNullable,
   resolveMockOverride,
@@ -120,6 +121,14 @@ export const getMockScalar = async ({
       });
 
       if (enums) {
+        if (!isReference(item.items)) {
+          return {
+            value,
+            imports: resolvedImports,
+            name: item.name,
+          };
+        }
+        
         const enumImp = imports.find(
           (imp) => name.replace('[]', '') === imp.name,
         );


### PR DESCRIPTION
## Status
**READY**

## Description
This addresses the 2nd part in #342. The first issue in #342 was already addressed by #366.

"2nd part" refers to this:

```
{ values: [], enums: Object.values(name) }, // javascript error
```
