### PR TITLE
feat: Add specific type to query key function

### DIFF
--- a/docs/src/pages/guides/react-query.md
+++ b/docs/src/pages/guides/react-query.md
@@ -38,7 +38,8 @@ export const showPetById = (
   return axios.get(`/pets/${petId}`, options);
 };
 
-export const getShowPetByIdQueryKey = (petId: string) => [`/pets/${petId}`];
+export const getShowPetByIdQueryKey = (petId: string) =>
+  [`/pets/${petId}`] as [string];
 
 export const useShowPetById = <
   TData = AsyncReturnType<typeof showPetById>,

--- a/docs/src/pages/guides/svelte-query.md
+++ b/docs/src/pages/guides/svelte-query.md
@@ -38,7 +38,8 @@ export const showPetById = (
   return axios.get(`/pets/${petId}`, options);
 };
 
-export const getShowPetByIdQueryKey = (petId: string) => [`/pets/${petId}`];
+export const getShowPetByIdQueryKey = (petId: string) =>
+  [`/pets/${petId}`] as [string];
 
 export const useShowPetById = <
   TData = AsyncReturnType<typeof showPetById>,

--- a/docs/src/pages/guides/swr.md
+++ b/docs/src/pages/guides/swr.md
@@ -38,7 +38,8 @@ export const showPetById = (
   return axios.get(`/pets/${petId}`, options);
 };
 
-export const getShowPetByIdKey = (petId: string) => [`/pets/${petId}`];
+export const getShowPetByIdKey = (petId: string) =>
+  [`/pets/${petId}`] as [string];
 Re;
 
 export const useShowPetById = <TError = Error>(

--- a/docs/src/pages/guides/vue-query.md
+++ b/docs/src/pages/guides/vue-query.md
@@ -38,7 +38,8 @@ export const showPetById = (
   return axios.get(`/pets/${petId}`, options);
 };
 
-export const getShowPetByIdQueryKey = (petId: string) => [`/pets/${petId}`];
+export const getShowPetByIdQueryKey = (petId: string) =>
+  [`/pets/${petId}`] as [string];
 
 export const useShowPetById = <
   TData = AsyncReturnType<typeof showPetById>,

--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -906,7 +906,13 @@ const generateQueryHook = async (
 
     const queryKeyFn = `export const ${queryKeyFnName} = (${queryKeyProps}) => [\`${route}\`${
       queryParams ? ', ...(params ? [params]: [])' : ''
-    }${body.implementation ? `, ${body.implementation}` : ''}];`;
+    }${body.implementation ? `, ${body.implementation}` : ''}] as ${
+      queryParams
+        ? `[string, ${queryParams.schema.name}${
+            queryParams.isOptional ? '| undefined' : ''
+          }]`
+        : '[string]'
+    };`;
 
     const implementation = `${!queryKeyMutator ? queryKeyFn : ''}
 

--- a/packages/swr/src/index.ts
+++ b/packages/swr/src/index.ts
@@ -323,7 +323,13 @@ const generateSwrHook = (
 
   return `export const ${swrKeyFnName} = (${queryKeyProps}) => [\`${route}\`${
     queryParams ? ', ...(params ? [params]: [])' : ''
-  }${body.implementation ? `, ${body.implementation}` : ''}];
+  }${body.implementation ? `, ${body.implementation}` : ''}] as ${
+    queryParams
+      ? `[string, ${queryParams.schema.name}${
+          queryParams.isOptional ? '| undefined' : ''
+        }]`
+      : '[string]'
+  };
 
     ${generateSwrImplementation({
       operationName,


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

The generated query key function would generate a function with an inferred return type (string | ParamType)[]. We can be more specific by defining [string, ParamType] instead. This is a small change, but more strict types improves the usability and cleanliness of code.

See: https://github.com/anymaniax/orval/issues/500

## Todos

- [ ] Tests
- [x] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

Outline the steps to test or reproduce the PR here.

1. Update a sample
- The query key function now has a strict return type of the following possible forms:
- [ ] [string] when only the route is returned
- [ ] [string, ParamsType] when the params are not optional
- [ ] [string, ParamsType | undefined] when the params are optional
