### PR TITLE
fix(generator): replace deprecated faker.random.arrayElement with faker.helpers.arrayElement

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   "devDependencies": {
     "@commitlint/cli": "^16.2.1",
     "@commitlint/config-conventional": "^16.2.1",
-    "@faker-js/faker": "^6.1.1",
+    "@faker-js/faker": "^6.3.0",
     "@release-it/conventional-changelog": "^4.2.0",
     "@types/chalk": "^2.2.0",
     "@types/commander": "^2.12.2",

--- a/src/core/generators/msw.ts
+++ b/src/core/generators/msw.ts
@@ -89,7 +89,7 @@ export const generateMSW = async (
   if (mockData) {
     value = mockData;
   } else if (definitions.length > 1) {
-    value = `faker.random.arrayElement(${definition})`;
+    value = `faker.helpers.arrayElement(${definition})`;
   } else if (definitions[0]) {
     value = definitions[0];
   }

--- a/src/core/getters/combine.mock.ts
+++ b/src/core/getters/combine.mock.ts
@@ -55,9 +55,9 @@ export const combineSchemasMock = async ({
       if (!index && !combine) {
         if (resolvedValue.enums || isOneOf) {
           if (arr.length === 1) {
-            return `faker.random.arrayElement([${resolvedValue.value}])`;
+            return `faker.helpers.arrayElement([${resolvedValue.value}])`;
           }
-          return `faker.random.arrayElement([${resolvedValue.value},`;
+          return `faker.helpers.arrayElement([${resolvedValue.value},`;
         }
         if (arr.length === 1) {
           return `{${resolvedValue.value}}`;

--- a/src/core/getters/object.mock.ts
+++ b/src/core/getters/object.mock.ts
@@ -94,7 +94,7 @@ export const getMockObject = async ({
 
             const keyDefinition = getKey(key);
             if (!isRequired && !resolvedValue.overrided) {
-              return `${keyDefinition}: faker.random.arrayElement([${resolvedValue.value}, undefined])`;
+              return `${keyDefinition}: faker.helpers.arrayElement([${resolvedValue.value}, undefined])`;
             }
 
             return `${keyDefinition}: ${resolvedValue.value}`;

--- a/src/core/getters/scalar.mock.ts
+++ b/src/core/getters/scalar.mock.ts
@@ -134,7 +134,7 @@ export const getMockScalar = async ({
         );
         const enumValue = enumImp?.name || name;
         return {
-          value: `faker.random.arrayElements(Object.values(${enumValue}))`,
+          value: `faker.helpers.arrayElements(Object.values(${enumValue}))`,
           imports: enumImp
             ? [...resolvedImports, { ...enumImp, values: true }]
             : resolvedImports,
@@ -162,7 +162,7 @@ export const getMockScalar = async ({
           imports = [{ name: item.name, values: true }];
         }
 
-        value = `faker.random.arrayElement(${enumValue})`;
+        value = `faker.helpers.arrayElement(${enumValue})`;
       }
 
       return {

--- a/src/core/resolvers/value.mock.ts
+++ b/src/core/resolvers/value.mock.ts
@@ -41,7 +41,7 @@ export const resolveMockOverride = (
 };
 
 export const getNullable = (value: string, nullable?: boolean) =>
-  nullable ? `faker.random.arrayElement([${value}, null])` : value;
+  nullable ? `faker.helpers.arrayElement([${value}, null])` : value;
 
 export const resolveMockValue = async ({
   schema,

--- a/yarn.lock
+++ b/yarn.lock
@@ -239,10 +239,10 @@
   resolved "https://registry.npmjs.org/@exodus/schemasafe/-/schemasafe-1.0.0-rc.4.tgz"
   integrity sha512-zHISeJ5jcHSo3i2bI5RHb0XEJ1JGxQ/QQzU2FLPcJxohNohJV8jHCM1FSrOUxTspyDRSSULg3iKQa1FJ4EsSiQ==
 
-"@faker-js/faker@^6.1.1":
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/@faker-js/faker/-/faker-6.1.1.tgz#adf002d986e1751daadfcf65d1cc03944dab3ced"
-  integrity sha512-8yq1LJVGn4GY06riLddIU1LbJm15yjt46hjfkpWNpH/mqdciPOBVzicKOJxzQNrGgVHVBxcdm7sgwjI/Y19MYw==
+"@faker-js/faker@^6.3.0":
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/@faker-js/faker/-/faker-6.3.1.tgz#1ae963dd40405450a2945408cba553e1afa3e0fb"
+  integrity sha512-8YXBE2ZcU/pImVOHX7MWrSR/X5up7t6rPWZlk34RwZEcdr3ua6X+32pSd6XuOQRN+vbuvYNfA6iey8NbrjuMFQ==
 
 "@humanwhocodes/config-array@^0.9.2":
   version "0.9.3"


### PR DESCRIPTION
## Status
**READY**

## Description
As of `faker` 6.3.0, the `random.arrayElement` and `random.arrayElements` functions are deprecated in favor of `helpers.arrayElement` and `helpers.arrayElements`, respectively. This results in many deprecation warning statements when running tests with generated msw:

```
    console.warn
      [@faker-js/faker]: faker.random.arrayElement() is deprecated since v6.3.0 and will be removed in v7.0.0. Please use faker.helpers.arrayElement() instead.
```

This PR updates generated code to use `helpers` namespace instead of `random`.