### PR TITLE
feat: changed cuids in MSW to dynamic faker strings to prevent file c…

### DIFF
--- a/packages/msw/src/constants.ts
+++ b/packages/msw/src/constants.ts
@@ -26,3 +26,5 @@ export const DEFAULT_FORMAT_MOCK: Record<
   uuid: 'faker.string.uuid()',
   zipCode: 'faker.location.zipCode()',
 };
+
+export const DEFAULT_OBJECT_KEY_MOCK = 'faker.string.alphanumeric(5)';

--- a/packages/msw/src/constants.ts
+++ b/packages/msw/src/constants.ts
@@ -27,4 +27,5 @@ export const DEFAULT_FORMAT_MOCK: Record<
   zipCode: 'faker.location.zipCode()',
 };
 
+// #980 replace CUID so tests are consistent
 export const DEFAULT_OBJECT_KEY_MOCK = 'faker.string.alphanumeric(5)';

--- a/packages/msw/src/getters/object.ts
+++ b/packages/msw/src/getters/object.ts
@@ -12,6 +12,7 @@ import { ReferenceObject, SchemaObject } from 'openapi3-ts';
 import { resolveMockValue } from '../resolvers/value';
 import { MockDefinition, MockSchemaObject } from '../types';
 import { combineSchemasMock } from './combine';
+import { DEFAULT_OBJECT_KEY_MOCK } from '../constants';
 
 export const getMockObject = ({
   item,
@@ -148,7 +149,7 @@ export const getMockObject = ({
     return {
       ...resolvedValue,
       value: `{
-        '${cuid()}': ${resolvedValue.value}
+        '[${DEFAULT_OBJECT_KEY_MOCK}]': ${resolvedValue.value}
       }`,
     };
   }


### PR DESCRIPTION
…hanges on each generation

Fix #974

## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

Changed on the MSW mock generation to make the key a 5 character alpha numeric string as the key. As the repo has no setup for testing with msw at this current time, no testing was needing to be added.
