### PR TITLE
feat(core): add optional flag to force number type instead of bigint

### DIFF
--- a/packages/core/src/getters/scalar.ts
+++ b/packages/core/src/getters/scalar.ts
@@ -28,7 +28,11 @@ export const getScalar = ({
   switch (item.type) {
     case 'number':
     case 'integer': {
-      let value = item.format === 'int64' ? 'bigint' : 'number';
+      let value = context.override.useNumberTypeForBigInt
+        ? 'number'
+        : item.format === 'int64'
+        ? 'bigint'
+        : 'number';
       let isEnum = false;
 
       if (item.enum) {

--- a/packages/core/src/getters/scalar.ts
+++ b/packages/core/src/getters/scalar.ts
@@ -28,11 +28,10 @@ export const getScalar = ({
   switch (item.type) {
     case 'number':
     case 'integer': {
-      let value = context.override.useNumberTypeForBigInt
-        ? 'number'
-        : item.format === 'int64'
-        ? 'bigint'
-        : 'number';
+      let value =
+        item.format === 'int64' && context.override.useBigInt
+          ? 'bigint'
+          : 'number';
       let isEnum = false;
 
       if (item.enum) {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -100,7 +100,7 @@ export type NormalizedOverrideOutput = {
   useDates?: boolean;
   useTypeOverInterfaces?: boolean;
   useDeprecatedOperations?: boolean;
-  useNumberTypeForBigInt?: boolean;
+  useBigInt?: boolean;
 };
 
 export type NormalizedMutator = {
@@ -279,7 +279,7 @@ export type OverrideOutput = {
   useDates?: boolean;
   useTypeOverInterfaces?: boolean;
   useDeprecatedOperations?: boolean;
-  useNumberTypeForBigInt?: boolean;
+  useBigInt?: boolean;
 };
 
 export type OverrideOutputContentType = {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -100,6 +100,7 @@ export type NormalizedOverrideOutput = {
   useDates?: boolean;
   useTypeOverInterfaces?: boolean;
   useDeprecatedOperations?: boolean;
+  useNumberTypeForBigInt?: boolean;
 };
 
 export type NormalizedMutator = {
@@ -278,6 +279,7 @@ export type OverrideOutput = {
   useDates?: boolean;
   useTypeOverInterfaces?: boolean;
   useDeprecatedOperations?: boolean;
+  useNumberTypeForBigInt?: boolean;
 };
 
 export type OverrideOutputContentType = {


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

The recent change from to add support for bigints caused issues in frontend code, as commented [here](https://github.com/anymaniax/orval/issues/824)

So, in this PR, I just added an optional field called `useNumberTypeForBigInt` that when true, forces the typing to always be number, instead of bigint.

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)
