### PR TITLE
feat(faker): update deprecated methods

### DIFF
--- a/docs/src/pages/reference/configuration/full-example.md
+++ b/docs/src/pages/reference/configuration/full-example.md
@@ -21,7 +21,7 @@ module.exports = {
             mock: {
               properties: () => {
                 return {
-                  id: () => faker.datatype.number({ min: 1, max: 99999 }),
+                  id: () => faker.number.int({ min: 1, max: 99999 }),
                 };
               },
             },
@@ -29,10 +29,10 @@ module.exports = {
           showPetById: {
             mock: {
               data: () => ({
-                id: faker.datatype.number({ min: 1, max: 99 }),
-                name: faker.name.firstName(),
+                id: faker.number.int({ min: 1, max: 99 }),
+                name: faker.person.firstName(),
                 tag: faker.helpers.arrayElement([
-                  faker.random.word(),
+                  faker.word.sample(),
                   undefined,
                 ]),
               }),
@@ -41,7 +41,7 @@ module.exports = {
         },
         mock: {
           properties: {
-            '/tag|name/': () => faker.name.lastName(),
+            '/tag|name/': () => faker.person.lastName(),
           },
           delay: 500,
         },

--- a/docs/src/pages/reference/configuration/output.md
+++ b/docs/src/pages/reference/configuration/output.md
@@ -888,7 +888,7 @@ module.exports = {
             mock: {
               properties: () => {
                 return {
-                  id: () => faker.datatype.number({ min: 1, max: 99999 }),
+                  id: () => faker.number.int({ min: 1, max: 99999 }),
                 };
               },
             },
@@ -896,10 +896,10 @@ module.exports = {
           showPetById: {
             mock: {
               data: () => ({
-                id: faker.datatype.number({ min: 1, max: 99 }),
-                name: faker.name.firstName(),
+                id: faker.number.int({ min: 1, max: 99 }),
+                name: faker.person.firstName(),
                 tag: faker.helpers.arrayElement([
-                  faker.random.word(),
+                  faker.word.sample(),
                   undefined,
                 ]),
               }),

--- a/packages/msw/src/getters/scalar.ts
+++ b/packages/msw/src/getters/scalar.ts
@@ -177,7 +177,7 @@ export const getMockScalar = ({
 
       return {
         value:
-          `Array.from({ length: faker.datatype.number({ ` +
+          `Array.from({ length: faker.number.int({ ` +
           `min: ${mockOptions?.arrayMin}, ` +
           `max: ${mockOptions?.arrayMax} }) ` +
           `}, (_, i) => i + 1).map(() => (${mapValue}))`,

--- a/samples/angular-app/orval.config.ts
+++ b/samples/angular-app/orval.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
             mock: {
               properties: () => {
                 return {
-                  id: () => faker.datatype.number({ min: 1, max: 99999 }),
+                  id: () => faker.number.int({ min: 1, max: 99999 }),
                 };
               },
             },
@@ -26,10 +26,10 @@ export default defineConfig({
           showPetById: {
             mock: {
               data: () => ({
-                id: faker.datatype.number({ min: 1, max: 99 }),
-                name: faker.name.firstName(),
+                id: faker.number.int({ min: 1, max: 99 }),
+                name: faker.person.firstName(),
                 tag: faker.helpers.arrayElement([
-                  faker.random.word(),
+                  faker.word.sample(),
                   undefined,
                 ]),
               }),
@@ -38,7 +38,7 @@ export default defineConfig({
         },
         mock: {
           properties: {
-            '/tag|name/': () => faker.name.lastName(),
+            '/tag|name/': () => faker.person.lastName(),
           },
         },
       },

--- a/samples/angular-app/src/api/endpoints/pets/pets.msw.ts
+++ b/samples/angular-app/src/api/endpoints/pets/pets.msw.ts
@@ -9,19 +9,19 @@ import { rest } from 'msw';
 
 export const getListPetsMock = () =>
   Array.from(
-    { length: faker.datatype.number({ min: 1, max: 10 }) },
+    { length: faker.number.int({ min: 1, max: 10 }) },
     (_, i) => i + 1,
   ).map(() => ({
     id: faker.number.int({ min: undefined, max: undefined }),
-    name: (() => faker.name.lastName())(),
-    tag: (() => faker.name.lastName())(),
+    name: (() => faker.person.lastName())(),
+    tag: (() => faker.person.lastName())(),
   }));
 
 export const getShowPetByIdMock = () =>
   (() => ({
-    id: faker.datatype.number({ min: 1, max: 99 }),
-    name: faker.name.firstName(),
-    tag: faker.helpers.arrayElement([faker.random.word(), void 0]),
+    id: faker.number.int({ min: 1, max: 99 }),
+    name: faker.person.firstName(),
+    tag: faker.helpers.arrayElement([faker.word.sample(), void 0]),
   }))();
 
 export const getPetsMSW = () => [

--- a/samples/basic/api/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/basic/api/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -54,7 +54,7 @@ export type ShowPetByIdResult = AxiosResponse<Pet>;
 
 export const getListPetsMock = () =>
   Array.from(
-    { length: faker.datatype.number({ min: 1, max: 10 }) },
+    { length: faker.number.int({ min: 1, max: 10 }) },
     (_, i) => i + 1,
   ).map(() => ({
     id: faker.number.int({ min: undefined, max: undefined }),
@@ -64,9 +64,9 @@ export const getListPetsMock = () =>
 
 export const getShowPetByIdMock = () =>
   (() => ({
-    id: faker.datatype.number({ min: 1, max: 99 }),
-    name: faker.name.firstName(),
-    tag: faker.helpers.arrayElement([faker.random.word(), void 0]),
+    id: faker.number.int({ min: 1, max: 99 }),
+    name: faker.person.firstName(),
+    tag: faker.helpers.arrayElement([faker.word.sample(), void 0]),
   }))();
 
 export const getSwaggerPetstoreMSW = () => [

--- a/samples/basic/orval.config.ts
+++ b/samples/basic/orval.config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
             mock: {
               properties: () => {
                 return {
-                  id: faker.datatype.number({ min: 1, max: 9 }),
+                  id: faker.number.int({ min: 1, max: 9 }),
                 };
               },
             },
@@ -27,10 +27,10 @@ export default defineConfig({
           showPetById: {
             mock: {
               data: () => ({
-                id: faker.datatype.number({ min: 1, max: 99 }),
-                name: faker.name.firstName(),
+                id: faker.number.int({ min: 1, max: 99 }),
+                name: faker.person.firstName(),
                 tag: faker.helpers.arrayElement([
-                  faker.random.word(),
+                  faker.word.sample(),
                   undefined,
                 ]),
               }),

--- a/samples/nx-fastify-react/apps/api/src/main.ts
+++ b/samples/nx-fastify-react/apps/api/src/main.ts
@@ -58,10 +58,10 @@ app.ready(async () => {
 });
 
 export const getGetPetsMock = () =>
-  [...Array(faker.datatype.number({ min: 1, max: 10 }))].map(() => ({
-    id: faker.datatype.number(),
-    name: faker.random.word(),
-    tag: faker.random.word(),
+  [...Array(faker.number.int({ min: 1, max: 10 }))].map(() => ({
+    id: faker.number.int(),
+    name: faker.word.sample(),
+    tag: faker.word.sample(),
   }));
 
 app.get(

--- a/samples/react-app-with-swr/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
+++ b/samples/react-app-with-swr/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
@@ -9,7 +9,7 @@ import { rest } from 'msw';
 
 export const getListPetsMock = () =>
   Array.from(
-    { length: faker.datatype.number({ min: 1, max: 10 }) },
+    { length: faker.number.int({ min: 1, max: 10 }) },
     (_, i) => i + 1,
   ).map(() => ({
     '@id': faker.helpers.arrayElement([faker.word.sample(), undefined]),

--- a/samples/react-app/orval.config.ts
+++ b/samples/react-app/orval.config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
             mock: {
               properties: () => {
                 return {
-                  '[].id': () => faker.datatype.number({ min: 1, max: 99999 }),
+                  '[].id': () => faker.number.int({ min: 1, max: 99999 }),
                 };
               },
             },
@@ -27,10 +27,10 @@ export default defineConfig({
           showPetById: {
             mock: {
               data: () => ({
-                id: faker.datatype.number({ min: 1, max: 99 }),
-                name: faker.name.firstName(),
+                id: faker.number.int({ min: 1, max: 99 }),
+                name: faker.person.firstName(),
                 tag: faker.helpers.arrayElement([
-                  faker.random.word(),
+                  faker.word.sample(),
                   undefined,
                 ]),
               }),
@@ -39,7 +39,7 @@ export default defineConfig({
         },
         mock: {
           properties: {
-            '/tag|name/': () => faker.name.lastName(),
+            '/tag|name/': () => faker.person.lastName(),
           },
         },
       },

--- a/samples/react-app/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
+++ b/samples/react-app/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
@@ -9,19 +9,19 @@ import { rest } from 'msw';
 
 export const getListPetsMock = () =>
   Array.from(
-    { length: faker.datatype.number({ min: 1, max: 10 }) },
+    { length: faker.number.int({ min: 1, max: 10 }) },
     (_, i) => i + 1,
   ).map(() => ({
-    id: (() => faker.datatype.number({ min: 1, max: 99999 }))(),
-    name: (() => faker.name.lastName())(),
-    tag: (() => faker.name.lastName())(),
+    id: (() => faker.number.int({ min: 1, max: 99999 }))(),
+    name: (() => faker.person.lastName())(),
+    tag: (() => faker.person.lastName())(),
   }));
 
 export const getShowPetByIdMock = () =>
   (() => ({
-    id: faker.datatype.number({ min: 1, max: 99 }),
-    name: faker.name.firstName(),
-    tag: faker.helpers.arrayElement([faker.random.word(), void 0]),
+    id: faker.number.int({ min: 1, max: 99 }),
+    name: faker.person.firstName(),
+    tag: faker.helpers.arrayElement([faker.word.sample(), void 0]),
   }))();
 
 export const getSwaggerPetstoreMSW = () => [

--- a/samples/react-query/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
+++ b/samples/react-query/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
@@ -9,7 +9,7 @@ import { rest } from 'msw';
 
 export const getListPetsMock = () =>
   Array.from(
-    { length: faker.datatype.number({ min: 1, max: 10 }) },
+    { length: faker.number.int({ min: 1, max: 10 }) },
     (_, i) => i + 1,
   ).map(() =>
     faker.helpers.arrayElement([

--- a/samples/react-query/custom-client/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
+++ b/samples/react-query/custom-client/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
@@ -9,7 +9,7 @@ import { rest } from 'msw';
 
 export const getListPetsMock = () =>
   Array.from(
-    { length: faker.datatype.number({ min: 1, max: 10 }) },
+    { length: faker.number.int({ min: 1, max: 10 }) },
     (_, i) => i + 1,
   ).map(() => ({
     '@id': faker.helpers.arrayElement([faker.word.sample(), undefined]),

--- a/samples/svelte-query/orval.config.ts
+++ b/samples/svelte-query/orval.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
             mock: {
               properties: () => {
                 return {
-                  '[].id': () => faker.datatype.number({ min: 1, max: 99999 }),
+                  '[].id': () => faker.number.int({ min: 1, max: 99999 }),
                 };
               },
             },
@@ -28,10 +28,10 @@ export default defineConfig({
           showPetById: {
             mock: {
               data: () => ({
-                id: faker.datatype.number({ min: 1, max: 99 }),
-                name: faker.name.firstName(),
+                id: faker.number.int({ min: 1, max: 99 }),
+                name: faker.person.firstName(),
                 tag: faker.helpers.arrayElement([
-                  faker.datatype.string(),
+                  faker.string.sample(),
                   undefined,
                 ]),
               }),
@@ -40,7 +40,7 @@ export default defineConfig({
         },
         mock: {
           properties: {
-            '/tag|name/': () => faker.name.lastName(),
+            '/tag|name/': () => faker.person.lastName(),
           },
         },
       },

--- a/samples/svelte-query/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
+++ b/samples/svelte-query/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
@@ -9,19 +9,19 @@ import { rest } from 'msw';
 
 export const getListPetsMock = () =>
   Array.from(
-    { length: faker.datatype.number({ min: 1, max: 10 }) },
+    { length: faker.number.int({ min: 1, max: 10 }) },
     (_, i) => i + 1,
   ).map(() => ({
-    id: (() => faker.datatype.number({ min: 1, max: 99999 }))(),
-    name: (() => faker.name.lastName())(),
-    tag: (() => faker.name.lastName())(),
+    id: (() => faker.number.int({ min: 1, max: 99999 }))(),
+    name: (() => faker.person.lastName())(),
+    tag: (() => faker.person.lastName())(),
   }));
 
 export const getShowPetByIdMock = () =>
   (() => ({
-    id: faker.datatype.number({ min: 1, max: 99 }),
-    name: faker.name.firstName(),
-    tag: faker.helpers.arrayElement([faker.datatype.string(), void 0]),
+    id: faker.number.int({ min: 1, max: 99 }),
+    name: faker.person.firstName(),
+    tag: faker.helpers.arrayElement([faker.string.sample(), void 0]),
   }))();
 
 export const getSwaggerPetstoreMSW = () => [

--- a/samples/vue-query/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
+++ b/samples/vue-query/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
@@ -9,7 +9,7 @@ import { rest } from 'msw';
 
 export const getListPetsMock = () =>
   Array.from(
-    { length: faker.datatype.number({ min: 1, max: 10 }) },
+    { length: faker.number.int({ min: 1, max: 10 }) },
     (_, i) => i + 1,
   ).map(() => ({
     email: faker.helpers.arrayElement([faker.internet.email(), undefined]),


### PR DESCRIPTION
## Status

**READY**

## Description

Faker v8 has [deprecated a few methods](https://fakerjs.dev/guide/upgrading.html#deprecations-and-other-changes). Most of them were already updated in #978 , but arrays were still using `faker.datatype.number`. This PR fixes that, as well as deprecated uses found in the documentation and samples.