### PR TITLE
fix: use require_tld instead of regex

### DIFF
--- a/packages/core/src/utils/assertion.ts
+++ b/packages/core/src/utils/assertion.ts
@@ -80,8 +80,6 @@ export const isRootKey = (specKey: string, target: string) => {
   return specKey === target;
 };
 
-const LOCALHOST_REGEX = /^https?:\/\/\w+(\.\w+)*(:[0-9]+)?(\/.*)?$/;
-
 export const isUrl = (str: string) => {
-  return validatorIsUrl(str) || LOCALHOST_REGEX.test(str);
+  return validatorIsUrl(str, { require_tld: false });
 };


### PR DESCRIPTION
## Status

**READY**

## Description

In this [commit](https://github.com/anymaniax/orval/commit/11e5dc96901f7a17634f1abc7ae0bafe0407dd0b), `require_tld` usage was removed in favor of a regex. I'm not sure why, but it creates issue with URLs like this one: `http://my-docker-service/docs.json`, which are not recognized.

## Related PRs

List related PRs against other branches: N/A

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

N/A