### PR TITLE
fix: prevent numeric prefixes in response types

### DIFF
--- a/src/core/generators/componentDefinition.ts
+++ b/src/core/generators/componentDefinition.ts
@@ -9,6 +9,7 @@ import { ContextSpecs } from '../../types';
 import { GeneratorSchema } from '../../types/generator';
 import { pascal } from '../../utils/case';
 import { jsDoc } from '../../utils/doc';
+import { sanitize } from '../../utils/string';
 import { getResReqTypes } from '../getters/resReqTypes';
 
 export const generateComponentDefinition = (
@@ -42,7 +43,7 @@ export const generateComponentDefinition = (
 
       const type = allResponseTypes.map(({ value }) => value).join(' | ');
 
-      const modelName = `${pascal(name)}${suffix}`;
+      const modelName = sanitize(`${pascal(name)}${suffix}`);
       const doc = jsDoc(response as ResponseObject | RequestBodyObject);
       const model = `${doc}export type ${modelName} = ${type || 'unknown'};\n`;
 

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -101,11 +101,6 @@ export const sanitize = (
   return newValue;
 };
 
-export const sanitizeAll = (s: TemplateStringsArray, ...v: string[]) => {
-  const sanitizedStrings = v.map((s) => sanitize(s));
-  return s.raw.reduce((a, c) => a + sanitizedStrings + c);
-};
-
 export const toObjectString = <T>(props: T[], path?: keyof T) => {
   if (!props.length) {
     return '';

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -94,7 +94,16 @@ export const sanitize = (
     newValue = keyword.isKeywordES5(newValue, true) ? `_${newValue}` : newValue;
   }
 
+  if (newValue.match(/^[0-9]/)) {
+    newValue = `N${newValue}`;
+  }
+
   return newValue;
+};
+
+export const sanitizeAll = (s: TemplateStringsArray, ...v: string[]) => {
+  const sanitizedStrings = v.map((s) => sanitize(s));
+  return s.raw.reduce((a, c) => a + sanitizedStrings + c);
 };
 
 export const toObjectString = <T>(props: T[], path?: keyof T) => {


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

This is a limited fix for an issue I was dealing with. I have a swagger file which returns response types that are prefixed with the response code: e.g. `404Response`.

There might be a better way to do this, but it fixes it for me.