### PR TITLE
added min and max so user can specifiy from swagger doc

### DIFF
--- a/src/core/getters/scalar.mock.ts
+++ b/src/core/getters/scalar.mock.ts
@@ -81,7 +81,7 @@ export const getMockScalar = async ({
     case 'number':
     case 'integer': {
       return {
-        value: getNullable('faker.datatype.number()', item.nullable),
+        value: getNullable(`faker.datatype.number({min: ${item.minimum}, max: ${item.maximum}})`, item.nullable),
         imports: [],
         name: item.name,
       };


### PR DESCRIPTION
Problem: When a user specifies a minimum and/or maximum value for a property of type `number` or `integer`, these values are not passed to the faker function that generates the number in the mock api files, and thus the mock returns values that are not wanted.

This change addresses that issue.

Example:

This specification in the swagger doc:
![Screen Shot 2022-07-10 at 11 41 48 AM](https://user-images.githubusercontent.com/45971543/178151913-b6ef17d5-df2e-496a-a325-2f61b0794d75.png)

Will lead to this in the mock api file:
<img width="995" alt="Screen Shot 2022-07-10 at 12 20 38 PM" src="https://user-images.githubusercontent.com/45971543/178153124-6bf5e905-fb72-45a5-9cb3-067972137161.png">

If no minimum or maximum is provided, those values will be passed as `undefined` in the faker function
<img width="1012" alt="Screen Shot 2022-07-10 at 12 23 19 PM" src="https://user-images.githubusercontent.com/45971543/178153194-0ee7fe24-26e6-4ae7-9569-e01f96c7118e.png">

[which will lead to the same default behavior before this change, of returning a random number between 0 and 99999.](https://fakerjs.dev/api/datatype.html#number)