### PR TITLE
feat(orval): allow custom baseUrl for each OpenAPI specification

### DIFF
--- a/docs/src/pages/guides/set-base-url.md
+++ b/docs/src/pages/guides/set-base-url.md
@@ -1,16 +1,30 @@
 ## Use your own base url
 
-orval doesn't set any base url by default but you have multiple possibility to add it
+Orval allows you to set a custom base url for each OpenAPI specification. This can be a part of the url that's been omitted from the specification or the entire url.
+
+```ts
+module.exports = {
+  petstore: {
+    output: {
+      target: 'src/petstore.ts',
+      baseUrl: '/api/v2',
+      // baseUrl: 'https://petstore.swagger.io/v2',
+    },
+  },
+};
+```
+
+It's also possible to configure the base url directly on your HTTP client instead.
 
 ### Axios
 
-You can set a default baseUrl
+You can set a default baseUrl for all requests:
 
 ```ts
-Axios.defaults.baseURL = '<BACKEND URL>'; // use your own URL here or environment variable
+axios.defaults.baseURL = '<BACKEND URL>'; // use your own URL here or environment variable
 ```
 
-You can also use an interceptor to do it
+You can also use an interceptor to do it:
 
 ```ts
 axios.interceptors.request.use((config) => {
@@ -21,16 +35,50 @@ axios.interceptors.request.use((config) => {
 });
 ```
 
-There is also the possibilty to create a custom axios instance
+There is also the possibility to create a custom axios instance. Check the [full guide](../guides/custom-axios.md) for more details.
 
 ```ts
-const AXIOS_INSTANCE = Axios.create({ baseURL: '<BACKEND URL>' }); // use your own URL here or environment variable
+const AXIOS_INSTANCE = axios.create({ baseURL: '<BACKEND URL>' }); // use your own URL here or environment variable
 ```
 
 ### Angular http client
 
 You can use an interceptor to automatically add the url of your API. Like you would do to add an authorization header.
 
+```ts
+import { Injectable } from '@angular/core';
+import {
+  HttpEvent,
+  HttpInterceptor,
+  HttpHandler,
+  HttpRequest,
+} from '@angular/common/http';
+import { Observable } from 'rxjs/Observable';
+
+@Injectable()
+export class APIInterceptor implements HttpInterceptor {
+  intercept(
+    req: HttpRequest<any>,
+    next: HttpHandler,
+  ): Observable<HttpEvent<any>> {
+    const apiReq = req.clone({ url: `<BACKEND URL>/${req.url}` });
+    return next.handle(apiReq);
+  }
+}
+```
+
+Also remember to add the interceptor to your providers in your module.
+
+```ts
+providers: [
+  {
+    provide: HTTP_INTERCEPTORS,
+    useClass: APIInterceptor,
+    multi: true,
+  },
+];
+```
+
 ### Other client
 
-Depending the client that you are using you will need to add it by yourself
+Depending on the client that you are using, you will need to add it by yourself

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -52,6 +52,7 @@ export type NormalizedOutputOptions = {
   packageJson?: PackageJson;
   headers: boolean;
   indexFiles: boolean;
+  baseUrl?: string;
 };
 
 export type NormalizedOverrideOutput = {
@@ -165,6 +166,7 @@ export type OutputOptions = {
   packageJson?: string;
   headers?: boolean;
   indexFiles?: boolean;
+  baseUrl?: string;
 };
 
 export type SwaggerParserOptions = Omit<SwaggerParser.Options, 'validate'> & {

--- a/packages/orval/src/api.ts
+++ b/packages/orval/src/api.ts
@@ -95,11 +95,18 @@ export const getApiBuilder = async ({
         [] as GeneratorSchema[],
       );
 
+      let fullRoute = route;
+      if (output.baseUrl) {
+        if (output.baseUrl.endsWith('/') && route.startsWith('/')) {
+          fullRoute = route.slice(1);
+        }
+        fullRoute = `${output.baseUrl}${fullRoute}`;
+      }
       const pathOperations = await generateOperations(
         output.client,
         verbsOptions,
         {
-          route,
+          route: fullRoute,
           pathRoute,
           override: output.override,
           context: resolvedContext,

--- a/packages/orval/src/utils/options.ts
+++ b/packages/orval/src/utils/options.ts
@@ -121,6 +121,7 @@ export const normalizeOptions = async (
       packageJson,
       headers: outputOptions.headers ?? false,
       indexFiles: outputOptions.indexFiles ?? true,
+      baseUrl: outputOptions.baseUrl,
       override: {
         ...outputOptions.override,
         mock: {


### PR DESCRIPTION
## Status

**READY**

## Description

Resolves #865.

Allows `baseUrl` configuration directly via Orval. Previous configuration methods still work, so no breaking changes.

`baseUrl` can be defined under `output` for each OpenAPI specification, allowing urls to be different without the need for multiple custom client instances.

