### PR TITLE
fix(msw): generated mocks for polymorphic type

### DIFF
--- a/src/core/getters/combine.mock.ts
+++ b/src/core/getters/combine.mock.ts
@@ -78,7 +78,9 @@ export const combineSchemasMock = ({
         ? `${resolvedValue.value.slice(0, -1)},${itemResolvedValue.value}}`
         : resolvedValue.value;
 
-    if (!index && !combine) {
+    const isObjectBounds = !combine || combine.separator == 'oneOf';
+
+    if (!index && isObjectBounds) {
       if (resolvedValue.enums || separator === 'oneOf') {
         if (arr.length === 1) {
           return `faker.helpers.arrayElement([${value}])`;
@@ -99,7 +101,7 @@ export const combineSchemasMock = ({
       }
       return `${acc}${value}${
         itemResolvedValue?.value ? `,${itemResolvedValue.value}` : ''
-      }${!combine ? '}' : ''}`;
+      }${isObjectBounds ? '}' : ''}`;
     }
     if (!value) {
       return acc;

--- a/tests/configs/react-query.config.ts
+++ b/tests/configs/react-query.config.ts
@@ -268,4 +268,16 @@ export default defineConfig({
       target: '../specifications/petstore.yaml',
     },
   },
+  polymorphic: {
+    output: {
+      target: '../generated/react-query/polymorphic/endpoints.ts',
+      schemas: '../generated/react-query/polymorphic/model',
+      client: 'react-query',
+      mock: true,
+      headers: true,
+    },
+    input: {
+      target: '../specifications/polymorphic.yaml',
+    },
+  },
 });

--- a/tests/specifications/polymorphic.yaml
+++ b/tests/specifications/polymorphic.yaml
@@ -1,0 +1,50 @@
+openapi: 3.0.1
+info:
+  title: API
+  version: V1
+paths:
+  /demo:
+    get:
+      operationId: getPolymorphicResponse
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: object
+                oneOf:
+                  - $ref: '#/components/schemas/DescendantOne'
+                  - $ref: '#/components/schemas/DescendantTwo'
+components:
+  schemas:
+    DescendantOne:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/ParentType'
+        - type: object
+          properties:
+            value:
+              type: boolean
+    DescendantTwo:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/ParentType'
+        - type: object
+          properties:
+            value:
+              type: string
+    ParentType:
+      type: object
+      properties:
+        value:
+          type: object
+        key:
+          type: string
+        type:
+          type: string
+          enum:
+            - BOOLEAN
+            - STRING
+      discriminator:
+        propertyName: type


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**WIP**

## Description

Fixes #555 - When a response contains a polymorphic type, the generated mock object code was missing curly braces. This error was introduced in https://github.com/anymaniax/orval/commit/899a8cbd4c93190bd01ebd5e36be81d750b7608f.
Previously, when calling `resolveMockValue` within a `oneOf`, the `combine` option was undefined. The change resulted in the option being defined, resulting in a failing check for object boundaries.

This fix adds a check for `combine.separator === 'oneOf'` when determining object boundaries.

## Todos

- [x] Tests
- [ ] Documentation - N/A
- [ ] Changelog Entry (unreleased)  - N/A

## Steps to Test or Reproduce

1. Added a sample YAML swagger definition to tests (polymorphic.yaml)
2. Added the sample case to the test react-query.config.ts
