### PR TITLE
fix(code): generated code for arrays with nullable items

### DIFF
--- a/src/core/getters/array.ts
+++ b/src/core/getters/array.ts
@@ -24,7 +24,7 @@ export const getArray = ({
       context,
     });
     return {
-      value: `${resolvedObject.value}[]`,
+      value: `(${resolvedObject.value})[]`,
       imports: resolvedObject.imports,
       schemas: resolvedObject.schemas,
       isEnum: false,

--- a/tests/configs/default.config.ts
+++ b/tests/configs/default.config.ts
@@ -42,4 +42,11 @@ export default defineConfig({
       schemas: '../generated/default/translation/model',
     },
   },
+  regressions: {
+    input: '../specifications/regressions.yaml',
+    output: {
+      target: '../generated/default/regressions/endpoints.ts',
+      schemas: '../generated/default/regressions/model',
+    },
+  },
 });

--- a/tests/regressions/arrays.ts
+++ b/tests/regressions/arrays.ts
@@ -1,0 +1,10 @@
+import { ArrayTest } from '../generated/default/regressions/model/arrayTest';
+
+// Ensure arrays with nullable items work correctly.
+// See: https://github.com/anymaniax/orval/pull/563
+const arrays: ArrayTest = {
+  nullable_items: ['string', null],
+  nested_nullable_items: [['string'], [null]],
+};
+
+void arrays;

--- a/tests/specifications/regressions.yaml
+++ b/tests/specifications/regressions.yaml
@@ -1,0 +1,22 @@
+openapi: '3.0.0'
+info:
+  title: Orval Regression Tests
+  version: 0.0.0
+paths: {}
+components:
+  schemas:
+    ArrayTest:
+      type: object
+      properties:
+        nullable_items:
+          type: array
+          items:
+            type: string
+            nullable: true
+        nested_nullable_items:
+          type: array
+          items:
+            type: array
+            items:
+              type: string
+              nullable: true

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "exclude": ["node_modules", "dist", "__tests__", "**/*.test*", "**/*.spec*"],
-  "include": ["generated/**/*"],
+  "include": ["generated/**/*", "regressions/**/*"],
   "compilerOptions": {
     "skipLibCheck": true,
     "target": "es5",


### PR DESCRIPTION
## Status

**READY**

## Description

The code generator for arrays outputs ambiguous types, and breaks for nullable array items. 
Currently, the generated code looks like: `string | null[]`
This is interpreted as "string or an array of null", which is incorrect.
With this fix, the generated code is: `(string | null)[]`

This change wraps _all_ array types in parenthesis (`()`). This is not necessarily needed for a single type, but it causes no harm, avoids any ambiguity, and avoids the need for more complex changes to the code generator.

I also added a regression test that fails to compile without this fix. I didn't see an existing pattern for regression tests so I came up with something. Let me know if you'd prefer a different approach.

## Related PRs

n/a

## Todos

- [X] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

> **Note** See tests for complete example.

1. Create a schema like:
    ```yaml
     nullable_items:
       type: array
       items:
         type: string
         nullable: true
    ```
2. Generate code, attempt to assign a value to the type, see error:
    ```
    TS2322: Type '[string]' is not assignable to type 'string | null[]'.   Type '[string]' is not assignable to type 'null[]'.     Type 'string' is not assignable to type 'null'.
    ```
