### PR TITLE
Fix(MSW):non ref enum const

### DIFF
--- a/packages/msw/src/getters/object.ts
+++ b/packages/msw/src/getters/object.ts
@@ -7,7 +7,6 @@ import {
   isReference,
   MockOptions,
 } from '@orval/core';
-import cuid from 'cuid';
 import { ReferenceObject, SchemaObject } from 'openapi3-ts';
 import { resolveMockValue } from '../resolvers/value';
 import { MockDefinition, MockSchemaObject } from '../types';

--- a/packages/msw/src/getters/scalar.ts
+++ b/packages/msw/src/getters/scalar.ts
@@ -6,6 +6,7 @@ import {
   isRootKey,
   mergeDeep,
   MockOptions,
+  log,
 } from '@orval/core';
 import { DEFAULT_FORMAT_MOCK } from '../constants';
 import {
@@ -37,6 +38,8 @@ export const getMockScalar = ({
   };
   context: ContextSpecs;
 }): MockDefinition => {
+  log(item);
+
   const operationProperty = resolveMockOverride(
     mockOptions?.operations?.[operationId]?.properties,
     item,
@@ -191,9 +194,12 @@ export const getMockScalar = ({
       let imports: GeneratorImport[] = [];
 
       if (item.enum) {
+        // By default the value isn't a reference, so we don't have the object explicitly defined.
+        // So we have to create an array with the enum values and force them to be a const.
         let enumValue =
-          "['" + item.enum.map((e) => escape(e)).join("','") + "']";
+          "['" + item.enum.map((e) => escape(e)).join("','") + "'] as const";
 
+        // But if the value is a reference, we can use the object directly via the imports and using Object.values.
         if (item.isRef) {
           enumValue = `Object.values(${item.name})`;
           imports = [

--- a/packages/msw/src/getters/scalar.ts
+++ b/packages/msw/src/getters/scalar.ts
@@ -6,7 +6,6 @@ import {
   isRootKey,
   mergeDeep,
   MockOptions,
-  log,
 } from '@orval/core';
 import { DEFAULT_FORMAT_MOCK } from '../constants';
 import {
@@ -38,8 +37,6 @@ export const getMockScalar = ({
   };
   context: ContextSpecs;
 }): MockDefinition => {
-  log(item);
-
   const operationProperty = resolveMockOverride(
     mockOptions?.operations?.[operationId]?.properties,
     item,


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

When a non-ref (non-importable) enum exists for the MSW generators, we now add an `as const` to enforce constant type handling here. Also added comments explaining this logic.

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

<img width="844" alt="CleanShot 2023-11-10 at 23 20 01@2x" src="https://github.com/anymaniax/orval/assets/7892675/d0910510-feb9-4bac-80bc-c561ee7039d7">

Fixes #960 