### PR TITLE
fix(core): use default response object as success/error response

### DIFF
--- a/packages/core/src/getters/response.ts
+++ b/packages/core/src/getters/response.ts
@@ -56,6 +56,13 @@ export const getResponse = ({
       })
     : types;
 
+  const imports = filteredTypes.flatMap(({ imports }) => imports);
+  const schemas = filteredTypes.flatMap(({ schemas }) => schemas);
+
+  const contentTypes = [
+    ...new Set(filteredTypes.map(({ contentType }) => contentType)),
+  ];
+
   const groupedByStatus = filteredTypes.reduce<{
     success: ResReqTypesValue[];
     errors: ResReqTypesValue[];
@@ -71,23 +78,18 @@ export const getResponse = ({
     { success: [], errors: [] },
   );
 
-  const imports = filteredTypes.flatMap(({ imports }) => imports);
-  const schemas = filteredTypes.flatMap(({ schemas }) => schemas);
-
-  const contentTypes = [
-    ...new Set(filteredTypes.map(({ contentType }) => contentType)),
-  ];
-
   const success = groupedByStatus.success
     .map(({ value, formData }) => (formData ? 'Blob' : value))
     .join(' | ');
   const errors = groupedByStatus.errors.map(({ value }) => value).join(' | ');
 
+  const defaultType = filteredTypes.find(({ key }) => key === 'default')?.value;
+
   return {
     imports,
     definition: {
-      success: success || 'unknown',
-      errors: errors || 'unknown',
+      success: success || (defaultType ?? 'unknown'),
+      errors: errors || (defaultType ?? 'unknown'),
     },
     isBlob: success === 'Blob',
     types: groupedByStatus,

--- a/tests/configs/default.config.ts
+++ b/tests/configs/default.config.ts
@@ -64,4 +64,11 @@ export default defineConfig({
       target: '../generated/default/readonly/endpoints.ts',
     },
   },
+  'default-status': {
+    input: '../specifications/default-status.yaml',
+    output: {
+      schemas: '../generated/default/default-status/model',
+      target: '../generated/default/default-status/endpoints.ts',
+    },
+  },
 });

--- a/tests/specifications/default-status.yaml
+++ b/tests/specifications/default-status.yaml
@@ -1,0 +1,73 @@
+openapi: 3.1.0
+info:
+  title: Orval Default Status Test
+  version: 0.0.0
+paths:
+  /default-only:
+    get:
+      operationId: defaultOnly
+      responses:
+        default:
+          description: Default response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Sample'
+  /w-200:
+    get:
+      operationId: with200
+      responses:
+        200:
+          description: 200 response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Sample'
+        default:
+          description: Default response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Sample'
+  /w-400:
+    get:
+      operationId: with400
+      responses:
+        400:
+          description: 400 response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Sample'
+        default:
+          description: Default response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Sample'
+  /w-200-400:
+    get:
+      operationId: with200and400
+      responses:
+        200:
+          description: 200 response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Sample'
+        400:
+          description: 400 response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Sample'
+        default:
+          description: Default response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Sample'
+components:
+  schemas:
+    Sample:
+      type: object


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

As an open API specification, we can utilize the default key as the key for the Responses Object. This serves as a fallback response for any uncovered HTTP status codes.

I have made modifications to consider the specified default response: if there are no success/error responses, the generator will treat the default response as a success/error response.

This behavior aligns with that of the @openapitools/openapi-generator-cli.

## Related PRs

No related PR.

<!--
| branch              | PR       |
| ------------------- | -------- |
| other_pr_production | [link]() |
| other_pr_master     | [link]() |
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

I added new testcase: `default-status.yaml`.

Please run `cd test && yarn generate` and check `tests/generated/default/default-status/endpoints.ts`.
