### PR TITLE
fix(useNamedParameters): use operationName instead of operationId

### DIFF
--- a/packages/core/src/generators/verbs-options.ts
+++ b/packages/core/src/generators/verbs-options.ts
@@ -130,7 +130,7 @@ const generateVerbOptions = async ({
     queryParams,
     params,
     headers,
-    operationId,
+    operationName,
     context,
   });
 

--- a/packages/core/src/getters/props.ts
+++ b/packages/core/src/getters/props.ts
@@ -12,14 +12,14 @@ export const getProps = ({
   body,
   queryParams,
   params,
-  operationId,
+  operationName,
   headers,
   context,
 }: {
   body: GetterBody;
   queryParams?: GetterQueryParam;
   params: GetterParams;
-  operationId: string;
+  operationName: string;
   headers?: GetterQueryParam;
   context: ContextSpecs;
 }): GetterProps => {
@@ -62,7 +62,7 @@ export const getProps = ({
 
   let paramGetterProps: GetterProps;
   if (context.override.useNamedParameters && params.length > 0) {
-    const parameterTypeName = `${pascal(operationId)}PathParameters`;
+    const parameterTypeName = `${pascal(operationName)}PathParameters`;
 
     const name = 'pathParams';
 


### PR DESCRIPTION
## Status

**READY**

## Description

This feature was using `operationId` to construct the `PathParameters` name. For consistency, it would be better to use `operationName` as it can be mapped to something by users.

## Related PRs

List related PRs against other branches:

| branch              | PR       |
| ------------------- | -------- |
| other_pr_production | [link]() |
| other_pr_master     | [link]() |

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

Outline the steps to test or reproduce the PR here.

```bash
> git pull --prune
> git checkout <branch>
> grunt jasmine
```

1.
