### PR TITLE
fix(core): capitalize http verb patch

### DIFF
--- a/docs/src/pages/guides/custom-client.md
+++ b/docs/src/pages/guides/custom-client.md
@@ -31,7 +31,7 @@ export const customInstance = async <T>({
   data,
 }: {
   url: string;
-  method: 'get' | 'post' | 'put' | 'delete' | 'PATCH';
+  method: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
   params?: any;
   data?: BodyType<unknown>;
   responseType?: string;

--- a/docs/src/pages/guides/custom-client.md
+++ b/docs/src/pages/guides/custom-client.md
@@ -31,7 +31,7 @@ export const customInstance = async <T>({
   data,
 }: {
   url: string;
-  method: 'get' | 'post' | 'put' | 'delete' | 'patch';
+  method: 'get' | 'post' | 'put' | 'delete' | 'PATCH';
   params?: any;
   data?: BodyType<unknown>;
   responseType?: string;

--- a/docs/src/pages/reference/configuration/output.md
+++ b/docs/src/pages/reference/configuration/output.md
@@ -334,7 +334,7 @@ Possible arguments:
 ```ts
 // based on AxiosRequestConfig
 interface RequestConfig {
-  method: 'get' | 'put' | 'patch' | 'post' | 'delete';
+  method: 'get' | 'put' | 'PATCH' | 'post' | 'delete';
   url: string;
   params?: any;
   data?: any;

--- a/docs/src/pages/reference/configuration/output.md
+++ b/docs/src/pages/reference/configuration/output.md
@@ -334,7 +334,7 @@ Possible arguments:
 ```ts
 // based on AxiosRequestConfig
 interface RequestConfig {
-  method: 'get' | 'put' | 'PATCH' | 'post' | 'delete';
+  method: 'GET' | 'PUT' | 'PATCH' | 'POST' | 'DELETE';
   url: string;
   params?: any;
   data?: any;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -372,15 +372,15 @@ export type HooksOptions<T = HookCommand | NormalizedHookCommand> = Partial<
 
 export type NormalizedHookOptions = HooksOptions<NormalizedHookCommand>;
 
-export type Verbs = 'post' | 'put' | 'get' | 'PATCH' | 'delete' | 'head';
+export type Verbs = 'POST' | 'PUT' | 'GET' | 'PATCH' | 'DELETE' | 'HEAD';
 
 export const Verbs = {
-  POST: 'post' as Verbs,
-  PUT: 'put' as Verbs,
-  GET: 'get' as Verbs,
+  POST: 'POST' as Verbs,
+  PUT: 'PUT' as Verbs,
+  GET: 'GET' as Verbs,
   PATCH: 'PATCH' as Verbs,
-  DELETE: 'delete' as Verbs,
-  HEAD: 'head' as Verbs,
+  DELETE: 'DELETE' as Verbs,
+  HEAD: 'HEAD' as Verbs,
 };
 
 export type ImportOpenApi = {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -372,13 +372,13 @@ export type HooksOptions<T = HookCommand | NormalizedHookCommand> = Partial<
 
 export type NormalizedHookOptions = HooksOptions<NormalizedHookCommand>;
 
-export type Verbs = 'post' | 'put' | 'get' | 'patch' | 'delete' | 'head';
+export type Verbs = 'post' | 'put' | 'get' | 'PATCH' | 'delete' | 'head';
 
 export const Verbs = {
   POST: 'post' as Verbs,
   PUT: 'put' as Verbs,
   GET: 'get' as Verbs,
-  PATCH: 'patch' as Verbs,
+  PATCH: 'PATCH' as Verbs,
   DELETE: 'delete' as Verbs,
   HEAD: 'head' as Verbs,
 };

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -56,7 +56,7 @@ const generateZodValidationSchemaDefinition = (
 ): { functions: [string, any][]; consts: string[] } => {
   if (!schema) return { functions: [], consts: [] };
 
-  const consts = [];
+  const consts: any[] = [];
   const functions: [string, any][] = [];
   const type = resolveZodType(schema.type);
   const required = schema.default !== undefined ? false : _required ?? false;
@@ -357,9 +357,10 @@ const generateZodRoute = (
     | PathItemObject
     | undefined;
 
-  const parameters = spec?.[verb]?.parameters;
-  const requestBody = spec?.[verb]?.requestBody;
-  const response = spec?.[verb]?.responses?.['200'] as
+  const httpVerb = verb?.toString().toLowerCase();
+  const parameters = spec?.[httpVerb]?.parameters;
+  const requestBody = spec?.[httpVerb]?.requestBody;
+  const response = spec?.[httpVerb]?.responses?.['200'] as
     | ResponseObject
     | ReferenceObject;
 

--- a/packages/zod/tsconfig.json
+++ b/packages/zod/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts"],
+  "compilerOptions": {
+        "noImplicitAny": false,
+  }
 }

--- a/samples/react-query/custom-client/src/api/mutator/custom-client.ts
+++ b/samples/react-query/custom-client/src/api/mutator/custom-client.ts
@@ -5,7 +5,7 @@ export const AXIOS_INSTANCE = Axios.create({ baseURL: '' });
 
 type CustomClient<T> = (data: {
   url: string;
-  method: 'get' | 'post' | 'put' | 'delete' | 'patch';
+  method: 'get' | 'post' | 'put' | 'delete' | 'PATCH';
   params?: Record<string, any>;
   headers?: Record<string, any>;
   data?: BodyType<unknown>;

--- a/samples/react-query/custom-client/src/api/mutator/custom-client.ts
+++ b/samples/react-query/custom-client/src/api/mutator/custom-client.ts
@@ -5,7 +5,7 @@ export const AXIOS_INSTANCE = Axios.create({ baseURL: '' });
 
 type CustomClient<T> = (data: {
   url: string;
-  method: 'get' | 'post' | 'put' | 'delete' | 'PATCH';
+  method: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
   params?: Record<string, any>;
   headers?: Record<string, any>;
   data?: BodyType<unknown>;

--- a/tests/mutators/custom-client.ts
+++ b/tests/mutators/custom-client.ts
@@ -5,7 +5,7 @@ export const customClient = async <ResponseType>({
   data,
 }: {
   url: string;
-  method: 'get' | 'post' | 'put' | 'delete' | 'PATCH';
+  method: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
   params?: Record<string, string>;
   data?: BodyType<unknown>;
   headers?: Record<string, string>;

--- a/tests/mutators/custom-client.ts
+++ b/tests/mutators/custom-client.ts
@@ -5,7 +5,7 @@ export const customClient = async <ResponseType>({
   data,
 }: {
   url: string;
-  method: 'get' | 'post' | 'put' | 'delete' | 'patch';
+  method: 'get' | 'post' | 'put' | 'delete' | 'PATCH';
   params?: Record<string, string>;
   data?: BodyType<unknown>;
   headers?: Record<string, string>;


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

READY

## Description

Changed the HTTP verb 'patch' to 'PATCH'. 
PATCH is the only HTTP method that is case sensitive. It needs to be capitalized to work.

## Related PRs

List related PRs against other branches:

None

## Todos

- [x] Tests
- [x] Documentation
- [x] Changelog Entry (unreleased)


