### PR TITLE
feat(packages): add option to filter generated endpoints

### DIFF
--- a/docs/src/pages/reference/configuration/input.md
+++ b/docs/src/pages/reference/configuration/input.md
@@ -63,6 +63,27 @@ module.exports = {
 
 Example of transformer <a href="https://github.com/anymaniax/orval/blob/master/samples/basic/api/transformer/add-version.js" target="_blank">here</a>
 
+### filters
+
+Type: `Object`.
+
+If specified, Orval only generates the endpoints after applying the filter.
+It is possible to filter on `tags`.
+
+For instance the example below only generates the endpoints that contain the tag `pets`.
+
+```js
+module.exports = {
+  petstore: {
+    input: {
+      filters: {
+        tags: ['pets'],
+      },
+    },
+  },
+};
+```
+
 ### converterOptions
 
 Type: `Object`.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -137,6 +137,9 @@ export type NormalizedInputOptions = {
   override: OverrideInput;
   converterOptions: swagger2openapi.Options;
   parserOptions: SwaggerParserOptions;
+  filters?: {
+    tags?: string[];
+  };
 };
 
 export type OutputClientFunc = (
@@ -169,6 +172,9 @@ export type InputOptions = {
   override?: OverrideInput;
   converterOptions?: swagger2openapi.Options;
   parserOptions?: SwaggerParserOptions;
+  filters?: {
+    tags?: string[];
+  };
 };
 
 export type OutputClient =

--- a/packages/orval/src/api.ts
+++ b/packages/orval/src/api.ts
@@ -7,6 +7,7 @@ import {
   GeneratorSchema,
   getRoute,
   isReference,
+  NormalizedInputOptions,
   NormalizedOutputOptions,
   resolveRef,
 } from '@orval/core';
@@ -21,9 +22,11 @@ import {
 } from './client';
 
 export const getApiBuilder = async ({
+  input,
   output,
   context,
 }: {
+  input: NormalizedInputOptions;
   output: NormalizedOutputOptions;
   context: ContextSpecs;
 }): Promise<GeneratorApiBuilder> => {
@@ -52,6 +55,7 @@ export const getApiBuilder = async ({
 
       let verbsOptions = await generateVerbsOptions({
         verbs: resolvedVerbs,
+        input,
         output,
         route,
         context: resolvedContext,

--- a/packages/orval/src/import-open-api.ts
+++ b/packages/orval/src/import-open-api.ts
@@ -33,6 +33,7 @@ export const importOpenApi = async ({
   const schemas = getApiSchemas({ output, target, workspace, specs });
 
   const api = await getApiBuilder({
+    input,
     output,
     context: {
       specKey: target,

--- a/packages/orval/src/utils/options.ts
+++ b/packages/orval/src/utils/options.ts
@@ -103,6 +103,7 @@ export const normalizeOptions = async (
         parserDefaultOptions,
         inputOptions.parserOptions ?? {},
       ),
+      filters: inputOptions.filters,
     },
     output: {
       target: globalOptions.output


### PR DESCRIPTION
In the case orval is run on a system with a lot of endpoints, it can be useful to limit which endpoints are actually generated.

## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

In the case orval is run on a system with a lot of endpoints, 
it can be useful to limit which endpoints are actually generated.

See: #739 

## Todos

- [ ] Tests
- [x] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

Outline the steps to test or reproduce the PR here.

1. Add a tag that should be filtered out to a orval.config for instance as follows:
```
output: {
      filterTags: ["pets"]
},
```
2. Only end points that contain tag "pets" will be generated.

