### PR TITLE
fix(MSW): accounted for properties with the same name

### DIFF
--- a/packages/msw/src/getters/combine.ts
+++ b/packages/msw/src/getters/combine.ts
@@ -17,6 +17,7 @@ export const combineSchemasMock = ({
   combine,
   context,
   imports,
+  existingReferencedProperties,
 }: {
   item: MockSchemaObject;
   separator: 'allOf' | 'oneOf' | 'anyOf';
@@ -29,6 +30,9 @@ export const combineSchemasMock = ({
   };
   context: ContextSpecs;
   imports: GeneratorImport[];
+  // This is used to prevent recursion when combining schemas
+  // When an element is added to the array, it means on this iteration, we've already seen this property
+  existingReferencedProperties: string[];
 }) => {
   let combineImports: GeneratorImport[] = [];
   let includedProperties: string[] = (combine?.includedProperties ?? []).slice(
@@ -47,6 +51,7 @@ export const combineSchemasMock = ({
           tags,
           context,
           imports,
+          existingReferencedProperties,
         })
       : undefined;
 
@@ -72,6 +77,7 @@ export const combineSchemasMock = ({
       tags,
       context,
       imports,
+      existingReferencedProperties,
     });
 
     combineImports.push(...resolvedValue.imports);

--- a/packages/msw/src/getters/object.ts
+++ b/packages/msw/src/getters/object.ts
@@ -21,6 +21,7 @@ export const getMockObject = ({
   combine,
   context,
   imports,
+  existingReferencedProperties,
 }: {
   item: MockSchemaObject;
   operationId: string;
@@ -32,6 +33,9 @@ export const getMockObject = ({
   };
   context: ContextSpecs;
   imports: GeneratorImport[];
+  // This is used to prevent recursion when combining schemas
+  // When an element is added to the array, it means on this iteration, we've already seen this property
+  existingReferencedProperties: string[];
 }): MockDefinition => {
   if (isReference(item)) {
     return resolveMockValue({
@@ -45,6 +49,7 @@ export const getMockObject = ({
       tags,
       context,
       imports,
+      existingReferencedProperties,
     });
   }
 
@@ -59,6 +64,7 @@ export const getMockObject = ({
       combine,
       context,
       imports,
+      existingReferencedProperties,
     });
   }
 
@@ -84,7 +90,12 @@ export const getMockObject = ({
           mockOptions?.required ||
           (Array.isArray(item.required) ? item.required : []).includes(key);
 
-        if (count(item.path, `\\.${key}\\.`) >= 1) {
+        // Check to see if the property is a reference to an existing property
+        // Fixes issue #910
+        if (
+          '$ref' in prop &&
+          existingReferencedProperties.includes(prop.$ref.split('/').pop()!)
+        ) {
           return undefined;
         }
 
@@ -99,6 +110,7 @@ export const getMockObject = ({
           tags,
           context,
           imports,
+          existingReferencedProperties,
         });
 
         imports.push(...resolvedValue.imports);
@@ -143,6 +155,7 @@ export const getMockObject = ({
       tags,
       context,
       imports,
+      existingReferencedProperties,
     });
 
     return {

--- a/packages/msw/src/getters/scalar.ts
+++ b/packages/msw/src/getters/scalar.ts
@@ -24,6 +24,7 @@ export const getMockScalar = ({
   tags,
   combine,
   context,
+  existingReferencedProperties,
 }: {
   item: MockSchemaObject;
   imports: GeneratorImport[];
@@ -36,7 +37,15 @@ export const getMockScalar = ({
     includedProperties: string[];
   };
   context: ContextSpecs;
+  // This is used to prevent recursion when combining schemas
+  // When an element is added to the array, it means on this iteration, we've already seen this property
+  existingReferencedProperties: string[];
 }): MockDefinition => {
+  // Add the property to the existing properties to validate on object recursion
+  if (item.isRef) {
+    existingReferencedProperties = [...existingReferencedProperties, item.name];
+  }
+
   const operationProperty = resolveMockOverride(
     mockOptions?.operations?.[operationId]?.properties,
     item,
@@ -136,6 +145,7 @@ export const getMockScalar = ({
         tags,
         context,
         imports,
+        existingReferencedProperties,
       });
 
       if (enums) {
@@ -231,6 +241,7 @@ export const getMockScalar = ({
         combine,
         context,
         imports,
+        existingReferencedProperties,
       });
     }
   }

--- a/packages/msw/src/mocks.ts
+++ b/packages/msw/src/mocks.ts
@@ -178,6 +178,7 @@ export const getResponsesMockDefinition = ({
               specKey: response.imports[0]?.specKey ?? context.specKey,
             }
           : context,
+        existingReferencedProperties: [],
       });
 
       acc.imports.push(...scalar.imports);

--- a/packages/msw/src/resolvers/value.ts
+++ b/packages/msw/src/resolvers/value.ts
@@ -55,6 +55,7 @@ export const resolveMockValue = ({
   combine,
   context,
   imports,
+  existingReferencedProperties,
 }: {
   schema: MockSchemaObject;
   operationId: string;
@@ -66,6 +67,9 @@ export const resolveMockValue = ({
   };
   context: ContextSpecs;
   imports: GeneratorImport[];
+  // This is used to prevent recursion when combining schemas
+  // When an element is added to the array, it means on this iteration, we've already seen this property
+  existingReferencedProperties: string[];
 }): MockDefinition & { type?: string } => {
   if (isReference(schema)) {
     const {
@@ -94,6 +98,7 @@ export const resolveMockValue = ({
         specKey,
       },
       imports,
+      existingReferencedProperties,
     });
 
     return {
@@ -110,6 +115,7 @@ export const resolveMockValue = ({
     combine,
     context,
     imports,
+    existingReferencedProperties,
   });
 
   return {


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**
Fix #910
Fix #764 

## Description

Added an explicit `existingRecursiveProperties` flag to account for if the recursive property has been accounted for already - to prevent infinite looping (which is what the old fix did, but had this bug as well).

This openapi schema will generate this MSW now.

```yaml
openapi: "3.0.0"
info:
  version: 1.0.0
  title: Swagger Petstore
  license:
    name: MIT
servers:
  - url: http://petstore.swagger.io/v1
paths:
  /pets/{petId}:
    get:
      summary: Info for a specific pet
      operationId: showPetById
      parameters:
        - name: petId
          in: path
          required: true
          description: The id of the pet to retrieve
          schema:
            type: string
      responses:
        "200":
          description: Expected response to a valid request
          content:
            application/json:
              schema:
                $ref: "#/components/schemas/Pet"
components:
  schemas:
    Pet:
      type: object
      required:
        - id
        - name
      properties:
        id:
          type: integer
          format: int64
        name:
          type: string
        tag:
          type: string
        parent:
          $ref: "#/components/schemas/Parent"
    Parent:
      type: object
      required:
        - id
        - name
      properties:
        id:
          type: integer
          format: int64
        name:
          type: string
        tag:
          type: string
        parent:
          $ref: "#/components/schemas/GrandParent"
    GrandParent:
      type: object
      required:
        - id
        - name
        - parent
      properties:
        id:
          type: integer
          format: int64
        name:
          type: string
        tag:
          type: string
        parent:
          $ref: "#/components/schemas/GreatParent"
    GreatParent:
      type: object
      required:
        - id
        - name
        - parent
      properties:
        id:
          type: integer
          format: int64
        name:
          type: string
        tag:
          type: string
        # purely to check to see if recursive schemas are handled
        parent:
          $ref: "#/components/schemas/Parent"

```

```typescript
/**
 * Generated by orval v6.20.0 🍺
 * Do not edit manually.
 * Swagger Petstore
 * OpenAPI spec version: 1.0.0
 */
import { faker } from "@faker-js/faker";
import { HttpResponse, delay, http } from "msw";

export const getShowPetByIdMock = () => ({
  id: faker.number.int({ min: undefined, max: undefined }),
  name: faker.word.sample(),
  parent: faker.helpers.arrayElement([
    {
      id: faker.number.int({ min: undefined, max: undefined }),
      name: faker.word.sample(),
      parent: faker.helpers.arrayElement([
        {
          id: faker.number.int({ min: undefined, max: undefined }),
          name: faker.word.sample(),
          parent: {
            id: faker.number.int({ min: undefined, max: undefined }),
            name: faker.word.sample(),
            tag: faker.helpers.arrayElement([faker.word.sample(), undefined]),
          },
          tag: faker.helpers.arrayElement([faker.word.sample(), undefined]),
        },
        undefined,
      ]),
      tag: faker.helpers.arrayElement([faker.word.sample(), undefined]),
    },
    undefined,
  ]),
  tag: faker.helpers.arrayElement([faker.word.sample(), undefined]),
});

export const getDefaultMSW = () => [
  http.get("*/pets/:petId", async () => {
    await delay(1000);
    return new HttpResponse(JSON.stringify(getShowPetByIdMock()), {
      status: 200,
      headers: {
        "Content-Type": "application/json",
      },
    });
  }),
];

```
