### PR TITLE
feat(msw): allow regex for entire paths instead of only property names

### DIFF
--- a/docs/src/pages/reference/configuration/output.md
+++ b/docs/src/pages/reference/configuration/output.md
@@ -681,7 +681,7 @@ Give you the possibility to override the generated mock
 
 Type: `Object` or `Function`.
 
-You can use this to override the generated mock per property. Properties can take a function who take the specification in argument and should return un object or directly the object. Each key of this object can be a regex or directly the name of the property to override and the value can be a function which return the wanted value or directly the value. If you use a function this will be executed at runtime.
+You can use this to override the generated mock per property. Properties can take a function who take the specification in argument and should return un object or directly the object. Each key of this object can be a regex or directly the path of the property to override and the value can be a function which return the wanted value or directly the value. If you use a function this will be executed at runtime.
 
 ```js
 module.exports = {
@@ -690,8 +690,10 @@ module.exports = {
       override: {
         mock: {
           properties: {
-            '/tag|name/': 'jon',
-            email: () => faker.internet.email(),
+            '/tag|name/': 'jon', // Matches every property named 'tag' or 'name', including nested ones
+            '/.*\.user\.id/': faker.string.uuid(), // Matches every property named 'id', inside an object named 'user', including nested ones
+            email: () => faker.internet.email(), // Matches only the property 'email'
+            'user.id': () => faker.string.uuid(), // Matches only the full path 'user.id'
           },
         },
       },

--- a/packages/msw/src/resolvers/value.ts
+++ b/packages/msw/src/resolvers/value.ts
@@ -16,15 +16,16 @@ export const resolveMockOverride = (
   properties: Record<string, string> | undefined = {},
   item: SchemaObject & { name: string; path?: string },
 ) => {
+  const path = item.path ? item.path : `#.${item.name}`;
   const property = Object.entries(properties).find(([key]) => {
     if (isRegex(key)) {
       const regex = new RegExp(key.slice(1, key.length - 1));
-      if (regex.test(item.name)) {
+      if (regex.test(item.name) || regex.test(path)) {
         return true;
       }
     }
 
-    if (`#.${key}` === (item.path ? item.path : `#.${item.name}`)) {
+    if (`#.${key}` === path) {
       return true;
     }
 


### PR DESCRIPTION
## Status

**READY**

## Description

Resolves #938.

Allows path regex comparison for mock properties, making it possible for nested properties to be overriden across multiple endpoints.

This could previously be achieved by overriding the parent property, but that required manually mocking all of the parent's properties. Another possibility was to override the child property directly, but this could cause issues if the value had to be different depending on it's parents.

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)
