### PR TITLE
Fix: correctly resolve paths when generating mocks with oneOf

### DIFF
--- a/src/core/resolvers/value.mock.ts
+++ b/src/core/resolvers/value.mock.ts
@@ -61,10 +61,7 @@ export const resolveMockValue = async ({
   imports: GeneratorImport[];
 }): Promise<MockDefinition & { type?: string }> => {
   if (isReference(schema)) {
-    const { name, specKey } = await getRefInfo(schema.$ref, {
-      ...context,
-      specKey: schema.specKey || context.specKey,
-    });
+    const { name, specKey } = await getRefInfo(schema.$ref, context);
 
     const newSchema = {
       ...getSchema(name, context, specKey || schema.specKey || context.specKey),

--- a/tests/configs/react-query.config.ts
+++ b/tests/configs/react-query.config.ts
@@ -221,4 +221,14 @@ export default defineConfig({
       target: '../specifications/form-url-encoded.yaml',
     },
   },
+  importFromSubdirectory: {
+    output: {
+      target: '../generated/react-query/importFromSubdirectory/endpoints.ts',
+      schemas: '../generated/react-query/importFromSubdirectory/model',
+      client: 'react-query',
+      mode: 'split',
+      mock: true,
+    },
+    input: '../specifications/import-from-subdirectory/petstore.yaml',
+  },
 });

--- a/tests/specifications/import-from-subdirectory/petstore.yaml
+++ b/tests/specifications/import-from-subdirectory/petstore.yaml
@@ -1,0 +1,17 @@
+openapi: 3.0.2
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pets:
+    post:
+      responses:
+        '200':
+          description: Created Pet
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: 'subdirectory/petstore.yaml#/components/schemas/Pet'

--- a/tests/specifications/import-from-subdirectory/subdirectory/petstore.yaml
+++ b/tests/specifications/import-from-subdirectory/subdirectory/petstore.yaml
@@ -1,0 +1,14 @@
+openapi: 3.0.2
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: integer
+          format: int64


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

When running Orval with:
- react-query
- mocks
- referencing a schema in a subdirectory in a `oneOf`

the generation would break, since if would create a `specKey` with the wrong path. The `specKey` would reference the subdirectory twice (eg: `..path/directory/directory/file.yaml` instead of `..path/directory/file.yaml`).

I copied how `getRefInfo` was called in other places in the code, this solved the issue.

Also added a minimal test (which breaks on master and passes on this branch) to explain the issue.

## Todos

- [x] Tests

## Steps to Test or Reproduce

In order to run the failing test:

```bash
> git pull --prune
> git checkout fix/correctly-resolve-paths-when-generating-mocks^1
> yarn build
> cd tests
> yarn
> yarn generate
```