### PR TITLE
feat: #338 add export of additional keywords

### DIFF
--- a/packages/core/src/generators/consts.ts
+++ b/packages/core/src/generators/consts.ts
@@ -1,0 +1,68 @@
+import { isSchemaObject, SchemaObject } from 'openapi3-ts';
+import { resolveRef } from '../resolvers';
+import { ContextSpecs } from '../types';
+import { isReference, pascal } from '../utils';
+
+/**
+ * Generate the consts based on passed schema
+ * Generated consts will be exported along with model to be used for validation purposes
+ *
+ * @param name Model name
+ * @param schema Model schema
+ */
+export const generateConsts = ({
+  name,
+  schema,
+  context,
+  initialOutput,
+}: {
+  name: string;
+  schema: SchemaObject;
+  context: ContextSpecs;
+  initialOutput?: string;
+}): string => {
+  let output = initialOutput ?? '';
+
+  if (isSchemaObject(schema) && schema.properties) {
+    output += [
+      ...new Set(
+        Object.entries(schema.properties).map(([propName, propSchema]) => {
+          if (isReference(propSchema)) return '';
+          return generateConsts({
+            name: pascal(`${name}-${propName}`),
+            schema: propSchema,
+            context,
+            initialOutput: output,
+          });
+        }),
+      ),
+    ].join('');
+    return output;
+  }
+
+  if (schema.minLength !== undefined) {
+    output += `export const ${name}MinLenght = ${schema.minLength};\n`;
+  }
+
+  if (schema.maxLength !== undefined) {
+    output += `export const ${name}MaxLenght = ${schema.maxLength};\n`;
+  }
+
+  if (schema.minimum !== undefined) {
+    output += `export const ${name}Minimum = ${schema.minimum};\n`;
+  }
+
+  if (schema.maximum !== undefined) {
+    output += `export const ${name}Maximum = ${schema.maximum};\n`;
+  }
+
+  if (schema.exclusiveMaximum !== undefined) {
+    output += `export const ${name}ExclusiveMaximum = ${schema.exclusiveMaximum};\n`;
+  }
+
+  if (schema.exclusiveMinimum !== undefined) {
+    output += `export const ${name}ExclusiveMinimum = ${schema.exclusiveMinimum};\n`;
+  }
+
+  return output;
+};

--- a/packages/core/src/generators/interface.ts
+++ b/packages/core/src/generators/interface.ts
@@ -3,6 +3,7 @@ import { generalJSTypesWithArray } from '../constants';
 import { getScalar } from '../getters';
 import { ContextSpecs } from '../types';
 import { jsDoc } from '../utils';
+import { generateConsts } from './consts';
 
 /**
  * Generate the interface string
@@ -55,6 +56,12 @@ export const generateInterface = ({
   const externalModulesImportsOnly = scalar.imports.filter(
     (importName) => importName.name !== name,
   );
+
+  model += generateConsts({
+    context,
+    name,
+    schema,
+  });
 
   return [
     ...scalar.schemas,

--- a/packages/core/src/generators/schema-definition.ts
+++ b/packages/core/src/generators/schema-definition.ts
@@ -4,6 +4,7 @@ import { getEnum, resolveDiscriminators } from '../getters';
 import { resolveValue } from '../resolvers';
 import { ContextSpecs, GeneratorSchema } from '../types';
 import { upath, isReference, jsDoc, pascal, sanitize } from '../utils';
+import { generateConsts } from './consts';
 import { generateInterface } from './interface';
 
 /**
@@ -91,6 +92,12 @@ export const generateSchemasDefinition = (
         } else {
           output += `export type ${schemaName} = ${resolvedValue.value};\n`;
         }
+
+        output += generateConsts({
+          context,
+          schema,
+          name: schemaName,
+        });
 
         acc.push(...resolvedValue.schemas, {
           name: schemaName,

--- a/samples/react-query/basic/petstore.yaml
+++ b/samples/react-query/basic/petstore.yaml
@@ -154,6 +154,10 @@ components:
       type: object
       required: ['cuteness']
       properties:
+        labraname:
+          type: string
+          minLength: 5
+          maxLength: 50
         cuteness:
           type: integer
     Dachshund:

--- a/samples/react-query/basic/src/api/model/labradoodle.ts
+++ b/samples/react-query/basic/src/api/model/labradoodle.ts
@@ -7,6 +7,9 @@
 import type { LabradoodleBreed } from './labradoodleBreed';
 
 export interface Labradoodle {
+  labraname?: string;
   cuteness: number;
   breed: LabradoodleBreed;
 }
+export const Labradoodle_labraname_minLenght = 5;
+export const Labradoodle_labraname_maxLenght = 50;

--- a/tests/specifications/petstore.yaml
+++ b/tests/specifications/petstore.yaml
@@ -228,6 +228,8 @@ components:
       properties:
         cuteness:
           type: integer
+          minimum: 1
+          maximum: 128
     Dachshund:
       type: object
       required: ['length']
@@ -259,3 +261,4 @@ components:
           format: int32
         message:
           type: string
+          maxLength: 256


### PR DESCRIPTION
## Status

**READY**

## Description

Adds additional keywords export in generated models e.g. **minimum** / **maximum**, **minLength** / **maxLength**.

These could be then used to for validation logic. One could argue that validation should not be part of generated code since it is not exactly related to data fetching / updating logic and it may be better to separate client side validation from data layer, or even use something like https://github.com/igtm/openapi-yup-generator.

But I see it as a very nice improvement in development experience and also do not see big harm in exporting additional keywords as conts. We are not adding restrictions on top of those constants, like wrapping them in Yup schemas or other validation lib, leaving it completely up to client to decide how to use const, or ignore it at all.

I was also thinking that maybe it would be nice to add setting to control const generation? 

Example:

```yaml
    Labradoodle:
      type: object
      required: ['cuteness']
      properties:
        cuteness:
          type: integer
          minimum: 1
          maximum: 128
```

Generated model:

```ts
export interface Labradoodle {
  cuteness: number;
  breed: LabradoodleBreed;
}
export const LabradoodleCutenessMinimum = 1;
export const LabradoodleCutenessMaximum = 128;
```

Client side validation:

```ts
const schema = yup.object().shape({
  cuteness: yup
    .number()
    .required()
    .min(LabradoodleCutenessMinimum)
    .max(LabradoodleCutenessMaximum)
})
```

After this BE can control the client side validation and there is no need to keep duplicated and manually hardcoded value anymore.

## Todos

- [x] Tests - not sure I understood completely how they work, but I added some keywords to basic yaml and saw it in generated
- [ ] Documentation - want to see if that even makes sense @anymaniax  before adding this
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

Outline the steps to test or reproduce the PR here.

```bash
> git pull --prune
> git checkout <branch>
> grunt jasmine
```

1.
