### PR TITLE
fix(writers): fix handling of duplicate kebab'd tag names

### DIFF
--- a/src/core/writers/splitTagsMode.ts
+++ b/src/core/writers/splitTagsMode.ts
@@ -2,7 +2,7 @@ import { outputFile } from 'fs-extra';
 import { join } from 'upath';
 import { OutputClient } from '../../types';
 import { WriteModeProps } from '../../types/writers';
-import { camel, kebab } from '../../utils/case';
+import { camel } from '../../utils/case';
 import { getFileInfo } from '../../utils/file';
 import { relativeSafe } from '../../utils/path';
 import { isSyntheticDefaultImportsAllow } from '../../utils/tsconfig';
@@ -108,19 +108,15 @@ export const writeSplitTagsMode = async ({
         mswData += `\n${implementationMSW}`;
 
         const implementationFilename =
-          kebab(tag) +
+          tag +
           (OutputClient.ANGULAR === output.client ? '.service' : '') +
           extension;
 
-        const implementationPath = join(
-          dirname,
-          kebab(tag),
-          implementationFilename,
-        );
+        const implementationPath = join(dirname, tag, implementationFilename);
         await outputFile(implementationPath, implementationData);
 
         const mockPath = output.mock
-          ? join(dirname, kebab(tag), kebab(tag) + '.msw' + extension)
+          ? join(dirname, tag, tag + '.msw' + extension)
           : undefined;
 
         if (mockPath) {

--- a/src/core/writers/targetTags.ts
+++ b/src/core/writers/targetTags.ts
@@ -6,7 +6,7 @@ import {
   GeneratorTarget,
   GeneratorTargetFull,
 } from '../../types/generator';
-import { pascal } from '../../utils/case';
+import { kebab, pascal } from '../../utils/case';
 import {
   generateClientFooter,
   generateClientHeader,
@@ -24,7 +24,7 @@ const generateTargetTags = (
 ): {
   [key: string]: GeneratorTargetFull;
 } =>
-  operation.tags.reduce((acc, tag) => {
+  operation.tags.map(kebab).reduce((acc, tag) => {
     const currentOperation = acc[tag];
 
     acc[tag] = !currentOperation

--- a/tests/configs/default.config.ts
+++ b/tests/configs/default.config.ts
@@ -47,6 +47,7 @@ export default defineConfig({
     output: {
       target: '../generated/default/regressions/endpoints.ts',
       schemas: '../generated/default/regressions/model',
+      mode: 'tags-split',
     },
   },
 });

--- a/tests/regressions/duplicateTags.ts
+++ b/tests/regressions/duplicateTags.ts
@@ -1,0 +1,13 @@
+import {
+  getEndpointA,
+  getEndpointB,
+  getEndpointC,
+  getEndpointD,
+  getEndpointE,
+} from '../generated/default/regressions/dup-tag/dup-tag';
+
+void getEndpointA;
+void getEndpointB;
+void getEndpointC;
+void getEndpointD;
+void getEndpointE;

--- a/tests/specifications/regressions.yaml
+++ b/tests/specifications/regressions.yaml
@@ -2,7 +2,6 @@ openapi: '3.0.0'
 info:
   title: Orval Regression Tests
   version: 0.0.0
-paths: {}
 components:
   schemas:
     ArrayTest:
@@ -20,3 +19,34 @@ components:
             items:
               type: string
               nullable: true
+paths:
+  /endpointA:
+    get:
+      tags: ['dup-tag']
+      responses:
+        200:
+          description: ''
+  /endpointB:
+    get:
+      tags: ['dup_tag']
+      responses:
+        200:
+          description: ''
+  /endpointC:
+    get:
+      tags: ['dup___tag']
+      responses:
+        200:
+          description: ''
+  /endpointD:
+    get:
+      tags: ['Dup Tag']
+      responses:
+        200:
+          description: ''
+  /endpointE:
+    get:
+      tags: ['dup tag']
+      responses:
+        200:
+          description: ''


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

The splitTagsMode writer uses kebab(tag) to generate output filenames. This is a problem if the
input schema has multiple tags that "kebab" to the same value.
For example: "dup_tag", "dup tag", "dupe-tag", "DUP TAG"

The current behavior is that files are overwritten non-deterministically.

This change fixes the problem by kebab-ing tag names earlier in the process so they can be merged
together into a single file.


## Related PRs

NA

## Todos

- [X] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

See regression tests.
