### PR TITLE
Make react query's `queryKey` optional.

### DIFF
--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -538,6 +538,7 @@ const getQueryOptionsDefinition = ({
   hasQueryV5,
   queryParams,
   queryParam,
+  isReturnType
 }: {
   operationName: string;
   definitions: string;
@@ -547,9 +548,11 @@ const getQueryOptionsDefinition = ({
   hasQueryV5: boolean;
   queryParams?: GetterQueryParam;
   queryParam?: string;
+  isReturnType: boolean;
 }) => {
   const isMutatorHook = mutator?.isHook;
   const prefix = !hasSvelteQueryV4 ? 'Use' : 'Create';
+  const partialOptions = !isReturnType && hasQueryV5;
 
   if (type) {
     const funcReturnType = `Awaited<ReturnType<${
@@ -558,14 +561,14 @@ const getQueryOptionsDefinition = ({
         : `typeof ${operationName}`
     }>>`;
 
-    return `${prefix}${pascal(type)}Options<${funcReturnType}, TError, TData${
+    return `${partialOptions ? 'WithOptional<':''}${prefix}${pascal(type)}Options<${funcReturnType}, TError, TData${
       hasQueryV5 &&
       (type === QueryType.INFINITE || type === QueryType.SUSPENSE_INFINITE) &&
       queryParam &&
       queryParams
         ? `, ${funcReturnType}, QueryKey, ${queryParams?.schema.name}['${queryParam}']`
         : ''
-    }>`;
+    }>${partialOptions ? ', "queryKey">':''}`;
   }
 
   return `${prefix}MutationOptions<Awaited<ReturnType<${
@@ -605,6 +608,7 @@ const generateQueryArguments = ({
     hasQueryV5,
     queryParams,
     queryParam,
+    isReturnType: false
   });
 
   if (!isRequestOptions) {
@@ -883,6 +887,7 @@ const generateQueryImplementation = ({
     hasQueryV5,
     queryParams,
     queryParam,
+    isReturnType: true
   });
 
   const queryOptionsImp = generateQueryOptions({
@@ -910,7 +915,7 @@ const generateQueryImplementation = ({
       : `Awaited<ReturnType<${dataType}>>`;
 
   const queryOptionsFn = `export const ${queryOptionsFnName} = <TData = ${TData}, TError = ${errorType}>(${queryProps} ${queryArguments}) => {
-    
+
 ${hookOptions}
 
   const queryKey =  ${
@@ -930,7 +935,7 @@ ${hookOptions}
       ? `const ${operationName} =  use${pascal(operationName)}Hook();`
       : ''
   }
-  
+
     const queryFn: QueryFunction<Awaited<ReturnType<${
       mutator?.isHook
         ? `ReturnType<typeof use${pascal(operationName)}Hook>`
@@ -952,7 +957,7 @@ ${hookOptions}
             )
           : ''
       }
-    
+
       ${
         queryOptionsMutator
           ? `const customOptions = ${
@@ -964,7 +969,7 @@ ${hookOptions}
             });`
           : ''
       }
-      
+
    return  ${
      !queryOptionsMutator
        ? `{ queryKey, queryFn, ${queryOptionsImp}}`
@@ -1251,6 +1256,7 @@ const generateQueryHook = async (
       mutator,
       hasSvelteQueryV4,
       hasQueryV5,
+      isReturnType: true
     });
 
     const mutationArguments = generateQueryArguments({
@@ -1322,7 +1328,7 @@ const generateQueryHook = async (
             : ''
         }
 
- 
+
    return  ${
      !mutationOptionsMutator
        ? '{ mutationFn, ...mutationOptions }'
@@ -1353,11 +1359,11 @@ ${mutationOptionsFn}
     )} = <TError = ${errorType},
     ${!definitions ? `TVariables = void,` : ''}
     TContext = unknown>(${mutationArguments}) => {
-    
+
       const ${mutationOptionsVarName} = ${mutationOptionsFnName}(${
       isRequestOptions ? 'options' : 'mutationOptions'
     });
-     
+
       return ${operationPrefix}Mutation(${mutationOptionsVarName});
     }
     `;
@@ -1394,7 +1400,9 @@ ${
   ? P
   : never;\n\n`
     : ''
-}`;
+}
+type WithOptional<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
+`;
 };
 
 export const generateQuery: ClientBuilder = async (

--- a/samples/react-query/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/react-query/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -71,6 +71,7 @@ type AwaitedInput<T> = PromiseLike<T> | T;
 
 type Awaited<O> = O extends AwaitedInput<infer T> ? T : never;
 
+type WithOptional<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
 /**
  * @summary List all pets
  */
@@ -96,13 +97,16 @@ export const getListPetsInfiniteQueryOptions = <
   params?: ListPetsParams,
   version = 1,
   options?: {
-    query?: UseInfiniteQueryOptions<
-      Awaited<ReturnType<typeof listPets>>,
-      TError,
-      TData,
-      Awaited<ReturnType<typeof listPets>>,
-      QueryKey,
-      ListPetsParams['limit']
+    query?: WithOptional<
+      UseInfiniteQueryOptions<
+        Awaited<ReturnType<typeof listPets>>,
+        TError,
+        TData,
+        Awaited<ReturnType<typeof listPets>>,
+        QueryKey,
+        ListPetsParams['limit']
+      >,
+      'queryKey'
     >;
   },
 ) => {
@@ -150,13 +154,16 @@ export const useListPetsInfinite = <
   params?: ListPetsParams,
   version = 1,
   options?: {
-    query?: UseInfiniteQueryOptions<
-      Awaited<ReturnType<typeof listPets>>,
-      TError,
-      TData,
-      Awaited<ReturnType<typeof listPets>>,
-      QueryKey,
-      ListPetsParams['limit']
+    query?: WithOptional<
+      UseInfiniteQueryOptions<
+        Awaited<ReturnType<typeof listPets>>,
+        TError,
+        TData,
+        Awaited<ReturnType<typeof listPets>>,
+        QueryKey,
+        ListPetsParams['limit']
+      >,
+      'queryKey'
     >;
   },
 ): UseInfiniteQueryResult<TData, TError> & { queryKey: QueryKey } => {
@@ -183,10 +190,9 @@ export const getListPetsQueryOptions = <
   params?: ListPetsParams,
   version = 1,
   options?: {
-    query?: UseQueryOptions<
-      Awaited<ReturnType<typeof listPets>>,
-      TError,
-      TData
+    query?: WithOptional<
+      UseQueryOptions<Awaited<ReturnType<typeof listPets>>, TError, TData>,
+      'queryKey'
     >;
   },
 ) => {
@@ -223,10 +229,9 @@ export const useListPets = <
   params?: ListPetsParams,
   version = 1,
   options?: {
-    query?: UseQueryOptions<
-      Awaited<ReturnType<typeof listPets>>,
-      TError,
-      TData
+    query?: WithOptional<
+      UseQueryOptions<Awaited<ReturnType<typeof listPets>>, TError, TData>,
+      'queryKey'
     >;
   },
 ): UseQueryResult<TData, TError> & { queryKey: QueryKey } => {
@@ -248,10 +253,13 @@ export const getListPetsSuspenseQueryOptions = <
   params?: ListPetsParams,
   version = 1,
   options?: {
-    query?: UseSuspenseQueryOptions<
-      Awaited<ReturnType<typeof listPets>>,
-      TError,
-      TData
+    query?: WithOptional<
+      UseSuspenseQueryOptions<
+        Awaited<ReturnType<typeof listPets>>,
+        TError,
+        TData
+      >,
+      'queryKey'
     >;
   },
 ) => {
@@ -290,10 +298,13 @@ export const useListPetsSuspense = <
   params?: ListPetsParams,
   version = 1,
   options?: {
-    query?: UseSuspenseQueryOptions<
-      Awaited<ReturnType<typeof listPets>>,
-      TError,
-      TData
+    query?: WithOptional<
+      UseSuspenseQueryOptions<
+        Awaited<ReturnType<typeof listPets>>,
+        TError,
+        TData
+      >,
+      'queryKey'
     >;
   },
 ): UseSuspenseQueryResult<TData, TError> & { queryKey: QueryKey } => {
@@ -323,13 +334,16 @@ export const getListPetsSuspenseInfiniteQueryOptions = <
   params?: ListPetsParams,
   version = 1,
   options?: {
-    query?: UseSuspenseInfiniteQueryOptions<
-      Awaited<ReturnType<typeof listPets>>,
-      TError,
-      TData,
-      Awaited<ReturnType<typeof listPets>>,
-      QueryKey,
-      ListPetsParams['limit']
+    query?: WithOptional<
+      UseSuspenseInfiniteQueryOptions<
+        Awaited<ReturnType<typeof listPets>>,
+        TError,
+        TData,
+        Awaited<ReturnType<typeof listPets>>,
+        QueryKey,
+        ListPetsParams['limit']
+      >,
+      'queryKey'
     >;
   },
 ) => {
@@ -377,13 +391,16 @@ export const useListPetsSuspenseInfinite = <
   params?: ListPetsParams,
   version = 1,
   options?: {
-    query?: UseSuspenseInfiniteQueryOptions<
-      Awaited<ReturnType<typeof listPets>>,
-      TError,
-      TData,
-      Awaited<ReturnType<typeof listPets>>,
-      QueryKey,
-      ListPetsParams['limit']
+    query?: WithOptional<
+      UseSuspenseInfiniteQueryOptions<
+        Awaited<ReturnType<typeof listPets>>,
+        TError,
+        TData,
+        Awaited<ReturnType<typeof listPets>>,
+        QueryKey,
+        ListPetsParams['limit']
+      >,
+      'queryKey'
     >;
   },
 ): UseSuspenseInfiniteQueryResult<TData, TError> & { queryKey: QueryKey } => {
@@ -562,10 +579,9 @@ export const getShowPetByIdQueryOptions = <
   petId: string,
   version = 1,
   options?: {
-    query?: UseQueryOptions<
-      Awaited<ReturnType<typeof showPetById>>,
-      TError,
-      TData
+    query?: WithOptional<
+      UseQueryOptions<Awaited<ReturnType<typeof showPetById>>, TError, TData>,
+      'queryKey'
     >;
   },
 ) => {
@@ -605,10 +621,9 @@ export const useShowPetById = <
   petId: string,
   version = 1,
   options?: {
-    query?: UseQueryOptions<
-      Awaited<ReturnType<typeof showPetById>>,
-      TError,
-      TData
+    query?: WithOptional<
+      UseQueryOptions<Awaited<ReturnType<typeof showPetById>>, TError, TData>,
+      'queryKey'
     >;
   },
 ): UseQueryResult<TData, TError> & { queryKey: QueryKey } => {


### PR DESCRIPTION
#975

This changes the query options to mark `queryKey` as optional in function arguments. This allows the `use___` hooks to add query options but not force overriding the query key as well. The query key is set internally in the generated code if not present so should be safe to make optional

Example - this no longer yields a typescript error about the `queryKey` option:
```tsx
const { data: pets, refetch } = useListPets(undefined, 1, {
    query: {
      staleTime: 5000
    }
  });
```