### PR TITLE
fix(msw): faker object keys no longer in quotes

### DIFF
--- a/packages/msw/src/getters/object.ts
+++ b/packages/msw/src/getters/object.ts
@@ -149,7 +149,7 @@ export const getMockObject = ({
     return {
       ...resolvedValue,
       value: `{
-        '[${DEFAULT_OBJECT_KEY_MOCK}]': ${resolvedValue.value}
+        [${DEFAULT_OBJECT_KEY_MOCK}]: ${resolvedValue.value}
       }`,
     };
   }


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

Fixed the faker object keys for generation to not be wrapped in quotes anymore. 

## Related PRs

List related PRs against other branches:

#980 

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

