### PR TITLE
fix(core): capitalize http verb patch

### DIFF
--- a/docs/src/pages/guides/custom-client.md
+++ b/docs/src/pages/guides/custom-client.md
@@ -31,7 +31,7 @@ export const customInstance = async <T>({
   data,
 }: {
   url: string;
-  method: 'get' | 'post' | 'put' | 'delete' | 'patch';
+  method: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
   params?: any;
   data?: BodyType<unknown>;
   responseType?: string;

--- a/docs/src/pages/reference/configuration/output.md
+++ b/docs/src/pages/reference/configuration/output.md
@@ -334,7 +334,7 @@ Possible arguments:
 ```ts
 // based on AxiosRequestConfig
 interface RequestConfig {
-  method: 'get' | 'put' | 'patch' | 'post' | 'delete';
+  method: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
   url: string;
   params?: any;
   data?: any;
@@ -691,7 +691,7 @@ module.exports = {
         mock: {
           properties: {
             '/tag|name/': 'jon', // Matches every property named 'tag' or 'name', including nested ones
-            '/.*\.user\.id/': faker.string.uuid(), // Matches every property named 'id', inside an object named 'user', including nested ones
+            '/.*.user.id/': faker.string.uuid(), // Matches every property named 'id', inside an object named 'user', including nested ones
             email: () => faker.internet.email(), // Matches only the property 'email'
             'user.id': () => faker.string.uuid(), // Matches only the full path 'user.id'
           },

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -388,15 +388,15 @@ export type HooksOptions<T = HookCommand | NormalizedHookCommand> = Partial<
 
 export type NormalizedHookOptions = HooksOptions<NormalizedHookCommand>;
 
-export type Verbs = 'post' | 'put' | 'get' | 'patch' | 'delete' | 'head';
+export type Verbs = 'POST' | 'PUT' | 'GET' | 'PATCH' | 'DELETE' | 'HEAD';
 
 export const Verbs = {
-  POST: 'post' as Verbs,
-  PUT: 'put' as Verbs,
-  GET: 'get' as Verbs,
-  PATCH: 'patch' as Verbs,
-  DELETE: 'delete' as Verbs,
-  HEAD: 'head' as Verbs,
+  POST: 'POST' as Verbs,
+  PUT: 'PUT' as Verbs,
+  GET: 'GET' as Verbs,
+  PATCH: 'PATCH' as Verbs,
+  DELETE: 'DELETE' as Verbs,
+  HEAD: 'HEAD' as Verbs,
 };
 
 export type ImportOpenApi = {

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -56,7 +56,7 @@ const generateZodValidationSchemaDefinition = (
 ): { functions: [string, any][]; consts: string[] } => {
   if (!schema) return { functions: [], consts: [] };
 
-  const consts = [];
+  const consts: any[] = [];
   const functions: [string, any][] = [];
   const type = resolveZodType(schema.type);
   const required = schema.default !== undefined ? false : _required ?? false;
@@ -279,7 +279,7 @@ const parseZodValidationSchemaDefinition = (
     if (fn === 'additionalProperties') {
       const value = args.functions.map(parseProperty).join('');
       const valueWithZod = `${value.startsWith('.') ? 'zod' : ''}${value}`;
-      consts += args.consts
+      consts += args.consts;
       return `zod.record(zod.string(), ${valueWithZod})`;
     }
 
@@ -357,9 +357,10 @@ const generateZodRoute = (
     | PathItemObject
     | undefined;
 
-  const parameters = spec?.[verb]?.parameters;
-  const requestBody = spec?.[verb]?.requestBody;
-  const response = spec?.[verb]?.responses?.['200'] as
+  const httpVerb = verb?.toString().toLowerCase();
+  const parameters = spec?.[httpVerb]?.parameters;
+  const requestBody = spec?.[httpVerb]?.requestBody;
+  const response = spec?.[httpVerb]?.responses?.['200'] as
     | ResponseObject
     | ReferenceObject;
 

--- a/packages/zod/tsconfig.json
+++ b/packages/zod/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts"],
+  "compilerOptions": {
+    "noImplicitAny": false
+  }
 }

--- a/samples/react-query/custom-client/src/api/mutator/custom-client.ts
+++ b/samples/react-query/custom-client/src/api/mutator/custom-client.ts
@@ -5,7 +5,7 @@ export const AXIOS_INSTANCE = Axios.create({ baseURL: '' });
 
 type CustomClient<T> = (data: {
   url: string;
-  method: 'get' | 'post' | 'put' | 'delete' | 'patch';
+  method: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
   params?: Record<string, any>;
   headers?: Record<string, any>;
   data?: BodyType<unknown>;

--- a/tests/mutators/custom-client.ts
+++ b/tests/mutators/custom-client.ts
@@ -5,7 +5,7 @@ export const customClient = async <ResponseType>({
   data,
 }: {
   url: string;
-  method: 'get' | 'post' | 'put' | 'delete' | 'patch';
+  method: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
   params?: Record<string, string>;
   data?: BodyType<unknown>;
   headers?: Record<string, string>;


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

READY

## Description

Changed the HTTP verb 'patch' to 'PATCH'. 
PATCH is the only HTTP method that is case sensitive. It needs to be capitalized to work.

## Related PRs

List related PRs against other branches:

None

## Todos

- [x] Tests
- [x] Documentation
- [x] Changelog Entry (unreleased)
