### PR TITLE
Don't use name with suffix when resolving discriminators

### DIFF
--- a/packages/core/src/getters/discriminators.ts
+++ b/packages/core/src/getters/discriminators.ts
@@ -1,6 +1,7 @@
 import { SchemasObject } from 'openapi3-ts';
 import { ContextSpecs } from '../types';
 import { getRefInfo } from './ref';
+import { pascal } from "../utils";
 
 export const resolveDiscriminators = (
   schemas: SchemasObject,
@@ -16,7 +17,9 @@ export const resolveDiscriminators = (
         let subTypeSchema;
 
         try {
-          const { name } = getRefInfo(mappingValue, context);
+          const { originalName } = getRefInfo(mappingValue, context);
+          // name from getRefInfo may contain a suffix, which we don't want
+          const name = pascal(originalName)
           subTypeSchema = transformedSchemas[name];
         } catch (e) {
           subTypeSchema = transformedSchemas[mappingValue];


### PR DESCRIPTION
## Status
**READY**

## Description
When Orval is configured to use a suffix in schemas, like
```
output: {
  override: {
    components: {
      schemas: {
        suffix: 'Schema'
      }
    }
  }
}
```
discriminators are not well resolved.

The reason is that discriminators are resolved before renaming the schemas, but using `getRefInfo` will return a name that includes the suffix. As a consequence, the schema will not be found in `transformedSchemas` and the generated code will not include the property name for the discriminator.
