### PR TITLE
fix(react-query): do not partialize required query options

### DIFF
--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -561,7 +561,7 @@ const getQueryOptionsDefinition = ({
         : `typeof ${operationName}`
     }>>`;
 
-    return `${partialOptions ? 'Partial<' : ''}${prefix}${pascal(
+    return `${partialOptions ? 'WithOptional<' : ''}${prefix}${pascal(
       type,
     )}Options<${funcReturnType}, TError, TData${
       hasQueryV5 &&
@@ -570,7 +570,7 @@ const getQueryOptionsDefinition = ({
       queryParams
         ? `, ${funcReturnType}, QueryKey, ${queryParams?.schema.name}['${queryParam}']`
         : ''
-    }>${partialOptions ? '>' : ''}`;
+    }>${partialOptions ? ', "queryKey">' : ''}`;
   }
 
   return `${prefix}MutationOptions<Awaited<ReturnType<${
@@ -619,9 +619,9 @@ const generateQueryArguments = ({
 
   const requestType = getQueryArgumentsRequestType(mutator);
 
-  return `options?: { ${
-    type ? 'query' : 'mutation'
-  }?:${definition}, ${requestType}}\n`;
+  return `options?: { ${type ? 'query' : 'mutation'}${
+    hasQueryV5 && type === 'infiniteQuery' ? '' : '?'
+  }:${definition}, ${requestType}}\n`;
 };
 
 const generateQueryReturnType = ({
@@ -1403,6 +1403,9 @@ ${
   : never;\n\n`
     : ''
 }
+
+// eslint-disable-next-line
+type WithOptional<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
 `;
 };
 

--- a/samples/react-query/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/react-query/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -71,6 +71,8 @@ type AwaitedInput<T> = PromiseLike<T> | T;
 
 type Awaited<O> = O extends AwaitedInput<infer T> ? T : never;
 
+// eslint-disable-next-line
+type WithOptional<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
 /**
  * @summary List all pets
  */
@@ -96,7 +98,7 @@ export const getListPetsInfiniteQueryOptions = <
   params?: ListPetsParams,
   version = 1,
   options?: {
-    query?: Partial<
+    query: WithOptional<
       UseInfiniteQueryOptions<
         Awaited<ReturnType<typeof listPets>>,
         TError,
@@ -104,7 +106,8 @@ export const getListPetsInfiniteQueryOptions = <
         Awaited<ReturnType<typeof listPets>>,
         QueryKey,
         ListPetsParams['limit']
-      >
+      >,
+      'queryKey'
     >;
   },
 ) => {
@@ -152,7 +155,7 @@ export const useListPetsInfinite = <
   params?: ListPetsParams,
   version = 1,
   options?: {
-    query?: Partial<
+    query: WithOptional<
       UseInfiniteQueryOptions<
         Awaited<ReturnType<typeof listPets>>,
         TError,
@@ -160,7 +163,8 @@ export const useListPetsInfinite = <
         Awaited<ReturnType<typeof listPets>>,
         QueryKey,
         ListPetsParams['limit']
-      >
+      >,
+      'queryKey'
     >;
   },
 ): UseInfiniteQueryResult<TData, TError> & { queryKey: QueryKey } => {
@@ -187,8 +191,9 @@ export const getListPetsQueryOptions = <
   params?: ListPetsParams,
   version = 1,
   options?: {
-    query?: Partial<
-      UseQueryOptions<Awaited<ReturnType<typeof listPets>>, TError, TData>
+    query?: WithOptional<
+      UseQueryOptions<Awaited<ReturnType<typeof listPets>>, TError, TData>,
+      'queryKey'
     >;
   },
 ) => {
@@ -225,8 +230,9 @@ export const useListPets = <
   params?: ListPetsParams,
   version = 1,
   options?: {
-    query?: Partial<
-      UseQueryOptions<Awaited<ReturnType<typeof listPets>>, TError, TData>
+    query?: WithOptional<
+      UseQueryOptions<Awaited<ReturnType<typeof listPets>>, TError, TData>,
+      'queryKey'
     >;
   },
 ): UseQueryResult<TData, TError> & { queryKey: QueryKey } => {
@@ -248,12 +254,13 @@ export const getListPetsSuspenseQueryOptions = <
   params?: ListPetsParams,
   version = 1,
   options?: {
-    query?: Partial<
+    query?: WithOptional<
       UseSuspenseQueryOptions<
         Awaited<ReturnType<typeof listPets>>,
         TError,
         TData
-      >
+      >,
+      'queryKey'
     >;
   },
 ) => {
@@ -292,12 +299,13 @@ export const useListPetsSuspense = <
   params?: ListPetsParams,
   version = 1,
   options?: {
-    query?: Partial<
+    query?: WithOptional<
       UseSuspenseQueryOptions<
         Awaited<ReturnType<typeof listPets>>,
         TError,
         TData
-      >
+      >,
+      'queryKey'
     >;
   },
 ): UseSuspenseQueryResult<TData, TError> & { queryKey: QueryKey } => {
@@ -327,7 +335,7 @@ export const getListPetsSuspenseInfiniteQueryOptions = <
   params?: ListPetsParams,
   version = 1,
   options?: {
-    query?: Partial<
+    query?: WithOptional<
       UseSuspenseInfiniteQueryOptions<
         Awaited<ReturnType<typeof listPets>>,
         TError,
@@ -335,7 +343,8 @@ export const getListPetsSuspenseInfiniteQueryOptions = <
         Awaited<ReturnType<typeof listPets>>,
         QueryKey,
         ListPetsParams['limit']
-      >
+      >,
+      'queryKey'
     >;
   },
 ) => {
@@ -383,7 +392,7 @@ export const useListPetsSuspenseInfinite = <
   params?: ListPetsParams,
   version = 1,
   options?: {
-    query?: Partial<
+    query?: WithOptional<
       UseSuspenseInfiniteQueryOptions<
         Awaited<ReturnType<typeof listPets>>,
         TError,
@@ -391,7 +400,8 @@ export const useListPetsSuspenseInfinite = <
         Awaited<ReturnType<typeof listPets>>,
         QueryKey,
         ListPetsParams['limit']
-      >
+      >,
+      'queryKey'
     >;
   },
 ): UseSuspenseInfiniteQueryResult<TData, TError> & { queryKey: QueryKey } => {
@@ -570,8 +580,9 @@ export const getShowPetByIdQueryOptions = <
   petId: string,
   version = 1,
   options?: {
-    query?: Partial<
-      UseQueryOptions<Awaited<ReturnType<typeof showPetById>>, TError, TData>
+    query?: WithOptional<
+      UseQueryOptions<Awaited<ReturnType<typeof showPetById>>, TError, TData>,
+      'queryKey'
     >;
   },
 ) => {
@@ -611,8 +622,9 @@ export const useShowPetById = <
   petId: string,
   version = 1,
   options?: {
-    query?: Partial<
-      UseQueryOptions<Awaited<ReturnType<typeof showPetById>>, TError, TData>
+    query?: WithOptional<
+      UseQueryOptions<Awaited<ReturnType<typeof showPetById>>, TError, TData>,
+      'queryKey'
     >;
   },
 ): UseQueryResult<TData, TError> & { queryKey: QueryKey } => {

--- a/samples/react-query/custom-client/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/react-query/custom-client/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -27,6 +27,8 @@ type AwaitedInput<T> = PromiseLike<T> | T;
 
 type Awaited<O> = O extends AwaitedInput<infer T> ? T : never;
 
+// eslint-disable-next-line
+type WithOptional<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
 /**
  * @summary List all pets
  */

--- a/samples/svelte-query/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/svelte-query/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -22,6 +22,8 @@ import type {
 } from '../model';
 import { customInstance } from '../mutator/custom-instance';
 
+// eslint-disable-next-line
+type WithOptional<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
 /**
  * @summary List all pets
  */

--- a/samples/vue-query/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/vue-query/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -30,6 +30,8 @@ type AwaitedInput<T> = PromiseLike<T> | T;
 
 type Awaited<O> = O extends AwaitedInput<infer T> ? T : never;
 
+// eslint-disable-next-line
+type WithOptional<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
 /**
  * @summary List all pets
  */


### PR DESCRIPTION
## Status

READY

## Description

The fix in https://github.com/anymaniax/orval/pull/977 also omits required query options such as `initialPageParam` and `getNextPageParam` for inifinite queries. This PR makes sure only the `queryKey` is partialized.

