### PR TITLE
Returns an AxiosResponse on return value

### DIFF
--- a/docs/src/pages/guides/custom-axios.md
+++ b/docs/src/pages/guides/custom-axios.md
@@ -22,7 +22,7 @@ module.exports = {
 ```ts
 // custom-instance.ts
 
-import Axios, { AxiosRequestConfig } from 'axios';
+import Axios, { AxiosRequestConfig, AxiosResponse } from 'axios';
 
 export const AXIOS_INSTANCE = Axios.create({ baseURL: '<BACKEND URL>' }); // use your own URL here or environment variable
 
@@ -30,7 +30,7 @@ export const AXIOS_INSTANCE = Axios.create({ baseURL: '<BACKEND URL>' }); // use
 export const customInstance = <T>(
   config: AxiosRequestConfig,
   options?: AxiosRequestConfig,
-): Promise<T> => {
+): Promise<AxiosResponse<T>> => {
   const source = Axios.CancelToken.source();
   const promise = AXIOS_INSTANCE({
     ...config,


### PR DESCRIPTION
## Status

READY

## Description

Fix #924.
The custom-axios guide returns `Promise<T>`,
But There is no AxiosResponse type, so status etc. are not returned.
Change to "Promise<AxiosResponse<T>" to get status code, etc. in the return value.

see https://orval.dev/guides/custom-axios

## Related PRs

No related PR.

## Steps to Test or Reproduce

see https://orval.dev/guides/custom-axios
