### PR TITLE
feat: support params serializer

### DIFF
--- a/docs/src/pages/reference/configuration/output.md
+++ b/docs/src/pages/reference/configuration/output.md
@@ -989,6 +989,71 @@ export const customFormUrlEncodedFn = <Body>(body: Body): URLSearchParams => {
 };
 ```
 
+#### paramsSerializer
+
+Type: `String` or `Object`.
+
+Valid values: path of the paramsSerializer function or object with a path and name.
+
+Use this property to add a custom params serializer to all requests that use query params.
+
+If you provide an object you can also add a default property to use an export default function.
+
+Example:
+
+```js
+module.exports = {
+  petstore: {
+    output: {
+      override: {
+        paramsSerializer: {
+          path: './api/mutator/custom-params-serializer-fn.ts',
+          name: 'customParamsSerializerFn',
+          // default: true
+        },
+      },
+    },
+  },
+};
+```
+
+```ts
+// type signature
+export const customParamsSerializerFn = (
+  params: Record<string, any>,
+): string => {
+  // do your implementation to transform the params
+
+  return params;
+};
+```
+
+#### paramsSerializerOptions
+
+Type: `Object`
+
+Use this property to add a default params serializer. Current options are: `qs`.
+
+All options are then passed to the chosen serializer.
+
+Example:
+
+```js
+module.exports = {
+  petstore: {
+    output: {
+      override: {
+        paramsSerializerOptions: {
+          qs: {
+            arrayFormat: 'repeat',
+          },
+        },
+      },
+    },
+  },
+};
+```
+
 #### useDates
 
 Type: `Boolean`

--- a/packages/angular/src/index.ts
+++ b/packages/angular/src/index.ts
@@ -125,6 +125,7 @@ const generateImplementation = (
     override,
     formData,
     formUrlEncoded,
+    paramsSerializer,
   }: GeneratorVerbOptions,
   { route, context }: GeneratorOptions,
 ) => {
@@ -204,6 +205,8 @@ const generateImplementation = (
     requestOptions: override?.requestOptions,
     isFormData,
     isFormUrlEncoded,
+    paramsSerializer,
+    paramsSerializerOptions: override?.paramsSerializerOptions,
     isAngular: true,
     isExactOptionalPropertyTypes,
     hasSignal: false,

--- a/packages/axios/src/index.ts
+++ b/packages/axios/src/index.ts
@@ -36,11 +36,29 @@ const AXIOS_DEPENDENCIES: GeneratorDependency[] = [
   },
 ];
 
+const PARAMS_SERIALIZER_DEPENDENCIES: GeneratorDependency[] = [
+  {
+    exports: [
+      {
+        name: 'qs',
+        default: true,
+        values: true,
+        syntheticDefaultImport: true,
+      },
+    ],
+    dependency: 'qs',
+  },
+];
+
 const returnTypesToWrite: Map<string, (title?: string) => string> = new Map();
 
 export const getAxiosDependencies: ClientDependenciesBuilder = (
   hasGlobalMutator,
-) => [...(!hasGlobalMutator ? AXIOS_DEPENDENCIES : [])];
+  hasParamsSerializerOptions: boolean,
+) => [
+  ...(!hasGlobalMutator ? AXIOS_DEPENDENCIES : []),
+  ...(hasParamsSerializerOptions ? PARAMS_SERIALIZER_DEPENDENCIES : []),
+];
 
 const generateAxiosImplementation = (
   {
@@ -55,6 +73,7 @@ const generateAxiosImplementation = (
     override,
     formData,
     formUrlEncoded,
+    paramsSerializer,
   }: GeneratorVerbOptions,
   { route, context }: GeneratorOptions,
 ) => {
@@ -141,6 +160,8 @@ const generateAxiosImplementation = (
     requestOptions: override?.requestOptions,
     isFormData,
     isFormUrlEncoded,
+    paramsSerializer,
+    paramsSerializerOptions: override?.paramsSerializerOptions,
     isExactOptionalPropertyTypes,
     hasSignal: false,
   });

--- a/packages/core/src/generators/options.ts
+++ b/packages/core/src/generators/options.ts
@@ -5,6 +5,7 @@ import {
   GetterBody,
   GetterQueryParam,
   GetterResponse,
+  ParamsSerializerOptions,
   Verbs,
 } from '../types';
 import { isObject, stringify } from '../utils';
@@ -36,6 +37,8 @@ export const generateAxiosOptions = ({
   headers,
   requestOptions,
   hasSignal,
+  paramsSerializer,
+  paramsSerializerOptions,
 }: {
   response: GetterResponse;
   isExactOptionalPropertyTypes: boolean;
@@ -43,6 +46,8 @@ export const generateAxiosOptions = ({
   headers?: GeneratorSchema;
   requestOptions?: object | boolean;
   hasSignal: boolean;
+  paramsSerializer?: GeneratorMutator;
+  paramsSerializerOptions?: ParamsSerializerOptions;
 }) => {
   const isRequestOptions = requestOptions !== false;
   if (!queryParams && !headers && !response.isBlob) {
@@ -99,6 +104,16 @@ export const generateAxiosOptions = ({
     }
   }
 
+  if (queryParams && (paramsSerializer || paramsSerializerOptions?.qs)) {
+    if (paramsSerializer) {
+      value += `\n        paramsSerializer: ${paramsSerializer.name},`;
+    } else {
+      value += `\n        paramsSerializer: (params) => qs.stringify(params, ${JSON.stringify(
+        paramsSerializerOptions!.qs,
+      )}),`;
+    }
+  }
+
   return value;
 };
 
@@ -115,6 +130,8 @@ export const generateOptions = ({
   isAngular,
   isExactOptionalPropertyTypes,
   hasSignal,
+  paramsSerializer,
+  paramsSerializerOptions,
 }: {
   route: string;
   body: GetterBody;
@@ -128,6 +145,8 @@ export const generateOptions = ({
   isAngular?: boolean;
   isExactOptionalPropertyTypes: boolean;
   hasSignal: boolean;
+  paramsSerializer?: GeneratorMutator;
+  paramsSerializerOptions?: ParamsSerializerOptions;
 }) => {
   const isBodyVerb = VERBS_WITH_BODY.includes(verb);
   const bodyOptions = isBodyVerb
@@ -141,6 +160,8 @@ export const generateOptions = ({
     requestOptions,
     isExactOptionalPropertyTypes,
     hasSignal,
+    paramsSerializer,
+    paramsSerializerOptions,
   });
 
   const options = axiosOptions ? `{${axiosOptions}}` : '';

--- a/packages/core/src/generators/verbs-options.ts
+++ b/packages/core/src/generators/verbs-options.ts
@@ -19,6 +19,7 @@ import {
   GeneratorVerbOptions,
   GeneratorVerbsOptions,
   NormalizedInputOptions,
+  NormalizedMutator,
   NormalizedOperationOptions,
   NormalizedOutputOptions,
   NormalizedOverrideOutput,
@@ -164,6 +165,17 @@ const generateVerbOptions = async ({
         })
       : undefined;
 
+  const paramsSerializer =
+    isString(override?.paramsSerializer) || isObject(override?.paramsSerializer)
+      ? await generateMutator({
+          output: output.target,
+          name: 'paramsSerializer',
+          mutator: override.paramsSerializer as NormalizedMutator,
+          workspace: context.workspace,
+          tsconfig: context.tsconfig,
+        })
+      : undefined;
+
   const doc = jsDoc({ description, deprecated, summary });
 
   const verbOption: GeneratorVerbOptions = {
@@ -181,6 +193,7 @@ const generateVerbOptions = async ({
     mutator,
     formData,
     formUrlEncoded,
+    paramsSerializer,
     override,
     doc,
     deprecated,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -55,6 +55,10 @@ export type NormalizedOutputOptions = {
   baseUrl?: string;
 };
 
+export type NormalizedParamsSerializerOptions = {
+  qs?: Record<string, any>;
+};
+
 export type NormalizedOverrideOutput = {
   title?: (title: string) => string;
   transformer?: OutputTransformer;
@@ -74,6 +78,8 @@ export type NormalizedOverrideOutput = {
   header: false | ((info: InfoObject) => string[] | string);
   formData: boolean | NormalizedMutator;
   formUrlEncoded: boolean | NormalizedMutator;
+  paramsSerializer?: NormalizedMutator;
+  paramsSerializerOptions?: NormalizedParamsSerializerOptions;
   components: {
     schemas: {
       suffix: string;
@@ -133,6 +139,7 @@ export type NormalizedOperationOptions = {
   ) => string;
   formData?: boolean | NormalizedMutator;
   formUrlEncoded?: boolean | NormalizedMutator;
+  paramsSerializer?: NormalizedMutator;
   requestOptions?: object | boolean;
 };
 
@@ -238,6 +245,10 @@ export type MutatorObject = {
 
 export type Mutator = string | MutatorObject;
 
+export type ParamsSerializerOptions = {
+  qs?: Record<string, any>;
+};
+
 export type OverrideOutput = {
   title?: (title: string) => string;
   transformer?: OutputTransformer;
@@ -257,6 +268,8 @@ export type OverrideOutput = {
   header?: boolean | ((info: InfoObject) => string[] | string);
   formData?: boolean | Mutator;
   formUrlEncoded?: boolean | Mutator;
+  paramsSerializer?: Mutator;
+  paramsSerializerOptions?: ParamsSerializerOptions;
   components?: {
     schemas?: {
       suffix?: string;
@@ -355,6 +368,7 @@ export type OperationOptions = {
   ) => string;
   formData?: boolean | Mutator;
   formUrlEncoded?: boolean | Mutator;
+  paramsSerializer?: Mutator;
   requestOptions?: object | boolean;
 };
 
@@ -487,6 +501,7 @@ export type GeneratorTarget = {
   clientMutators?: GeneratorMutator[];
   formData?: GeneratorMutator[];
   formUrlEncoded?: GeneratorMutator[];
+  paramsSerializer?: GeneratorMutator[];
 };
 
 export type GeneratorTargetFull = {
@@ -501,6 +516,7 @@ export type GeneratorTargetFull = {
   clientMutators?: GeneratorMutator[];
   formData?: GeneratorMutator[];
   formUrlEncoded?: GeneratorMutator[];
+  paramsSerializer?: GeneratorMutator[];
 };
 
 export type GeneratorOperation = {
@@ -513,6 +529,7 @@ export type GeneratorOperation = {
   clientMutators?: GeneratorMutator[];
   formData?: GeneratorMutator;
   formUrlEncoded?: GeneratorMutator;
+  paramsSerializer?: GeneratorMutator;
   operationName: string;
   types?: {
     result: (title?: string) => string;
@@ -535,6 +552,7 @@ export type GeneratorVerbOptions = {
   mutator?: GeneratorMutator;
   formData?: GeneratorMutator;
   formUrlEncoded?: GeneratorMutator;
+  paramsSerializer?: GeneratorMutator;
   override: NormalizedOverrideOutput;
   deprecated?: boolean;
   originalOperation: OperationObject;
@@ -601,6 +619,7 @@ export type ClientTitleBuilder = (title: string) => string;
 
 export type ClientDependenciesBuilder = (
   hasGlobalMutator: boolean,
+  hasParamsSerializerOptions: boolean,
   packageJson?: PackageJson,
 ) => GeneratorDependency[];
 
@@ -817,6 +836,7 @@ export type GeneratorClientImports = (data: {
   hasSchemaDir: boolean;
   isAllowSyntheticDefaultImports: boolean;
   hasGlobalMutator: boolean;
+  hasParamsSerializerOptions: boolean;
   packageJson?: PackageJson;
 }) => string;
 

--- a/packages/core/src/writers/single-mode.ts
+++ b/packages/core/src/writers/single-mode.ts
@@ -31,6 +31,7 @@ export const writeSingleMode = async ({
       clientMutators,
       formData,
       formUrlEncoded,
+      paramsSerializer,
     } = generateTarget(builder, output);
 
     let data = header;
@@ -60,6 +61,7 @@ export const writeSingleMode = async ({
       hasSchemaDir: !!output.schemas,
       isAllowSyntheticDefaultImports,
       hasGlobalMutator: !!output.override.mutator,
+      hasParamsSerializerOptions: !!output.override.paramsSerializerOptions,
       packageJson: output.packageJson,
     });
 
@@ -89,6 +91,10 @@ export const writeSingleMode = async ({
 
     if (formUrlEncoded) {
       data += generateMutatorImports({ mutators: formUrlEncoded });
+    }
+
+    if (paramsSerializer) {
+      data += generateMutatorImports({ mutators: paramsSerializer });
     }
 
     if (implementation.includes('NonReadonly<')) {

--- a/packages/core/src/writers/split-mode.ts
+++ b/packages/core/src/writers/split-mode.ts
@@ -31,6 +31,7 @@ export const writeSplitMode = async ({
       clientMutators,
       formData,
       formUrlEncoded,
+      paramsSerializer,
     } = generateTarget(builder, output);
 
     let implementationData = header;
@@ -52,6 +53,7 @@ export const writeSplitMode = async ({
       hasSchemaDir: !!output.schemas,
       isAllowSyntheticDefaultImports,
       hasGlobalMutator: !!output.override.mutator,
+      hasParamsSerializerOptions: !!output.override.paramsSerializerOptions,
       packageJson: output.packageJson,
     });
     mswData += builder.importsMock({
@@ -100,6 +102,12 @@ export const writeSplitMode = async ({
     if (formUrlEncoded) {
       implementationData += generateMutatorImports({
         mutators: formUrlEncoded,
+      });
+    }
+
+    if (paramsSerializer) {
+      implementationData += generateMutatorImports({
+        mutators: paramsSerializer,
       });
     }
 

--- a/packages/core/src/writers/split-tags-mode.ts
+++ b/packages/core/src/writers/split-tags-mode.ts
@@ -39,6 +39,7 @@ export const writeSplitTagsMode = async ({
           clientMutators,
           formData,
           formUrlEncoded,
+          paramsSerializer,
         } = target;
 
         let implementationData = header;
@@ -57,6 +58,7 @@ export const writeSplitTagsMode = async ({
           hasSchemaDir: !!output.schemas,
           isAllowSyntheticDefaultImports,
           hasGlobalMutator: !!output.override.mutator,
+          hasParamsSerializerOptions: !!output.override.paramsSerializerOptions,
           packageJson: output.packageJson,
         });
         mswData += builder.importsMock({
@@ -106,6 +108,12 @@ export const writeSplitTagsMode = async ({
         if (formUrlEncoded) {
           implementationData += generateMutatorImports({
             mutators: formUrlEncoded,
+            oneMore: true,
+          });
+        }
+        if (paramsSerializer) {
+          implementationData += generateMutatorImports({
+            mutators: paramsSerializer,
             oneMore: true,
           });
         }

--- a/packages/core/src/writers/tags-mode.ts
+++ b/packages/core/src/writers/tags-mode.ts
@@ -40,6 +40,7 @@ export const writeTagsMode = async ({
           clientMutators,
           formData,
           formUrlEncoded,
+          paramsSerializer,
         } = target;
 
         let data = header;
@@ -63,6 +64,7 @@ export const writeTagsMode = async ({
           hasSchemaDir: !!output.schemas,
           isAllowSyntheticDefaultImports,
           hasGlobalMutator: !!output.override.mutator,
+          hasParamsSerializerOptions: !!output.override.paramsSerializerOptions,
           packageJson: output.packageJson,
         });
 
@@ -102,6 +104,10 @@ export const writeTagsMode = async ({
 
         if (formUrlEncoded) {
           data += generateMutatorImports({ mutators: formUrlEncoded });
+        }
+
+        if (paramsSerializer) {
+          data += generateMutatorImports({ mutators: paramsSerializer });
         }
 
         data += '\n\n';

--- a/packages/core/src/writers/target-tags.ts
+++ b/packages/core/src/writers/target-tags.ts
@@ -32,6 +32,9 @@ const generateTargetTags = (
         formUrlEncoded: operation.formUrlEncoded
           ? [operation.formUrlEncoded]
           : [],
+        paramsSerializer: operation.paramsSerializer
+          ? [operation.paramsSerializer]
+          : [],
         implementation: operation.implementation,
         implementationMSW: {
           function: operation.implementationMSW.function,
@@ -70,6 +73,12 @@ const generateTargetTags = (
       formUrlEncoded: operation.formUrlEncoded
         ? [...(currentOperation.formUrlEncoded ?? []), operation.formUrlEncoded]
         : currentOperation.formUrlEncoded,
+      paramsSerializer: operation.paramsSerializer
+        ? [
+            ...(currentOperation.paramsSerializer ?? []),
+            operation.paramsSerializer,
+          ]
+        : currentOperation.paramsSerializer,
     };
 
     return acc;
@@ -147,6 +156,7 @@ export const generateTargetForTags = (
             clientMutators: target.clientMutators,
             formData: target.formData,
             formUrlEncoded: target.formUrlEncoded,
+            paramsSerializer: target.paramsSerializer,
           };
 
           return acc;

--- a/packages/core/src/writers/target.ts
+++ b/packages/core/src/writers/target.ts
@@ -39,6 +39,9 @@ export const generateTarget = (
       if (operation.formUrlEncoded) {
         acc.formUrlEncoded.push(operation.formUrlEncoded);
       }
+      if (operation.paramsSerializer) {
+        acc.paramsSerializer.push(operation.paramsSerializer);
+      }
 
       if (operation.clientMutators) {
         acc.clientMutators.push(...operation.clientMutators);
@@ -93,6 +96,7 @@ export const generateTarget = (
       clientMutators: [],
       formData: [],
       formUrlEncoded: [],
+      paramsSerializer: [],
     } as Required<GeneratorTargetFull>,
   );
 

--- a/packages/orval/src/client.ts
+++ b/packages/orval/src/client.ts
@@ -55,13 +55,21 @@ export const generateClientImports: GeneratorClientImports = ({
   hasSchemaDir,
   isAllowSyntheticDefaultImports,
   hasGlobalMutator,
+  hasParamsSerializerOptions,
   packageJson,
 }) => {
   const { dependencies } = getGeneratorClient(client);
   return generateDependencyImports(
     implementation,
     dependencies
-      ? [...dependencies(hasGlobalMutator, packageJson), ...imports]
+      ? [
+          ...dependencies(
+            hasGlobalMutator,
+            hasParamsSerializerOptions,
+            packageJson,
+          ),
+          ...imports,
+        ]
       : imports,
     specsName,
     hasSchemaDir,
@@ -217,6 +225,7 @@ export const generateOperations = (
         clientMutators: client.mutators,
         formData: verbOption.formData,
         formUrlEncoded: verbOption.formUrlEncoded,
+        paramsSerializer: verbOption.paramsSerializer,
         operationName: verbOption.operationName,
       };
 

--- a/packages/orval/src/utils/options.ts
+++ b/packages/orval/src/utils/options.ts
@@ -155,6 +155,10 @@ export const normalizeOptions = async (
                 outputOptions.override?.formUrlEncoded,
               )
             : outputOptions.override?.formUrlEncoded) ?? true,
+        paramsSerializer: normalizeMutator(
+          outputWorkspace,
+          outputOptions.override?.paramsSerializer,
+        ),
         header:
           outputOptions.override?.header === false
             ? false
@@ -274,7 +278,15 @@ const normalizeOperationsAndTags = (
     Object.entries(operationsOrTags).map(
       ([
         key,
-        { transformer, mutator, formData, formUrlEncoded, query, ...rest },
+        {
+          transformer,
+          mutator,
+          formData,
+          formUrlEncoded,
+          paramsSerializer,
+          query,
+          ...rest
+        },
       ]) => {
         return [
           key,
@@ -303,6 +315,14 @@ const normalizeOperationsAndTags = (
                   formUrlEncoded: !isBoolean(formUrlEncoded)
                     ? normalizeMutator(workspace, formUrlEncoded)
                     : formUrlEncoded,
+                }
+              : {}),
+            ...(paramsSerializer
+              ? {
+                  paramsSerializer: normalizeMutator(
+                    workspace,
+                    paramsSerializer,
+                  ),
                 }
               : {}),
           },

--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -58,6 +58,20 @@ const AXIOS_DEPENDENCIES: GeneratorDependency[] = [
   },
 ];
 
+const PARAMS_SERIALIZER_DEPENDENCIES: GeneratorDependency[] = [
+  {
+    exports: [
+      {
+        name: 'qs',
+        default: true,
+        values: true,
+        syntheticDefaultImport: true,
+      },
+    ],
+    dependency: 'qs',
+  },
+];
+
 const SVELTE_QUERY_DEPENDENCIES_V3: GeneratorDependency[] = [
   {
     exports: [
@@ -112,12 +126,14 @@ const isSvelteQueryV3 = (packageJson: PackageJson | undefined) => {
 
 export const getSvelteQueryDependencies: ClientDependenciesBuilder = (
   hasGlobalMutator,
+  hasParamsSerializerOptions,
   packageJson,
 ) => {
   const hasSvelteQueryV3 = isSvelteQueryV3(packageJson);
 
   return [
     ...(!hasGlobalMutator ? AXIOS_DEPENDENCIES : []),
+    ...(hasParamsSerializerOptions ? PARAMS_SERIALIZER_DEPENDENCIES : []),
     ...(hasSvelteQueryV3
       ? SVELTE_QUERY_DEPENDENCIES_V3
       : SVELTE_QUERY_DEPENDENCIES),
@@ -170,6 +186,7 @@ const REACT_QUERY_DEPENDENCIES: GeneratorDependency[] = [
 
 export const getReactQueryDependencies: ClientDependenciesBuilder = (
   hasGlobalMutator,
+  hasParamsSerializerOptions,
   packageJson,
 ) => {
   const hasReactQuery =
@@ -181,6 +198,7 @@ export const getReactQueryDependencies: ClientDependenciesBuilder = (
 
   return [
     ...(!hasGlobalMutator ? AXIOS_DEPENDENCIES : []),
+    ...(hasParamsSerializerOptions ? PARAMS_SERIALIZER_DEPENDENCIES : []),
     ...(hasReactQuery && !hasReactQueryV4
       ? REACT_QUERY_DEPENDENCIES_V3
       : REACT_QUERY_DEPENDENCIES),
@@ -259,12 +277,14 @@ const isVueQueryV3 = (packageJson: PackageJson | undefined) => {
 
 export const getVueQueryDependencies: ClientDependenciesBuilder = (
   hasGlobalMutator: boolean,
+  hasParamsSerializerOptions: boolean,
   packageJson,
 ) => {
   const hasVueQueryV3 = isVueQueryV3(packageJson);
 
   return [
     ...(!hasGlobalMutator ? AXIOS_DEPENDENCIES : []),
+    ...(hasParamsSerializerOptions ? PARAMS_SERIALIZER_DEPENDENCIES : []),
     ...(hasVueQueryV3 ? VUE_QUERY_DEPENDENCIES_V3 : VUE_QUERY_DEPENDENCIES),
   ];
 };
@@ -336,6 +356,7 @@ const generateQueryRequestFunction = (
     verb,
     formData,
     formUrlEncoded,
+    paramsSerializer,
     override,
   }: GeneratorVerbOptions,
   { route, context }: GeneratorOptions,
@@ -440,6 +461,8 @@ const generateQueryRequestFunction = (
     requestOptions: override?.requestOptions,
     isFormData,
     isFormUrlEncoded,
+    paramsSerializer,
+    paramsSerializerOptions: override?.paramsSerializerOptions,
     isExactOptionalPropertyTypes,
     hasSignal,
   });

--- a/packages/swr/src/index.ts
+++ b/packages/swr/src/index.ts
@@ -43,6 +43,20 @@ const AXIOS_DEPENDENCIES: GeneratorDependency[] = [
   },
 ];
 
+const PARAMS_SERIALIZER_DEPENDENCIES: GeneratorDependency[] = [
+  {
+    exports: [
+      {
+        name: 'qs',
+        default: true,
+        values: true,
+        syntheticDefaultImport: true,
+      },
+    ],
+    dependency: 'qs',
+  },
+];
+
 const SWR_DEPENDENCIES: GeneratorDependency[] = [
   {
     exports: [
@@ -56,7 +70,12 @@ const SWR_DEPENDENCIES: GeneratorDependency[] = [
 
 export const getSwrDependencies: ClientDependenciesBuilder = (
   hasGlobalMutator: boolean,
-) => [...(!hasGlobalMutator ? AXIOS_DEPENDENCIES : []), ...SWR_DEPENDENCIES];
+  hasParamsSerializerOptions: boolean,
+) => [
+  ...(!hasGlobalMutator ? AXIOS_DEPENDENCIES : []),
+  ...(hasParamsSerializerOptions ? PARAMS_SERIALIZER_DEPENDENCIES : []),
+  ...SWR_DEPENDENCIES,
+];
 
 const generateSwrRequestFunction = (
   {
@@ -71,6 +90,7 @@ const generateSwrRequestFunction = (
     formData,
     formUrlEncoded,
     override,
+    paramsSerializer,
   }: GeneratorVerbOptions,
   { route, context }: GeneratorOptions,
 ) => {
@@ -144,6 +164,8 @@ const generateSwrRequestFunction = (
     requestOptions: override?.requestOptions,
     isFormData,
     isFormUrlEncoded,
+    paramsSerializer,
+    paramsSerializerOptions: override?.paramsSerializerOptions,
     isExactOptionalPropertyTypes,
     hasSignal: false,
   });


### PR DESCRIPTION
## Status

**READY**

## Description

Resolves #296 .

Adds support for axios' `paramsSerializer`. This can be used to adapt the format of arrays and other properties to the API's requirements.

Adds a `paramsSerializer` property, which behaves as other mutators, allowing for any custom params serializer. Also adds a `paramsSerializerOptions`, to use `qs` directly, where users only have to define the `options` that will be passed.

