### PR TITLE
docs: add delay options

### DIFF
--- a/docs/src/pages/reference/configuration/output.md
+++ b/docs/src/pages/reference/configuration/output.md
@@ -681,6 +681,28 @@ module.exports = {
 };
 ```
 
+#### delay
+
+Type: `number`.
+
+Give you the possibility to set delay time for mock
+
+Default Value: `1000`
+
+```js
+module.exports = {
+  petstore: {
+    output: {
+      override: {
+        mock: {
+          delay: 0,
+        },
+      },
+    },
+  },
+};
+```
+
 #### arrayMin
 
 Type: `Number`.


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY/WIP/HOLD**

## Description

Currently there is no delay options in Orval.dev docs

## Related PRs

List related PRs against other branches:

| branch              | PR       |
| ------------------- | -------- |
| other_pr_production | [link]() |
| other_pr_master     | [link]() |

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

Just a docs update so it's pretty staightforward
