### PR TITLE
fix: uppercase method verbs

### DIFF
--- a/packages/core/src/generators/options.ts
+++ b/packages/core/src/generators/options.ts
@@ -268,7 +268,7 @@ export const generateMutatorConfig = ({
     ? ',\n      headers'
     : '';
 
-  return `{url: \`${route}\`, method: '${verb}'${headerOptions}${bodyOptions}${queryParamsOptions}${
+  return `{url: \`${route}\`, method: '${verb.toUpperCase()}'${headerOptions}${bodyOptions}${queryParamsOptions}${
     !isBodyVerb && hasSignal
       ? `, ${
           isExactOptionalPropertyTypes

--- a/packages/core/src/utils/assertion.ts
+++ b/packages/core/src/utils/assertion.ts
@@ -1,5 +1,4 @@
 import { ReferenceObject, SchemaObject } from 'openapi3-ts';
-import validatorIsUrl from 'validator/lib/isURL';
 import { SchemaType, Verbs } from '../types';
 import { extname } from './path';
 
@@ -81,5 +80,11 @@ export const isRootKey = (specKey: string, target: string) => {
 };
 
 export const isUrl = (str: string) => {
-  return validatorIsUrl(str, { require_tld: false });
+  let givenURL;
+  try {
+    givenURL = new URL(str);
+  } catch (error) {
+    return false;
+  }
+  return givenURL.protocol === 'http:' || givenURL.protocol === 'https:';
 };

--- a/tests/mutators/custom-client.ts
+++ b/tests/mutators/custom-client.ts
@@ -5,7 +5,7 @@ export const customClient = async <ResponseType>({
   data,
 }: {
   url: string;
-  method: 'get' | 'post' | 'put' | 'delete' | 'patch';
+  method: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
   params?: Record<string, string>;
   data?: BodyType<unknown>;
   headers?: Record<string, string>;


### PR DESCRIPTION
## Status

Fix #888 

Bare minimum change and least invasive to uppercase the Axios method like...

```js
method: 'GET'
```
