### PR TITLE
fix: required query parameters with content

### DIFF
--- a/packages/core/src/getters/query-params.test.ts
+++ b/packages/core/src/getters/query-params.test.ts
@@ -1,0 +1,123 @@
+import { ParameterObject } from 'openapi3-ts';
+import { describe, expect, it } from 'vitest';
+import { ContextSpecs } from '../types';
+import { getQueryParams } from './query-params';
+
+// Mock context for getQueryParams
+const context: ContextSpecs = {
+  specs: {},
+  // @ts-ignore
+  override: {
+    useDates: true,
+  },
+};
+
+const queryParams: {
+  parameter: ParameterObject;
+  optional: boolean;
+}[] = [
+  {
+    parameter: {
+      name: 'queryParamWithSchemaNotRequired',
+      in: 'query',
+      schema: {
+        type: 'string',
+      },
+      required: false,
+    },
+    optional: true,
+  },
+  {
+    parameter: {
+      name: 'queryParamWithSchemaRequired',
+      in: 'query',
+      schema: {
+        type: 'string',
+      },
+      required: true,
+    },
+    optional: false,
+  },
+  {
+    parameter: {
+      name: 'queryParamWithSchemaDefaultValue',
+      in: 'query',
+      schema: {
+        default: 'defaultValue',
+        type: 'string',
+      },
+    },
+    optional: true,
+  },
+  {
+    parameter: {
+      name: 'queryParamWithContentNotRequired',
+      in: 'query',
+      content: {
+        'application/json': {
+          schema: {
+            type: 'string',
+          },
+        },
+      },
+      required: false,
+    },
+    optional: true,
+  },
+  {
+    parameter: {
+      name: 'queryParamWithContentRequired',
+      in: 'query',
+      content: {
+        'application/json': {
+          schema: {
+            type: 'string',
+          },
+        },
+      },
+      required: true,
+    },
+    optional: false,
+  },
+  {
+    parameter: {
+      name: 'queryParamWithContentDefaultValue',
+      in: 'query',
+      content: {
+        'application/json': {
+          schema: {
+            default: 'defaultValue',
+            type: 'string',
+          },
+        },
+      },
+      required: true,
+    },
+    optional: true,
+  },
+];
+
+describe('getQueryParams getter', () => {
+  queryParams.forEach(({ parameter, optional }) => {
+    it(`${parameter.name} should${
+      !optional ? ' NOT ' : ' '
+    }be optional`, () => {
+      const result = getQueryParams({
+        queryParams: [
+          {
+            parameter,
+            imports: [],
+          },
+        ],
+        operationName: '',
+        context,
+      });
+
+      expect(result?.schema.model.trim()).toBe(
+        `export type Params = { ${parameter.name}${
+          optional ? '?' : ''
+        }: string };`,
+      );
+    });
+  });
+});

--- a/packages/core/src/getters/query-params.ts
+++ b/packages/core/src/getters/query-params.ts
@@ -23,7 +23,12 @@ const getQueryParamsTypes = (
   context: ContextSpecs,
 ): QueryParamsType[] => {
   return queryParams.map(({ parameter, imports: parameterImports }) => {
-    const { name, required, schema, content } = parameter as {
+    const {
+      name,
+      required,
+      schema: schemaParam,
+      content,
+    } = parameter as {
       name: string;
       required: boolean;
       schema: SchemaObject;
@@ -38,8 +43,10 @@ const getQueryParamsTypes = (
       es5IdentifierName: true,
     });
 
+    const schema = (schemaParam || content['application/json'].schema)!;
+
     const resolvedeValue = resolveValue({
-      schema: (schema || content['application/json'].schema)!,
+      schema,
       context,
       name: queryName,
     });


### PR DESCRIPTION
## Status

**READY**

## Description

Support required query parameters with content instead of schema along with tests that verify that code generation for required/non-required and with/without default generates types as optional correctly.

Currently client generation fails for required query parameters with content, but works for required query parameters with schema.

The error is `TypeError: Cannot read properties of undefined (reading 'default')` since the schema variable is undefined when you specify content.


    # Works
    queryParamWithContentNotRequired:
      name: queryParamWithContentNotRequired
      in: query
      required: false
      content:
        application/json:
          schema:
            type: object
            properties:
              prop1:
                type: string
              prop2:
                type: string

    # Works
    queryParamWithSchemaNotRequired:
      name: queryParamWithSchemaNotRequired
      in: query
      required: false
      schema:
        type: object
        properties:
          prop1:
            type: string
          prop2:
            type: string

    # Works
    queryParamWithSchemaRequired:
      name: queryParamWithSchemaRequired
      in: query
      required: true
      schema:
        type: object
        properties:
          prop1:
            type: string
          prop2:
            type: string

    # Doesn't work
    queryParamWithContentRequired:
      name: queryParamWithContentRequired
      in: query
      required: true
      content:
        application/json:
          schema:
            type: object
            properties:
              prop1:
                type: string
              prop2:
                type: string
