### PR TITLE
fix: msw mock delay time

### DIFF
--- a/src/core/generators/msw.ts
+++ b/src/core/generators/msw.ts
@@ -82,7 +82,7 @@ export const generateMSW = (
           : '',
       handler: `rest.${verb}('${route}', (_req, res, ctx) => {
         return res(
-          ctx.delay(${override?.mock?.delay || 1000}),
+          ctx.delay(${override?.mock?.delay ?? 1000}),
           ctx.status(200, 'Mocked status'),${
             value && value !== 'undefined'
               ? `\nctx.${responseType}(get${pascal(operationId)}Mock()),`

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -227,6 +227,7 @@ export type OverrideOutput = {
     format?: { [key: string]: unknown };
     required?: boolean;
     baseUrl?: string;
+    delay?: number;
   };
   contentType?: OverrideOutputContentType;
   header?: boolean | ((info: InfoObject) => string[] | string);


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

Change from logical or to the nullish coalescing operator, in order that 0 is a valid value.

`undefined || 1000` -> `1000`
`0 || 1000` -> `1000`

`undefined ?? 1000` -> `1000`
`0 ?? 1000` -> `0`
