### PR TITLE
docs: fix position of mock options

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -79,6 +79,6 @@
     "webp-loader": "^0.6.0"
   },
   "engines": {
-    "node": ">=12.x"
+    "node": ">=12.x <17"
   }
 }

--- a/docs/src/pages/reference/configuration/output.md
+++ b/docs/src/pages/reference/configuration/output.md
@@ -615,7 +615,7 @@ Type: `Object`.
 
 Give you the possibility to override the generated mock
 
-#### properties
+##### properties
 
 Type: `Object` or `Function`.
 
@@ -638,7 +638,7 @@ module.exports = {
 };
 ```
 
-#### format
+##### format
 
 Type: `Object`.
 
@@ -661,7 +661,7 @@ module.exports = {
 };
 ```
 
-#### required
+##### required
 
 Type: `Boolean`.
 
@@ -681,7 +681,7 @@ module.exports = {
 };
 ```
 
-#### delay
+##### delay
 
 Type: `number`.
 
@@ -703,7 +703,7 @@ module.exports = {
 };
 ```
 
-#### arrayMin
+##### arrayMin
 
 Type: `Number`.
 
@@ -723,7 +723,7 @@ module.exports = {
 };
 ```
 
-#### arrayMax
+##### arrayMax
 
 Type: `Number`.
 
@@ -743,7 +743,7 @@ module.exports = {
 };
 ```
 
-#### baseUrl
+##### baseUrl
 
 Type: `String`.
 


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

### Set node engine limits to 16
There is error that starting docs is not working when node version is over 16. 
https://github.com/webpack/webpack/issues/15900

It could be resolved by updating librarys in docs folder, but it would be too large and may not be the way all contributor wants.  So just update package.json file.

### Integrate mocks options

Mock options has same depth as mock itself so it is hard to recognize that it is property of mock without looking at example. So fixed it according to https://github.com/anymaniax/orval/blob/68f84a8b49a78e19b45c4623b2f659b2f2d0481d/packages/core/src/types.ts#L59

AS_IS
![image](https://user-images.githubusercontent.com/69702813/204078994-36695332-e199-45a4-b836-f9db0d122bf9.png)

TO_BE
![image](https://user-images.githubusercontent.com/69702813/204079043-6b78f023-6e1f-4fb8-8c60-cbdc52a16b38.png)


## Related PRs

List related PRs against other branches:

| branch              | PR       |
| ------------------- | -------- |
| other_pr_production | [link]() |
| other_pr_master     | [link]() |

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

check deployed docs.
