### PR TITLE
feat(msw): allow mock delay override via function

### DIFF
--- a/docs/src/pages/reference/configuration/output.md
+++ b/docs/src/pages/reference/configuration/output.md
@@ -745,9 +745,9 @@ module.exports = {
 
 ##### delay
 
-Type: `number`.
+Type: `number` or `Function`.
 
-Give you the possibility to set delay time for mock
+Give you the possibility to set delay time for mock. It can either be a fixed number or a function that returns a number.
 
 Default Value: `1000`
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -66,7 +66,7 @@ export type NormalizedOverrideOutput = {
     format?: { [key: string]: unknown };
     required?: boolean;
     baseUrl?: string;
-    delay?: number;
+    delay?: number | (() => number);
   };
   contentType?: OverrideOutputContentType;
   header: false | ((info: InfoObject) => string[] | string);

--- a/packages/msw/src/index.ts
+++ b/packages/msw/src/index.ts
@@ -4,6 +4,7 @@ import {
   GeneratorDependency,
   GeneratorOptions,
   GeneratorVerbOptions,
+  NormalizedOverrideOutput,
   pascal,
 } from '@orval/core';
 import { getRouteMSW } from './getters';
@@ -34,6 +35,18 @@ export const generateMSWImports: GenerateMockImports = ({
     hasSchemaDir,
     isAllowSyntheticDefaultImports,
   );
+};
+
+const getDelay = (override?: NormalizedOverrideOutput): number => {
+  const overrideDelay = override?.mock?.delay;
+  switch (typeof overrideDelay) {
+    case 'function':
+      return overrideDelay();
+    case 'number':
+      return overrideDelay;
+    default:
+      return 1000;
+  }
 };
 
 export const generateMSW = (
@@ -73,7 +86,7 @@ export const generateMSW = (
           : '',
       handler: `rest.${verb}('${route}', (_req, res, ctx) => {
         return res(
-          ctx.delay(${override?.mock?.delay ?? 1000}),
+          ctx.delay(${getDelay(override)}),
           ctx.status(200, 'Mocked status'),${
             value && value !== 'undefined'
               ? `\nctx.${responseType}(get${pascal(operationId)}Mock()),`


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

This adds the possibility to override MSW mocks with a dynamic delay using a function that returns a number, making API calls more similar to real-world ones, where responses can potentially come back at different times:

```js
{
  // ... other options ...
  override: {
    mock: {
      delay: () => { ... }
    }
  }
}
```

This change is backwards compatible and the previous default value has been maintained.

## Todos

- [ ] Tests
- [X] Documentation
- [ ] Changelog Entry (unreleased)
