### PR TITLE
Add option to enable Zod type coercion for query params

### DIFF
--- a/docs/src/pages/reference/configuration/output.md
+++ b/docs/src/pages/reference/configuration/output.md
@@ -691,7 +691,7 @@ module.exports = {
         mock: {
           properties: {
             '/tag|name/': 'jon', // Matches every property named 'tag' or 'name', including nested ones
-            '/.*\.user\.id/': faker.string.uuid(), // Matches every property named 'id', inside an object named 'user', including nested ones
+            '/.*.user.id/': faker.string.uuid(), // Matches every property named 'id', inside an object named 'user', including nested ones
             email: () => faker.internet.email(), // Matches only the property 'email'
             'user.id': () => faker.string.uuid(), // Matches only the full path 'user.id'
           },
@@ -1153,6 +1153,30 @@ module.exports = {
     output: {
       override: {
         useBigInt: true,
+      },
+    },
+  },
+};
+```
+
+#### coerceTypes
+
+Type: `Boolean`
+
+Valid values: true or false. Defaults to false.
+
+Use this property to enable [type coercion](https://zod.dev/?id=coercion-for-primitives) for [Zod](https://zod.dev/) schemas (only applies to query parameters schemas).
+
+This is helpful if you want to use the zod schema to coerce (likely string-serialized) query parameters into the correct type before validation.
+
+Example:
+
+```js
+module.exports = {
+  petstore: {
+    output: {
+      override: {
+        coerceTypes: true,
       },
     },
   },

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -107,6 +107,7 @@ export type NormalizedOverrideOutput = {
   ) => string;
   requestOptions: Record<string, any> | boolean;
   useDates?: boolean;
+  coerceTypes?: boolean;
   useTypeOverInterfaces?: boolean;
   useDeprecatedOperations?: boolean;
   useBigInt?: boolean;

--- a/packages/zod/package.json
+++ b/packages/zod/package.json
@@ -10,7 +10,8 @@
   "scripts": {
     "build": "tsup ./src/index.ts --target node12 --minify --clean --dts --splitting",
     "dev": "tsup ./src/index.ts --target node12 --clean --watch src",
-    "lint": "eslint src/**/*.ts"
+    "lint": "eslint src/**/*.ts",
+    "test": "vitest --global test.ts"
   },
   "dependencies": {
     "@orval/core": "6.19.1",

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -49,6 +49,9 @@ const resolveZodType = (schemaTypeValue: SchemaObject['type']) => {
   }
 };
 
+// https://github.com/colinhacks/zod#coercion-for-primitives
+const COERCEABLE_TYPES = ['string', 'number', 'boolean', 'bigint', 'date'];
+
 const generateZodValidationSchemaDefinition = (
   schema: SchemaObject | undefined,
   _required: boolean | undefined,
@@ -227,8 +230,14 @@ const generateZodValidationSchemaDefinition = (
   return { functions, consts: uniq(consts) };
 };
 
-const parseZodValidationSchemaDefinition = (
-  input: Record<string, { functions: [string, any][]; consts: string[] }>,
+export type ZodValidationSchemaDefinitionInput = Record<
+  string,
+  { functions: [string, any][]; consts: string[] }
+>;
+
+export const parseZodValidationSchemaDefinition = (
+  input: ZodValidationSchemaDefinitionInput,
+  coerceTypes = false,
 ): { zod: string; consts: string } => {
   if (!Object.keys(input).length) {
     return { zod: '', consts: '' };
@@ -279,7 +288,7 @@ const parseZodValidationSchemaDefinition = (
     if (fn === 'additionalProperties') {
       const value = args.functions.map(parseProperty).join('');
       const valueWithZod = `${value.startsWith('.') ? 'zod' : ''}${value}`;
-      consts += args.consts
+      consts += args.consts;
       return `zod.record(zod.string(), ${valueWithZod})`;
     }
 
@@ -293,6 +302,11 @@ const parseZodValidationSchemaDefinition = (
       consts += args.consts;
       return `.array(${value.startsWith('.') ? 'zod' : ''}${value})`;
     }
+
+    if (coerceTypes && COERCEABLE_TYPES.includes(fn)) {
+      return `.coerce.${fn}(${args})`;
+    }
+
     return `.${fn}(${args})`;
   };
 
@@ -301,12 +315,12 @@ const parseZodValidationSchemaDefinition = (
   }, '');
 
   const zod = `zod.object({
-  ${Object.entries(input)
-    .map(([key, schema]) => {
-      const value = schema.functions.map(parseProperty).join('');
-      return `"${key}": ${value.startsWith('.') ? 'zod' : ''}${value}`;
-    })
-    .join(',')}
+${Object.entries(input)
+  .map(([key, schema]) => {
+    const value = schema.functions.map(parseProperty).join('');
+    return `  "${key}": ${value.startsWith('.') ? 'zod' : ''}${value}`;
+  })
+  .join(',\n')}
 })`;
 
   return { zod, consts };
@@ -351,7 +365,7 @@ const deference = (
 
 const generateZodRoute = (
   { operationName, body, verb }: GeneratorVerbOptions,
-  { pathRoute, context }: GeneratorOptions,
+  { pathRoute, context, override }: GeneratorOptions,
 ) => {
   const spec = context.specs[context.specKey].paths[pathRoute] as
     | PathItemObject
@@ -485,6 +499,7 @@ const generateZodRoute = (
   );
   const inputQueryParams = parseZodValidationSchemaDefinition(
     zodDefinitionsParameters.queryParams,
+    override.coerceTypes,
   );
   const inputHeaders = parseZodValidationSchemaDefinition(
     zodDefinitionsParameters.headers,

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import {
+  type ZodValidationSchemaDefinitionInput,
+  parseZodValidationSchemaDefinition,
+} from '.';
+
+const queryParams: ZodValidationSchemaDefinitionInput = {
+  // limit = non-required integer schema (coerce-able)
+  limit: {
+    functions: [
+      ['number', undefined],
+      ['optional', undefined],
+    ],
+    consts: [],
+  },
+
+  // q = non-required string array schema (not coerce-able)
+  q: {
+    functions: [
+      [
+        'array',
+        {
+          functions: [['string', undefined]],
+          consts: [],
+        },
+      ],
+      ['optional', undefined],
+    ],
+    consts: [],
+  },
+};
+
+describe('parseZodValidationSchemaDefinition', () => {
+  describe('with `override.coerceTypes = false` (default)', () => {
+    it('does not emit coerced zod property schemas', () => {
+      const parseResult = parseZodValidationSchemaDefinition(queryParams);
+
+      expect(parseResult.zod).toBe(
+        'zod.object({\n  "limit": zod.number().optional(),\n  "q": zod.array(zod.string()).optional()\n})',
+      );
+    });
+  });
+
+  describe('with `override.coerceTypes = true`', () => {
+    it('emits coerced zod property schemas', () => {
+      const parseResult = parseZodValidationSchemaDefinition(queryParams, true);
+
+      expect(parseResult.zod).toBe(
+        'zod.object({\n  "limit": zod.coerce.number().optional(),\n  "q": zod.array(zod.coerce.string()).optional()\n})',
+      );
+    });
+  });
+});

--- a/tests/configs/zod-parameters.config.ts
+++ b/tests/configs/zod-parameters.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'orval';
+
+export default defineConfig({
+  basic: {
+    output: {
+      target: '../generated/zod',
+      client: 'zod',
+      override: {
+        coerceTypes: true,
+      },
+    },
+    input: {
+      target: '../specifications/parameters.yaml',
+    },
+  },
+});

--- a/tests/package.json
+++ b/tests/package.json
@@ -16,6 +16,7 @@
     "generate:swr": "yarn orval --config ./configs/swr.config.ts",
     "generate:multi-file": "yarn orval --config ./configs/multi-file.config.ts",
     "generate:zod": "yarn orval --config ./configs/zod.config.ts",
+    "generate:zod-parameters": "yarn orval --config ./configs/zod-parameters.config.ts",
     "build": "tsc"
   },
   "author": "Victor Bury",

--- a/tests/specifications/parameters.yaml
+++ b/tests/specifications/parameters.yaml
@@ -21,12 +21,56 @@ paths:
       tags:
         - pets
       parameters:
+        - name: q
+          in: query
+          description: Filter pets by substring
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
         - name: limit
           in: query
           description: How many items to return at one time (max 100)
           required: false
           schema:
+            type: integer
+            format: int32
+        - name: offset
+          in: query
+          description: How many items to skip
+          required: false
+          schema:
+            type: integer
+            format: int32
+        - name: order
+          in: query
+          description: How to order the items
+          required: false
+          schema:
             type: string
+            enum: [asc, desc]
+        - name: sort
+          in: query
+          description: |
+            Which property to sort by?
+            Example: name sorts ASC while -name sorts DESC.
+          required: false
+          schema:
+            type: string
+            enum:
+              - name
+              - -name
+              - age
+              - -age
+        - name: cnonly
+          in: query
+          description: |
+            Only return pets from China?
+            Example: true
+          required: false
+          schema:
+            type: boolean
       responses:
         '200':
           description: A paged array of pets


### PR DESCRIPTION
## Status

**READY**

## Description

Fix #961 I expressed a desire to make the generated zod schema for endpoint query parameters more useful for parsing and validating `URLSearchParams` by making use of zod's type-coercion. It turns out that part of this problem isn't easily solvable within this library's generated code (more on that below), but the part that is ended up being relatively simple to add.

This PR is one possible (relatively naive) approach to how that might work.

#### **Key points**:
- adds a new `override.coerceTypes` boolean flag to the output config
- when enabled, the zod codegen will emit e.g. `zod.coerce.string()` instead of `zod.string()`
- this only applies only to coerce-able types (string, number, boolean, bigint, date)
- this _will_ apply to nested schemas, and I'm not sure that's _always_ the correct thing to do (e.g. `zod.array(zod.coerce.number())`) - I expect this is useful in some cases

#### **Additional considerations**:
- zod schemas can be arbitrarily complex, and assuming users want simply `zod.coerce.<type>()` is a naive/opinionated approach
- there are merits to taking different approaches, e.g.:
  - `zod.string().pipe(zod.coerce.date())` or 
  - `zod.transform(v => new Date(v)).date()` (full example not shown here, but you get the idea - do something with input data before sending it to a parser/schema)
- another approach we could take would be exposing to users something like mutators for individual zod schemas
  - I didn't opt to attempt to solve for that, which is going to be a lot more complex than this simple and hopefully useful approach

---

#### **Deeper dive on zod + URLSearchParams**
It has been discussed before and there are some lingering challenges that aren't really in the scope of the zod package to solve.
Ref: https://github.com/colinhacks/zod/discussions/1763

**Assumptions:**
- you are using the zod query params schema to both cast AND validate `URLSearchParams`

**Problems:**
- you still need to collect the entries from `URLSearchParams`, since it can contain multiple values for the same key
- you can't just do `Array.from(urlSearchParams.entries())` because it will return multiple entries with the same key, whereas the zod schema will expect those to be grouped as an array
- you instead need to collect the values from the `URLSearchParams` first, only converting them to an array if there are multiple values for the same key
- a field may be an array field despite having 0 or 1 values, so you can't only rely on the presence of multiple same keys to determine whether it should be an array (you _can_ write the zod schema in a way that handles this more intelligently using `zod.transform()` before passing that data into `zod.array()` or another schema)
- you could introspect the schema to see if the field is expected to be an array, but that code can be a little hairy
  - the approach [zodix](https://github.com/rileytomasek/zodix/blob/master/src/parsers.ts#L218C73-L231) takes is to assume it's an array if the key appears more than once
  - [remix-params-helper](https://github.com/kiliman/remix-params-helper/blob/main/src/helper.ts#L217) uses schema introspection

---

**Closing thoughts**:

I found it a bit challenging to figure out the best way to add test coverage for these changes. There are some reasonably well-defined boundaries among the source files here but still it felt heavy-handed to test at the `generateZod` level. Spinning up the necessary input data wasn't super straightforward.

Right now the tests cover the main codegen emission which is conditional on `override.coerceTypes` but does not test the code that pipes the generator options through to the internal function (`parseZodValidationSchemaDefinition`) that uses it.

I know there has been some discussion in other places that touches on some of the overall design decisions within the library such as using string building vs ASTs for the codegen.

I simply wanted to share my perspective as a new contributor wishing it were easier to contribute test coverage to new features.

## Todos

- [x] Tests
- [x] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

Outline the steps to test or reproduce the PR here.

1. set up an openapi document that uses query parameters with types other than string (e.g. integer, boolean)
2. configure orval with:

```ts
import { defineConfig } from 'orval';

export default defineConfig({
  validators: {
    output: {
      target: '<target>', // fill in
      client: 'zod',
      override: {
        coerceTypes: true,
      },
    },
    input: {
      target: '<input specfile>', // fill in
    },
  },
});
```

3. run orval
4. the emitted zod schemas should have e.g. `zod.coerce.number()` rather than `zod.number()`
