### PR TITLE
fix[zod]: enable multiple properties of array consts

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,7 +8,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup ./src/index.ts --clean --dts",
+    "build": "tsup ./src/index.ts --clean --dts --sourcemap",
     "dev": "tsup ./src/index.ts --clean --watch src",
     "lint": "eslint src/**/*.ts",
     "test": "vitest --global test.ts"

--- a/packages/zod/package.json
+++ b/packages/zod/package.json
@@ -8,7 +8,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup ./src/index.ts --target node12 --clean --dts",
+    "build": "tsup ./src/index.ts --target node12 --clean --dts --sourcemap",
     "dev": "tsup ./src/index.ts --target node12 --clean --watch src",
     "lint": "eslint src/**/*.ts"
   },

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -290,7 +290,11 @@ const parseZodValidationSchemaDefinition = (
     }
     if (fn === 'array') {
       const value = args.functions.map(parseProperty).join('');
-      consts += args.consts;
+      if (typeof args.consts === 'string') {
+        consts += args.consts;
+      } else if (Array.isArray(args.consts)) {
+        consts += args.consts.join('\n');
+      }
       return `.array(${value.startsWith('.') ? 'zod' : ''}${value})`;
     }
     return `.${fn}(${args})`;

--- a/tests/configs/zod.config.ts
+++ b/tests/configs/zod.config.ts
@@ -10,4 +10,13 @@ export default defineConfig({
       target: '../specifications/circular.yaml',
     },
   },
+  nestedArrays: {
+    output: {
+      target: '../generated/zod',
+      client: 'zod',
+    },
+    input: {
+      target: '../specifications/arrays.yaml',
+    },
+  },
 });

--- a/tests/specifications/arrays.yaml
+++ b/tests/specifications/arrays.yaml
@@ -1,0 +1,30 @@
+openapi: 3.0.3
+info:
+  title: NestedArrays
+  version: 1.0.0
+paths:
+  /api/sample:
+    post:
+      summary: sample
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResSampleModel'
+components:
+  schemas:
+    ResSampleModel:
+      type: object
+      required:
+        - items
+      properties:
+        items:
+          type: array
+          items:
+            type: array
+            minItems: 2
+            maxItems: 5
+            items:
+              type: string


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

This should fix #1027. The zod function that concatenated consts while parsing the properties of schemas was able to handle multiple properties (eg. `min:2, max:5`) only on objects, but not arrays. This code checks if there are multiple consts and concatenates them intelligently depending on it being either a single string or an array of strings.

## Related PRs

## Todos

- [x] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

Outline the steps to test or reproduce the PR here.

```bash
> git pull --prune
> git checkout <branch>
> cd tests
> yarn run generate:zod

```

1. Look at the file `tests/generated/zod/nestedArrays.ts
2. The file should not contain any extra commas that cause a typescript parsing error.