### PR TITLE
🐛 Fix anyOf mocks generation (msw)

### DIFF
--- a/packages/msw/src/getters/combine.ts
+++ b/packages/msw/src/getters/combine.ts
@@ -100,6 +100,7 @@ export const combineSchemasMock = ({
       if (
         resolvedValue.enums ||
         separator === 'oneOf' ||
+        separator === 'anyOf' ||
         resolvedValue.type === 'array'
       ) {
         if (arr.length === 1) {
@@ -122,6 +123,7 @@ export const combineSchemasMock = ({
       if (
         resolvedValue.enums ||
         separator === 'oneOf' ||
+        separator === 'anyOf' ||
         resolvedValue.type === 'array'
       ) {
         return `${acc}${currentValue}${!combine ? '])' : ''}`;

--- a/packages/msw/src/getters/object.ts
+++ b/packages/msw/src/getters/object.ts
@@ -63,7 +63,12 @@ export const getMockObject = ({
   }
 
   if (item.properties) {
-    let value = !combine || combine?.separator === 'oneOf' ? '{' : '';
+    let value =
+      !combine ||
+      combine?.separator === 'oneOf' ||
+      combine?.separator === 'anyOf'
+        ? '{'
+        : '';
     let imports: GeneratorImport[] = [];
     let includedProperties: string[] = [];
     value += Object.entries(item.properties)
@@ -105,7 +110,12 @@ export const getMockObject = ({
       })
       .filter(Boolean)
       .join(', ');
-    value += !combine || combine?.separator === 'oneOf' ? '}' : '';
+    value +=
+      !combine ||
+      combine?.separator === 'oneOf' ||
+      combine?.separator === 'anyOf'
+        ? '}'
+        : '';
     return {
       value,
       imports,

--- a/packages/msw/src/getters/scalar.ts
+++ b/packages/msw/src/getters/scalar.ts
@@ -158,7 +158,7 @@ export const getMockScalar = ({
 
       let mapValue = value;
 
-      if (combine && (!value.startsWith('faker') || !value.startsWith('{'))) {
+      if (combine && !value.startsWith('faker') && !value.startsWith('{')) {
         mapValue = `{${value}}`;
       }
 


### PR DESCRIPTION
## Status

**READY**

## Description

This PR aims to fix the msw package by handling properly "anyOf" types (see the related issue: #755). 

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

Try to generate msw with an object with the following property type :

```json
"propertyAnyOf":{
    "type":"array",
    "items":{
        "type":"object",
        "properties":{
            "id":{
                "type":"string",
                "transform":["trim"]
             },
            "value":{"anyOf":[{"type":"array","items":{"type":"string","transform":["trim"]}},{"type":"object","properties":{},"additionalProperties":true},{"type":"boolean"},{"type":"number"},{"type":"string","transform":["trim"]},{"type":"null"}]}
```

2 problems occured before :

* Brackets were always added leading to types such :
    ```typescript
        faker.helpers.arrayElement([ { Array.from(....) } ])
    ```
    instead of :
    ```typescript
    faker.helpers.arrayElement([ { Array.from(....) } ])
    ```
* Objects inside `faker.helpers.arrayElement` were missing brackets sometimes