### PR TITLE
fix(resolvers): fix generating schema for alias object

### DIFF
--- a/src/core/resolvers/ref.ts
+++ b/src/core/resolvers/ref.ts
@@ -25,6 +25,22 @@ export const resolveRef = async <
   schema: Schema;
   imports: GeneratorImport[];
 }> => {
+  // the schema is refering to another object
+  if (schema?.schema?.$ref) {
+    const resolvedRef = await resolveRef<Schema>(
+      schema?.schema,
+      context,
+      imports,
+    );
+    return {
+      schema: {
+        ...schema,
+        schema: resolvedRef.schema,
+      } as Schema,
+      imports,
+    };
+  }
+  
   if (!isReference(schema)) {
     return { schema: schema as Schema, imports };
   }


### PR DESCRIPTION
## Status
<!--- **READY/WIP/HOLD** --->
**READY**

## Description
A few sentences describing the overall goals of the pull request's commits.
resolveRef expect as input one of the following options:
```js
{ '$ref': '#/components/schemas/Error' }
```
```js
{ type: 'array', items: { '$ref': '#/components/schemas/Pet' } }
```
```js
{
  type: 'object',
  required: [ 'id', 'name' ],
  properties: {
    '@id': { type: 'string', format: 'iri-reference' },
    id: { type: 'integer', format: 'int64' },
    name: { type: 'string' },
    tag: { type: 'string' },
    email: { type: 'string', format: 'email' },
    callingCode: { type: 'string', enum: [Array] },
    country: { type: 'string', enum: [Array] }
  }
}
```
But it's possible for a schema to reference another schema (alias)
```js
{
  name: 'fileType',
  in: 'path',
  description: 'the file type of verifications Identity.',
  required: true,
  schema: { '$ref': '#/components/schemas/EIdentityFileType' }
}
```
in that case the resolver will crash since he doesn't manage to find the $ref.
