### PR TITLE
fix: use SwaggerParser dereference for input path

### DIFF
--- a/src/core/importers/specs.ts
+++ b/src/core/importers/specs.ts
@@ -25,6 +25,8 @@ const resolveSpecs = async (
   }
 
   const data = (await SwaggerParser.resolve(path, options)).values();
+  const dereferencedData = await SwaggerParser.dereference(path, options);
+  data[path] = dereferencedData;
 
   if (isUrl) {
     return data;


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description


FIX of https://github.com/anymaniax/orval/issues/589



SwaggerParser.resolve dereference only one depth of json schema.

After one depth, it only gives you ref path. It does not affect your API codegen, but does affect mocks.

Mocks will be always `{}` empy object because it does not belong to any condition in getMockObject in `getters/object.mock.ts`and resolveMockValue in `resolvers/value.mock.ts`

So use `SwaggerParser.dereference` for main server input path that dereference fulll depth of ref.

## Related PRs

List related PRs against other branches:

| branch              | PR       |
| ------------------- | -------- |
| other_pr_production | [link]() |
| other_pr_master     | [link]() |

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

use example of https://github.com/anymaniax/orval/issues/589


server.yaml
```
openapi: 3.0.3
info:
  title: test
  version: 0.0.1
servers:
  - url: abcd.com
paths:
  /signup:
    get:
      operationId: getTest
      responses:
        200:
          description: test
          content:
            application/json:
              schema:
                $ref: '#abc.yaml#/User'
```
abc.yaml
```
RoleName:
  type: string
  enum:
    - A
    - B
    - C

User:
  type: object
  required:
    - role
  properties:
    role:
      $ref: '#/RoleName'

```

to check whether mock is properly genereated after fix

