### PR TITLE
fix:  Nullable enums break strict mode tsc checks

### DIFF
--- a/packages/core/src/getters/enum.ts
+++ b/packages/core/src/getters/enum.ts
@@ -2,7 +2,14 @@ import { keyword } from 'esutils';
 import { isNumeric, sanitize } from '../utils';
 
 export const getEnum = (value: string, enumName: string, names?: string[]) => {
-  let enumValue = `export type ${enumName} = typeof ${enumName}[keyof typeof ${enumName}];\n`;
+  let enumValue = `export type ${enumName} = typeof ${enumName}[keyof typeof ${enumName}]`;
+
+  if (value.endsWith(' | null')) {
+    value = value.replace(' | null', '');
+    enumValue += ' | null';
+  }
+
+  enumValue += ';\n';
 
   const implementation = getEnumImplementation(value, names);
 

--- a/tests/configs/default.config.ts
+++ b/tests/configs/default.config.ts
@@ -64,6 +64,13 @@ export default defineConfig({
       target: '../generated/default/null-type-v3-0/endpoints.ts',
     },
   },
+  'nullable-enum': {
+    input: '../specifications/nullable-enum.yaml',
+    output: {
+      schemas: '../generated/default/nullable-enum/model',
+      target: '../generated/default/nullable-enum/endpoints.ts',
+    },
+  },
   readonly: {
     input: '../specifications/readonly.yaml',
     output: {

--- a/tests/specifications/nullable-enum.yaml
+++ b/tests/specifications/nullable-enum.yaml
@@ -1,0 +1,66 @@
+openapi: 3.0.0
+info:
+  title: Nullables
+  description: 'OpenAPI 3.0 Nullable types'
+  version: 1.0.0
+tags:
+  - name: nullables
+    description: Nullable types
+servers:
+  - url: http://localhost
+paths:
+  /post-object-with-nullable-enum:
+    post:
+      tags:
+        - nullables
+      summary: Nullable object with nullable properties request
+      operationId: createNullableObject
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ObjectWithNullableEnum'
+      responses:
+        200:
+          description: Successful Operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ObjectWithNullableEnum'
+  /get-object-with-nullable-enum:
+    get:
+      tags:
+        - nullables
+      summary: Nullable object with nullable properties response
+      operationId: getNullableObject
+      parameters:
+        - name: nullableEnum
+          in: query
+          description: Nullable enum
+          required: false
+          schema:
+            type: string
+            nullable: true
+            enum:
+              - ONE
+              - TWO
+              - THREE
+      responses:
+        200:
+          description: Successful Operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ObjectWithNullableEnum'
+components:
+  schemas:
+    ObjectWithNullableEnum:
+      type: object
+      properties:
+        nullableEnum:
+          type: string
+          nullable: true
+          enum:
+            - ONE
+            - TWO
+            - THREE


### PR DESCRIPTION
## Status

Fix  #913

**READY**

## Description

Now generates nullable enum choices as:

```
export const Choices = {
  NUMBER_1: 1,
  NUMBER_2: 2,
  NUMBER_3: 3,
} as const;

export type Choices = typeof Choices[keyof typeof Choices] | null;
```

Instead of:

```typescript
export const Choices = {
  NUMBER_1: 1,
  NUMBER_2: 2,
  NUMBER_3: 3,
  null: null,
} as const;
``` 

to avoid breaking tsc strict mode checks.

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

Added a test specification `tests/specifications/nullable-enum.yaml`