### PR TITLE
docs: update custom-axios.md

### DIFF
--- a/docs/src/pages/guides/custom-axios.md
+++ b/docs/src/pages/guides/custom-axios.md
@@ -26,9 +26,10 @@ import Axios, { AxiosRequestConfig } from 'axios';
 
 export const AXIOS_INSTANCE = Axios.create({ baseURL: '<BACKEND URL>' }); // use your own URL here or environment variable
 
-export const customInstance = <T>(config: AxiosRequestConfig): Promise<T> => {
+// add a second `options` argument here if you want to pass extra options to each generated query 
+export const customInstance = <T>(config: AxiosRequestConfig, options?: AxiosRequestConfig): Promise<T> => {
   const source = Axios.CancelToken.source();
-  const promise = AXIOS_INSTANCE({ ...config, cancelToken: source.token }).then(
+  const promise = AXIOS_INSTANCE({ ...config, ...options, cancelToken: source.token }).then(
     ({ data }) => data,
   );
 


### PR DESCRIPTION
Specify the usage of adding second `options` argument in custom axios instance. See https://github.com/anymaniax/orval/issues/282 and https://github.com/anymaniax/orval/issues/379

## Status
<!--- **READY/WIP/HOLD** --->
**READY**

## Description
Update docs

fix #379 
