### PR TITLE
fix: Nullable Object type

### DIFF
--- a/packages/core/src/getters/object.ts
+++ b/packages/core/src/getters/object.ts
@@ -178,7 +178,7 @@ export const getObject = ({
 
   return {
     value:
-      item.type === 'object' ? '{ [key: string]: any }' : 'unknown' + nullable,
+        (item.type === 'object' ? '{ [key: string]: any }' : 'unknown') + nullable,
     imports: [],
     schemas: [],
     isEnum: false,

--- a/tests/configs/default.config.ts
+++ b/tests/configs/default.config.ts
@@ -57,6 +57,13 @@ export default defineConfig({
       target: '../generated/default/null-type/endpoints.ts',
     },
   },
+  'null-type-v-3-0': {
+    input: '../specifications/null-type-v3-0.yaml',
+    output: {
+      schemas: '../generated/default/null-type-v3-0/model',
+      target: '../generated/default/null-type-v3-0/endpoints.ts',
+    },
+  },
   readonly: {
     input: '../specifications/readonly.yaml',
     output: {

--- a/tests/specifications/null-type-v3-0.yaml
+++ b/tests/specifications/null-type-v3-0.yaml
@@ -1,0 +1,68 @@
+openapi: 3.0.0
+info:
+  title: Nullables
+  description: 'OpenAPI 3.0 Nullable types'
+  version: 1.0.0
+tags:
+  - name: nullables
+    description: Nullable types
+servers:
+  - url: http://localhost
+paths:
+  /nullable:
+    get:
+      tags:
+        - nullables
+      summary: Nullable response
+      operationId: fetchNullable
+      responses:
+        200:
+          description: Successful Operation
+          content:
+            application/json:
+              schema:
+                nullable: true
+                type: 'string'
+  /nullable-object:
+    get:
+      tags:
+        - nullables
+      summary: Nullable object with nullable properties response
+      operationId: fetchNullableObject
+      responses:
+        200:
+          description: Successful Operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NullableObject'
+  /nullable-any-object-key:
+    get:
+      tags:
+        - nullables
+      summary: Nullable object without properties response
+      operationId: fetchNullableAnyObject
+      responses:
+        200:
+          description: Successful Operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NullableAnyObject'
+components:
+  schemas:
+    ObjectWithNullableObjectKey:
+      type: object
+      properties:
+        nullableObject:
+          $ref: '#/components/schemas/NullableAnyObject'
+    NullableObject:
+      type: object
+      nullable: true
+      properties:
+        name:
+          type: 'string'
+          nullable: true
+    NullableAnyObject:
+      type: object
+      nullable: true


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

Fix #981

**READY**

## Description

`| null` was missing for nullable objects without properties

```yaml
    NullableAnyObject:
      type: object
      nullable: true
```

got translated to
```ts
export type NullableAnyObject = { [key: string]: any }; // <<-- missing ` | null`
```

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

Outline the steps to test or reproduce the PR here.

I added new test specification with described case - `null-type-v3-0.yaml`
