### PR TITLE
feat: disable minification

### DIFF
--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -8,7 +8,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup ./src/index.ts --target node12 --minify --clean --dts --splitting",
+    "build": "tsup ./src/index.ts --target node12 --clean --dts",
     "dev": "tsup ./src/index.ts --target node12 --clean --watch src",
     "lint": "eslint src/**/*.ts"
   },

--- a/packages/axios/package.json
+++ b/packages/axios/package.json
@@ -8,7 +8,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup ./src/index.ts --target node12 --minify --clean --dts --splitting",
+    "build": "tsup ./src/index.ts --target node12 --clean --dts",
     "dev": "tsup ./src/index.ts --target node12 --clean --watch src",
     "lint": "eslint src/**/*.ts"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,7 +8,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup ./src/index.ts --minify --clean --dts --splitting",
+    "build": "tsup ./src/index.ts --clean --dts",
     "dev": "tsup ./src/index.ts --clean --watch src",
     "lint": "eslint src/**/*.ts",
     "test": "vitest --global test.ts"

--- a/packages/msw/package.json
+++ b/packages/msw/package.json
@@ -8,7 +8,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup ./src/index.ts --target node12 --minify --clean --dts --splitting",
+    "build": "tsup ./src/index.ts --target node12 --clean --dts",
     "dev": "tsup ./src/index.ts --target node12 --clean --watch src",
     "lint": "eslint src/**/*.ts"
   },

--- a/packages/orval/package.json
+++ b/packages/orval/package.json
@@ -43,7 +43,7 @@
     "url": "https://github.com/anymaniax/orval"
   },
   "scripts": {
-    "build": "tsup ./src/bin/orval.ts ./src/index.ts --target node12 --minify --clean --dts --splitting",
+    "build": "tsup ./src/bin/orval.ts ./src/index.ts --target node12 --clean --dts",
     "dev": "tsup ./src/bin/orval.ts ./src/index.ts --target node12 --clean --watch ./src --onSuccess 'yarn generate-api'",
     "lint": "eslint src/**/*.ts",
     "generate-api": "node ./dist/bin/orval.js --config ../../samples/react-query/basic/orval.config.ts"

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -8,7 +8,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup ./src/index.ts --target node12 --minify --clean --dts --splitting",
+    "build": "tsup ./src/index.ts --target node12 --clean --dts",
     "dev": "tsup ./src/index.ts --target node12 --clean --watch src",
     "lint": "eslint src/**/*.ts"
   },

--- a/packages/swr/package.json
+++ b/packages/swr/package.json
@@ -8,7 +8,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup ./src/index.ts --target node12 --minify --clean --dts --splitting",
+    "build": "tsup ./src/index.ts --target node12 --clean --dts",
     "dev": "tsup ./src/index.ts --target node12 --clean --watch src",
     "lint": "eslint src/**/*.ts"
   },

--- a/packages/zod/package.json
+++ b/packages/zod/package.json
@@ -8,7 +8,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup ./src/index.ts --target node12 --minify --clean --dts --splitting",
+    "build": "tsup ./src/index.ts --target node12 --clean --dts",
     "dev": "tsup ./src/index.ts --target node12 --clean --watch src",
     "lint": "eslint src/**/*.ts"
   },


### PR DESCRIPTION
## Status

**READY**

## Description

Resolves #964 

There's no need to minify the code, since Orval is only used as a dev dependency and never at runtime. I've also disabled `splitting` as it generates extra files that constantly change between versions, which can make debugging harder.