### PR TITLE
fix(core): use `bigint` for `int64` types

### DIFF
--- a/packages/core/src/getters/scalar.ts
+++ b/packages/core/src/getters/scalar.ts
@@ -28,7 +28,7 @@ export const getScalar = ({
   switch (item.type) {
     case 'number':
     case 'integer': {
-      let value = 'number';
+      let value = item.format === 'int64' ? 'bigint' : 'number';
       let isEnum = false;
 
       if (item.enum) {


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

There are two types of integers supported in OpenAPI spec: `int32` and `int64`. The current version of `orval`, however, converts all those integers to js `number` and doesn't consider `int64` types as `bigint`.

Check the type of the integer and use `bigint` instead of `number` if it is an `int64`.

Closes #824.
