### PR TITLE
feat(zod): Add nullable & nullish to zod output

### DIFF
--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -58,10 +58,8 @@ const generateZodValidationSchemaDefinition = (
   const consts = [];
   const functions: [string, any][] = [];
   const type = resolveZodType(schema.type);
-  const required =
-    schema.default !== undefined
-      ? false
-      : _required ?? !schema.nullable ?? false;
+  const required = schema.default !== undefined ? false : _required ?? false;
+  const nullable = schema.nullable ?? false;
   const min =
     schema.minimum ?? schema.exclusiveMinimum ?? schema.minLength ?? undefined;
   const max =
@@ -200,7 +198,11 @@ const generateZodValidationSchemaDefinition = (
     ]);
   }
 
-  if (!required) {
+  if (!required && nullable) {
+    functions.push(['nullish', undefined]);
+  } else if (nullable) {
+    functions.push(['nullable', undefined]);
+  } else if (!required) {
     functions.push(['optional', undefined]);
   }
 


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

Orval's zod generator will output `optional` even if `nullable: true` is set.
I fixed it to output `nullable` or `nullish` by the conditions.


## Related PRs

List related PRs against other branches:

| branch              | PR       |
| ------------------- | -------- |
| feature_client_zod | [link](https://github.com/anymaniax/orval/pull/785) |

