### PR TITLE
fix: should use spread options

### DIFF
--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -416,7 +416,7 @@ const generateQueryOptions = ({
   }
 
   const queryConfig = isObject(options)
-    ? ` ${stringify(
+    ? ` ...${stringify(
         omitBy(
           options,
           (_, key) =>
@@ -793,7 +793,7 @@ export const ${camel(
       : `typeof ${operationName}`
   }>>, TError, TData>(${
     !queryOptionsMutator
-      ? `{ queryKey, queryFn, ...${generateQueryOptions({
+      ? `{ queryKey, queryFn, ${generateQueryOptions({
           params,
           options,
           type,

--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -793,7 +793,7 @@ export const ${camel(
       : `typeof ${operationName}`
   }>>, TError, TData>(${
     !queryOptionsMutator
-      ? `{ queryKey, queryFn, ${generateQueryOptions({
+      ? `{ queryKey, queryFn, ...${generateQueryOptions({
           params,
           options,
           type,


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

I encounter this problem when I use the below configuration:

```js
module.exports = {
  openapi: {
  // ...
    output: {
    // ...
      client: 'vue-query',
      override: {
        query: {
          options: {
            retry: 1,
            retryDelay: 3000,
          },
        },
      },
    },
  },
}
```

And the output:

```ts
const query = useQuery<Awaited<ReturnType<typeof listEndpoints>>, TError, TData>({ queryKey, queryFn, {  retry: 1, retryDelay: 3000,  ...queryOptions}}) as UseQueryReturnType<TData, TError> & { queryKey: QueryKey };
```

The query options should also be expanded, as `{ queryKey, queryFn, ...{  retry: 1, retryDelay: 3000,  ...queryOptions}}`.

## Related PRs

List related PRs against other branches:

| branch              | PR       |
| ------------------- | -------- |
| other_pr_production | [link]() |
| other_pr_master     | [link]() |

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

Outline the steps to test or reproduce the PR here.

```bash
> git pull --prune
> git checkout <branch>
> grunt jasmine
```

1.
