### PR TITLE
fix(getters): handle OpenAPI 3.1 nullability

### DIFF
--- a/src/core/getters/object.ts
+++ b/src/core/getters/object.ts
@@ -50,6 +50,16 @@ export const getObject = ({
     });
   }
 
+  if (item.type instanceof Array) {
+    return combineSchemas({
+      schema: { anyOf: item.type.map((type) => ({ type })) },
+      name,
+      separator: 'anyOf',
+      context,
+      nullable,
+    });
+  }
+
   if (item.properties && Object.entries(item.properties).length > 0) {
     return Object.entries(item.properties).reduce(
       (

--- a/src/core/getters/scalar.ts
+++ b/src/core/getters/scalar.ts
@@ -104,6 +104,16 @@ export const getScalar = ({
       };
     }
 
+    case 'null':
+      return {
+        value: 'null',
+        isEnum: false,
+        type: 'null',
+        imports: [],
+        schemas: [],
+        isRef: false,
+      };
+
     case 'object':
     default: {
       const { value, ...rest } = getObject({

--- a/tests/configs/default.config.ts
+++ b/tests/configs/default.config.ts
@@ -50,4 +50,11 @@ export default defineConfig({
       mode: 'tags-split',
     },
   },
+  'null-type': {
+    input: '../specifications/null-type.yaml',
+    output: {
+      schemas: '../generated/default/null-type/model',
+      target: '../generated/default/null-type/endpoints.ts',
+    },
+  },
 });

--- a/tests/specifications/null-type.yaml
+++ b/tests/specifications/null-type.yaml
@@ -1,0 +1,56 @@
+openapi: 3.1.0
+info:
+  title: Nullables
+  description: 'Nullable types'
+  version: 1.0.0
+tags:
+  - name: nullables
+    description: Nullable types
+servers:
+  - url: http://localhost
+paths:
+  /nullable:
+    get:
+      tags:
+        - nullables
+      summary: Nullable response
+      operationId: fetchNullable
+      responses:
+        200:
+          description: Successful Operation
+          content:
+            application/json:
+              schema:
+                type:
+                  - 'string'
+                  - 'null'
+  /nullable-object:
+    get:
+      tags:
+        - nullables
+      summary: Nullable object response
+      operationId: fetchNullableObject
+      responses:
+        200:
+          description: Successful Operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NullableObject'
+components:
+  schemas:
+    NullableObject:
+      type: object
+      properties:
+        name:
+          type:
+            - 'string'
+            - 'null'
+        age:
+          anyOf:
+            - type: 'integer'
+            - type: 'null'
+        address:
+          oneOf:
+            - type: 'string'
+            - type: 'null'

--- a/yarn.lock
+++ b/yarn.lock
@@ -4794,11 +4794,11 @@ open@8.4.0:
     is-wsl "^2.2.0"
 
 openapi3-ts@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/openapi3-ts/-/openapi3-ts-3.0.0.tgz#6c13236c6071bf147c2abf2210f7b11dd107c634"
-  integrity sha512-LqX4+nSPXreJcgV/QdcazH2Mg5V9yHznTV08WNWCqjNO7d0QiPVlkq0Tp5bWVglsmZkjgVgr5/cFDRY6MjHrUg==
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/openapi3-ts/-/openapi3-ts-3.1.1.tgz#6e5ffa44a9b47098c8b0a1c58794875bd7a6d967"
+  integrity sha512-lNUS87ncFqm1m8W21sbTGIeD7sydkQ4nnRUrkBiGlAzTngr50eBKU2suUXhdEk51z6m4cCgaXdB1SFgXtyn81Q==
   dependencies:
-    yaml "^2.1.1"
+    yaml "^2.1.3"
 
 optionator@^0.8.1:
   version "0.8.3"
@@ -6635,10 +6635,10 @@ yaml@^1.10.0, yaml@^1.10.2:
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
-yaml@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.1.1.tgz#1e06fb4ca46e60d9da07e4f786ea370ed3c3cfec"
-  integrity sha512-o96x3OPo8GjWeSLF+wOAbrPfhFOGY0W00GNaxCDv+9hkcDJEnev1yh8S7pgHF0ik6zc8sQLuL8hjHjJULZp8bw==
+yaml@^2.1.1, yaml@^2.1.3:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.1.3.tgz#9b3a4c8aff9821b696275c79a8bee8399d945207"
+  integrity sha512-AacA8nRULjKMX2DvWvOAdBZMOfQlypSFkjcOcu9FalllIDJ1kvlREzcdIZmidQUqqeMv7jorHjq2HlLv/+c2lg==
 
 yargs-parser@21.1.1, yargs-parser@^21.0.0:
   version "21.1.1"


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

READY

## Description

In OpenAPI 3.1, the `nullable` keyword has been removed, and nullability is handled by `oneOf`, `anyOf` or type arrays: https://www.openapis.org/blog/2021/02/16/migrating-from-openapi-3-0-to-3-1-0

Currently, Orval does not support this, with nullable types ending up as `unknown` (for type arrays) or e.g. `string | unknown` (for oneOf/anyOf).

This PR adds support both for `oneOf`, `anyOf` and type arrays:

```yaml
components:
  schemas:
    NullableObject:
      type: object
      properties:
        name:
          type:
            - 'string'
            - 'null'
        age:
          anyOf:
            - type: 'integer'
            - type: 'null'
        address:
          oneOf:
            - type: 'string'
            - type: 'null'
```

Resulting in:

```ts
export interface NullableObject {
  name?: NullableObjectName
  age?: NullableObjectAge
  address?: NullableObjectAddress
}

export type NullableObjectAddress = string | null
export type NullableObjectAge = number | null
export type NullableObjectName = string | null
```

Also fixes #551 by interpreting type arrays as `anyOf` (as suggested by https://stackoverflow.com/a/48114924/500976)

## Todos

- [x] Tests
