### PR TITLE
Generate constant enum name specifier

### DIFF
--- a/src/core/getters/enum.ts
+++ b/src/core/getters/enum.ts
@@ -8,6 +8,10 @@ export const getEnum = (value: string, type: string, enumName: string) => {
 
   enumValue += `\n\n`;
 
+  enumValue += `export const ${enumName}Enum = '${enumName}';`;
+  
+  enumValue += `\n\n`;
+  
   enumValue += '// eslint-disable-next-line @typescript-eslint/no-redeclare\n';
 
   enumValue += `export const ${enumName} = {\n${implementation}} as const;\n`;


### PR DESCRIPTION
## Status

**READY**

## Description

Updated the getEnum function to export a constant accessor for the enum name, so that we can access this property in our client-side code in a type-safe way.

I have the following use case and I am sure this must be somewhat common:

Our enums have multiple attributes, ie. Group, Description etc. These attributes are not captured when the OpenAPI spec is generated, therefore we have an API that accepts the name of an enum and returns a list of objects which contain the enum value, description, group etc.

Currently, using Orval our only option to implement this on the clientside is to use hardcoded strings for the enum names we need to fetch from our API. The ideal solution is for Orval to generate an accessor to the enum name, this way if an enum is removed server side, when we regenerate the api spec client side, typescript will throw errors for each usage of the enum.

An example of what this PR achieves is:

**Input**
Enum => `SystemCodes`

**Output**
`export const SystemCodesEnum = 'SystemCodes';`


## Related PRs

None

## Todos

- [ ] Tests
- [ ] Documentation
- [x] Changelog Entry (unreleased)

I don't believe Tests and Documentation are required for this PR.

## Steps to Test or Reproduce

Not relevant, steps to test should be generating models from an OpenAPI spec that contains atleast one enum and then verifying that the output contains the name accessor.