### PR TITLE
fix(generator): fix missing comma in axios generator when mutator has 2nd arg

### DIFF
--- a/src/core/generators/axios.ts
+++ b/src/core/generators/axios.ts
@@ -108,7 +108,7 @@ const generateAxiosImplementation = (
       'implementation',
     )}\n ${
       isRequestOptions && mutator.hasSecondArg
-        ? `options?: SecondParameter<typeof ${mutator.name}>`
+        ? `options?: SecondParameter<typeof ${mutator.name}>,`
         : ''
     }${!isBodyVerb ? 'signal?: AbortSignal\n' : '\n'}) => {${bodyForm}
       return ${mutator.name}<${response.definition.success || 'unknown'}>(


### PR DESCRIPTION
## Status
**READY**

## Description
When using a custom Axios client that has a 2nd argument, there is a missing comma that breaks the generated code. See screenshot below. This bug was introduced with PR #357.

<img width="530" alt="Screen Shot 2022-05-10 at 10 50 08 AM" src="https://user-images.githubusercontent.com/227340/167657556-2a097b31-7d4b-4db4-89b0-21026eee09e1.png">

This PR updates the axios generator with the missing comma, matching this similar line in the query generator: https://github.com/anymaniax/orval/blob/d63d4c313202aa0d3442d899b17d36907c11747a/src/core/generators/query.ts#L211

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
[feature/add-query-cancellation](https://github.com/anymaniax/orval/tree/feature/add-query-cancellation) | [link](https://github.com/anymaniax/orval/pull/357)
