### PR TITLE
fix(jsdoc): add jsDoc to query parameters

### DIFF
--- a/packages/core/src/getters/query-params.test.ts
+++ b/packages/core/src/getters/query-params.test.ts
@@ -114,10 +114,38 @@ describe('getQueryParams getter', () => {
       });
 
       expect(result?.schema.model.trim()).toBe(
-        `export type Params = { ${parameter.name}${
+        `export type Params = {\n${parameter.name}${
           optional ? '?' : ''
-        }: string };`,
+        }: string;\n};`,
       );
     });
+  });
+
+  it('queryParamWithDescription should be documented', () => {
+    const result = getQueryParams({
+      queryParams: [
+        {
+          parameter: {
+            name: 'queryParamWithDescription',
+            in: 'query',
+            description: 'Parameter description.',
+            schema: {
+              type: 'string',
+            },
+          },
+          imports: [],
+        },
+      ],
+      operationName: '',
+      context,
+    });
+    expect(result?.schema.model.trim()).toBe([
+      'export type Params = {',
+      '/**',
+      ' * Parameter description.',
+      ' */',
+      'queryParamWithDescription?: string;',
+      '};',
+    ].join('\n'));
   });
 });

--- a/packages/core/src/getters/query-params.ts
+++ b/packages/core/src/getters/query-params.ts
@@ -7,7 +7,7 @@ import {
   GetterParameters,
   GetterQueryParam,
 } from '../types';
-import { pascal, sanitize } from '../utils';
+import { jsDoc, pascal, sanitize } from '../utils';
 import { getEnum } from './enum';
 import { getKey } from './keys';
 
@@ -52,12 +52,13 @@ const getQueryParamsTypes = (
     });
 
     const key = getKey(name);
+    const doc = jsDoc(parameter);
 
     if (parameterImports.length) {
       return {
-        definition: `${key}${!required || schema.default ? '?' : ''}: ${
+        definition: `${doc}${key}${!required || schema.default ? '?' : ''}: ${
           parameterImports[0].name
-        }`,
+        };`,
         imports: parameterImports,
         schemas: [],
       };
@@ -73,9 +74,9 @@ const getQueryParamsTypes = (
       );
 
       return {
-        definition: `${key}${
+        definition: `${doc}${key}${
           !required || schema.default ? '?' : ''
-        }: ${enumName}`,
+        }: ${enumName};`,
         imports: [{ name: enumName }],
         schemas: [
           ...resolvedeValue.schemas,
@@ -84,9 +85,9 @@ const getQueryParamsTypes = (
       };
     }
 
-    const definition = `${key}${!required || schema.default ? '?' : ''}: ${
-      resolvedeValue.value
-    }`;
+    const definition = `${doc}${key}${
+      !required || schema.default ? '?' : ''
+    }: ${resolvedeValue.value};`;
 
     return {
       definition,
@@ -115,12 +116,12 @@ export const getQueryParams = ({
   const schemas = types.flatMap(({ schemas }) => schemas);
   const name = `${pascal(operationName)}${pascal(suffix)}`;
 
-  const type = types.map(({ definition }) => definition).join('; ');
+  const type = types.map(({ definition }) => definition).join('\n');
   const allOptional = queryParams.every(({ parameter }) => !parameter.required);
 
   const schema = {
     name,
-    model: `export type ${name} = { ${type} };\n`,
+    model: `export type ${name} = {\n${type}\n};\n`,
     imports,
   };
 


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

Use parameter descriptions to document the types
https://github.com/anymaniax/orval/blob/ba7ee988557a63c392c6d9bee50bbd7eddfe3b86/samples/react-app/petstore.yaml#L16-L22

```diff
- export type ListPetsParams = { limit?: string };
+ export type ListPetsParams = {
+ /**
+  * How many items to return at one time (max 100)
+  */
+ limit?: string;
+ };
```

## Todos

- [x] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)
