### PR TITLE
fix: dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,15 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
 version: 2
 updates:
-  - package-ecosystem: 'yarn' # See documentation for possible values
-    directory: '/' # Location of package manifests
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+  - package-ecosystem: 'github-actions'
+    directory: '/'
     schedule:
       interval: 'weekly'


### PR DESCRIPTION
## Status

**READY**

## Description

<img width="789" alt="image" src="https://user-images.githubusercontent.com/34721312/169687632-87d759a8-1e5f-4548-9a59-f397dc0929d2.png">

Source: [dependabot `package-ecosystem`](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem)

The correct yaml-value for Yarn in combination with dependabot is `npm`. This has been fixed. Now it should work.
In addition, the GitHub actions are now also kept up to date.
