### PR TITLE
fix: make order of imports and object properties deterministic

### DIFF
--- a/packages/core/src/generators/imports.ts
+++ b/packages/core/src/generators/imports.ts
@@ -140,7 +140,9 @@ const generateDependency = ({
     deps
       .filter((e) => !e.default && !e.syntheticDefaultImport)
       .map(({ name, alias }) => (alias ? `${name} as ${alias}` : name)),
-  ).join(',\n  ');
+  )
+    .sort()
+    .join(',\n  ');
 
   let importString = '';
 
@@ -246,6 +248,11 @@ export const addDependency = ({
     .join('\n');
 };
 
+const getLibName = (code: string) => {
+  const splitString = code.split(' from ');
+  return splitString[splitString.length - 1].split(';')[0].trim();
+};
+
 export const generateDependencyImports = (
   implementation: string,
   imports: {
@@ -267,6 +274,19 @@ export const generateDependencyImports = (
       }),
     )
     .filter(Boolean)
+    .sort((a, b) => {
+      const aLib = getLibName(a!);
+      const bLib = getLibName(b!);
+
+      if (aLib === bLib) {
+        return 0;
+      }
+
+      if (aLib.startsWith("'.") && !bLib.startsWith("'.")) {
+        return 1;
+      }
+      return aLib < bLib ? -1 : 1;
+    })
     .join('\n');
 
   return dependencies ? dependencies + '\n' : '';

--- a/packages/core/src/getters/object.ts
+++ b/packages/core/src/getters/object.ts
@@ -58,90 +58,94 @@ export const getObject = ({
   }
 
   if (item.properties && Object.entries(item.properties).length > 0) {
-    return Object.entries(item.properties).reduce(
-      (
-        acc,
-        [key, schema]: [string, ReferenceObject | SchemaObject],
-        index,
-        arr,
-      ) => {
-        const isRequired = (
-          Array.isArray(item.required) ? item.required : []
-        ).includes(key);
+    return Object.entries(item.properties)
+      .sort((a, b) => {
+        return a[0].localeCompare(b[0]);
+      })
+      .reduce(
+        (
+          acc,
+          [key, schema]: [string, ReferenceObject | SchemaObject],
+          index,
+          arr,
+        ) => {
+          const isRequired = (
+            Array.isArray(item.required) ? item.required : []
+          ).includes(key);
 
-        let propName = '';
+          let propName = '';
 
-        if (name) {
-          const isKeyStartWithUnderscore = key.startsWith('_');
+          if (name) {
+            const isKeyStartWithUnderscore = key.startsWith('_');
 
-          propName += pascal(
-            `${isKeyStartWithUnderscore ? '_' : ''}${name}_${key}`,
-          );
-        }
-
-        const allSpecSchemas =
-          context.specs[context.target]?.components?.schemas ?? {};
-
-        const isNameAlreadyTaken = Object.keys(allSpecSchemas).some(
-          (schemaName) => pascal(schemaName) === propName,
-        );
-
-        if (isNameAlreadyTaken) {
-          propName = propName + 'Property';
-        }
-
-        const resolvedValue = resolveObject({
-          schema,
-          propName,
-          context,
-        });
-
-        const isReadOnly = item.readOnly || (schema as SchemaObject).readOnly;
-        if (!index) {
-          acc.value += '{';
-        }
-
-        const doc = jsDoc(schema as SchemaObject, true);
-
-        acc.hasReadonlyProps ||= isReadOnly || false;
-        acc.imports.push(...resolvedValue.imports);
-        acc.value += `\n  ${doc ? `${doc}  ` : ''}${
-          isReadOnly ? 'readonly ' : ''
-        }${getKey(key)}${isRequired ? '' : '?'}: ${resolvedValue.value};`;
-        acc.schemas.push(...resolvedValue.schemas);
-
-        if (arr.length - 1 === index) {
-          if (item.additionalProperties) {
-            if (isBoolean(item.additionalProperties)) {
-              acc.value += `\n  [key: string]: any;\n }`;
-            } else {
-              const resolvedValue = resolveValue({
-                schema: item.additionalProperties,
-                name,
-                context,
-              });
-              acc.value += `\n  [key: string]: ${resolvedValue.value};\n}`;
-            }
-          } else {
-            acc.value += '\n}';
+            propName += pascal(
+              `${isKeyStartWithUnderscore ? '_' : ''}${name}_${key}`,
+            );
           }
 
-          acc.value += nullable;
-        }
+          const allSpecSchemas =
+            context.specs[context.target]?.components?.schemas ?? {};
 
-        return acc;
-      },
-      {
-        imports: [],
-        schemas: [],
-        value: '',
-        isEnum: false,
-        type: 'object' as SchemaType,
-        isRef: false,
-        schema: {},
-        hasReadonlyProps: false,
-      } as ScalarValue,
-    );
+          const isNameAlreadyTaken = Object.keys(allSpecSchemas).some(
+            (schemaName) => pascal(schemaName) === propName,
+          );
+
+          if (isNameAlreadyTaken) {
+            propName = propName + 'Property';
+          }
+
+          const resolvedValue = resolveObject({
+            schema,
+            propName,
+            context,
+          });
+
+          const isReadOnly = item.readOnly || (schema as SchemaObject).readOnly;
+          if (!index) {
+            acc.value += '{';
+          }
+
+          const doc = jsDoc(schema as SchemaObject, true);
+
+          acc.hasReadonlyProps ||= isReadOnly || false;
+          acc.imports.push(...resolvedValue.imports);
+          acc.value += `\n  ${doc ? `${doc}  ` : ''}${
+            isReadOnly ? 'readonly ' : ''
+          }${getKey(key)}${isRequired ? '' : '?'}: ${resolvedValue.value};`;
+          acc.schemas.push(...resolvedValue.schemas);
+
+          if (arr.length - 1 === index) {
+            if (item.additionalProperties) {
+              if (isBoolean(item.additionalProperties)) {
+                acc.value += `\n  [key: string]: any;\n }`;
+              } else {
+                const resolvedValue = resolveValue({
+                  schema: item.additionalProperties,
+                  name,
+                  context,
+                });
+                acc.value += `\n  [key: string]: ${resolvedValue.value};\n}`;
+              }
+            } else {
+              acc.value += '\n}';
+            }
+
+            acc.value += nullable;
+          }
+
+          return acc;
+        },
+        {
+          imports: [],
+          schemas: [],
+          value: '',
+          isEnum: false,
+          type: 'object' as SchemaType,
+          isRef: false,
+          schema: {},
+          hasReadonlyProps: false,
+        } as ScalarValue,
+      );
   }
 
   if (item.additionalProperties) {

--- a/packages/msw/src/getters/object.ts
+++ b/packages/msw/src/getters/object.ts
@@ -72,6 +72,9 @@ export const getMockObject = ({
     let imports: GeneratorImport[] = [];
     let includedProperties: string[] = [];
     value += Object.entries(item.properties)
+      .sort((a, b) => {
+        return a[0].localeCompare(b[0]);
+      })
       .map(([key, prop]: [string, ReferenceObject | SchemaObject]) => {
         if (combine?.includedProperties.includes(key)) {
           return undefined;

--- a/packages/msw/src/getters/scalar.ts
+++ b/packages/msw/src/getters/scalar.ts
@@ -46,13 +46,17 @@ export const getMockScalar = ({
     return operationProperty;
   }
 
-  const overrideTag = Object.entries(mockOptions?.tags ?? {}).reduce<{
-    properties: Record<string, string>;
-  }>(
-    (acc, [tag, options]) =>
-      tags.includes(tag) ? mergeDeep(acc, options) : acc,
-    {} as { properties: Record<string, string> },
-  );
+  const overrideTag = Object.entries(mockOptions?.tags ?? {})
+    .sort((a, b) => {
+      return a[0].localeCompare(b[0]);
+    })
+    .reduce<{
+      properties: Record<string, string>;
+    }>(
+      (acc, [tag, options]) =>
+        tags.includes(tag) ? mergeDeep(acc, options) : acc,
+      {} as { properties: Record<string, string> },
+    );
 
   const tagProperty = resolveMockOverride(overrideTag?.properties, item);
 


### PR DESCRIPTION
## Status

**READY**

## Description

Resolves #703 and #780.

Currently the order of imports and properties inside an object may vary between executions, generating unnecessary diffs. The changes here were to simply sort those fields during code generation.
