### PR TITLE
feat(config): allow types to be used instead of interfaces

### DIFF
--- a/docs/src/pages/reference/configuration/output.md
+++ b/docs/src/pages/reference/configuration/output.md
@@ -887,3 +887,25 @@ export function handleDates(body: any) {
   }
 }
 ```
+
+#### useTypeOverInterfaces
+
+Type: `Boolean`
+
+Valid values: true or false. Defaults to false.
+
+Use this property to use TypeScript `type` instead of `interface`.
+
+Example:
+
+```js
+module.exports = {
+  petstore: {
+    output: {
+      override: {
+        useTypeOverInterfaces: true,
+      },
+    },
+  },
+};
+```

--- a/src/core/generators/interface.ts
+++ b/src/core/generators/interface.ts
@@ -42,7 +42,10 @@ export const generateInterface = async ({
     }
   }
 
-  if (!generalJSTypesWithArray.includes(scalar.value)) {
+  if (
+    !generalJSTypesWithArray.includes(scalar.value) &&
+    !context?.override?.useTypeOverInterfaces
+  ) {
     model += `export interface ${name} ${scalar.value}\n`;
   } else {
     model += `export type ${name} = ${scalar.value};\n`;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -85,6 +85,7 @@ export type NormalizedOverrideOutput = {
   ) => string;
   requestOptions: Record<string, any> | boolean;
   useDates?: boolean;
+  useTypeOverInterfaces?: boolean;
 };
 
 export type NormalizedMutator = {
@@ -239,6 +240,7 @@ export type OverrideOutput = {
   ) => string;
   requestOptions?: Record<string, any> | boolean;
   useDates?: boolean;
+  useTypeOverInterfaces?: boolean;
 };
 
 type QueryOptions = {


### PR DESCRIPTION
## Status

**READY**

## Description

The goal of this PR is to allow types to be used instead of interfaces when generating objects.

## Todos

- [ ] Tests
- [x] Documentation
- [ ] Changelog Entry (unreleased)
