### PR TITLE
fix: improve isurl regex

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,17 +14,16 @@
     "test": "vitest --global test.ts"
   },
   "devDependencies": {
-    "@types/debug": "^4.1.10",
-    "@types/fs-extra": "^11.0.3",
-    "@types/inquirer": "^9.0.6",
-    "@types/lodash.get": "^4.4.8",
-    "@types/lodash.isempty": "^4.4.8",
-    "@types/lodash.omit": "^4.5.8",
-    "@types/lodash.uniq": "^4.5.8",
-    "@types/lodash.uniqby": "^4.7.8",
-    "@types/lodash.uniqwith": "^4.5.8",
-    "@types/micromatch": "^4.0.4",
-    "@types/validator": "^13.11.5"
+    "@types/debug": "^4.1.12",
+    "@types/fs-extra": "^11.0.4",
+    "@types/inquirer": "^9.0.7",
+    "@types/lodash.get": "^4.4.9",
+    "@types/lodash.isempty": "^4.4.9",
+    "@types/lodash.omit": "^4.5.9",
+    "@types/lodash.uniq": "^4.5.9",
+    "@types/lodash.uniqby": "^4.7.9",
+    "@types/lodash.uniqwith": "^4.5.9",
+    "@types/micromatch": "^4.0.5"
   },
   "dependencies": {
     "@apidevtools/swagger-parser": "^10.1.0",
@@ -47,7 +46,6 @@
     "micromatch": "^4.0.5",
     "openapi-types": "^12.1.3",
     "openapi3-ts": "^3.2.0",
-    "swagger2openapi": "^7.0.8",
-    "validator": "^13.11.0"
+    "swagger2openapi": "^7.0.8"
   }
 }

--- a/packages/core/src/utils/assertion.test.ts
+++ b/packages/core/src/utils/assertion.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { isUrl } from './assertion';
+
+describe('assertion testing', () => {
+  it('check for valid URLs', () => {
+    expect(isUrl('http://my-docker-service/docs.json')).toBeTruthy();
+    expect(isUrl('https://www.example.com')).toBeTruthy();
+    expect(isUrl('http://localhost:8080/docs/spec.yaml')).toBeTruthy();
+    expect(isUrl('http://localhost/test.json')).toBeTruthy();
+    expect(isUrl('http://localhost:6001/swagger/v1/swagger.json')).toBeTruthy();
+    expect(isUrl('D:/a/test.txt')).toBeFalsy();
+    expect(isUrl('./file.txt')).toBeFalsy();
+  });
+});

--- a/packages/core/src/utils/assertion.ts
+++ b/packages/core/src/utils/assertion.ts
@@ -1,5 +1,4 @@
 import { ReferenceObject, SchemaObject } from 'openapi3-ts';
-import validatorIsUrl from 'validator/lib/isURL';
 import { SchemaType, Verbs } from '../types';
 import { extname } from './path';
 
@@ -81,5 +80,11 @@ export const isRootKey = (specKey: string, target: string) => {
 };
 
 export const isUrl = (str: string) => {
-  return validatorIsUrl(str, { require_tld: false });
+  let givenURL;
+  try {
+    givenURL = new URL(str);
+  } catch (error) {
+    return false;
+  }
+  return givenURL.protocol === 'http:' || givenURL.protocol === 'https:';
 };


### PR DESCRIPTION
Improves on #920 and adds unit tests

Ensures that new scenario and old scenarios are still all working so we don't keep breaking this.

according to Snyk this is the correct way to detect a URL: https://snyk.io/blog/secure-javascript-url-validation/