### PR TITLE
fix(zod): array min max issues

### DIFF
--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -49,6 +49,8 @@ const resolveZodType = (schemaTypeValue: SchemaObject['type']) => {
   }
 };
 
+let counter = 0;
+
 const generateZodValidationSchemaDefinition = (
   schema: SchemaObject | undefined,
   _required: boolean | undefined,
@@ -56,7 +58,7 @@ const generateZodValidationSchemaDefinition = (
 ): { functions: [string, any][]; consts: string[] } => {
   if (!schema) return { functions: [], consts: [] };
 
-  const consts = [];
+  const consts: string[] = [];
   const functions: [string, any][] = [];
   const type = resolveZodType(schema.type);
   const required = schema.default !== undefined ? false : _required ?? false;
@@ -185,13 +187,15 @@ const generateZodValidationSchemaDefinition = (
     if (min === 1) {
       functions.push(['min', `${min}`]);
     } else {
-      consts.push(`export const ${name}Min = ${min};`);
-      functions.push(['min', `${name}Min`]);
+      counter++;
+      consts.push(`export const ${name}Min${counter} = ${min};\n`);
+      functions.push(['min', `${name}Min${counter}`]);
     }
   }
   if (max !== undefined) {
-    consts.push(`export const ${name}Max = ${max};`);
-    functions.push(['max', `${name}Max`]);
+    counter++;
+    consts.push(`export const ${name}Max${counter} = ${max};\n`);
+    functions.push(['max', `${name}Max${counter}`]);
   }
   if (matches) {
     const isStartWithSlash = matches.startsWith('/');
@@ -201,7 +205,7 @@ const generateZodValidationSchemaDefinition = (
       matches.slice(isStartWithSlash ? 1 : 0, isEndWithSlash ? -1 : undefined),
     )}')`;
 
-    consts.push(`export const ${name}RegExp = ${regexp};`);
+    consts.push(`export const ${name}RegExp = ${regexp};\n`);
     functions.push(['regex', `${name}RegExp`]);
   }
 

--- a/tests/specifications/circular.yaml
+++ b/tests/specifications/circular.yaml
@@ -13,6 +13,29 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Node'
+  /list:
+    post:
+      summary: Add list
+      operationId: add-list
+      responses:
+        '200':
+          description: OK
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                list:
+                  type: array
+                  minItems: 1
+                  maxItems: 10
+                  items:
+                    type: number
+                    minimum: 1
+                    maximum: 10
+              required:
+                - list
 components:
   schemas:
     Node:


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY/WIP/HOLD**

## Description

Fix #933

This YAML
```yaml
  /list:
    post:
      summary: Add list
      operationId: add-list
      responses:
        '200':
          description: OK
      requestBody:
        content:
          application/json:
            schema:
              type: object
              properties:
                list:
                  type: array
                  minItems: 1
                  maxItems: 10
                  items:
                    type: number
                    minimum: 1
                    maximum: 10
              required:
                - list
```

gets generated properly as this

```js
export const addListBodyListMax2 = 10;
export const addListBodyListMax1 = 10;


export const addListBody = zod.object({
  "list": zod.array(zod.number().min(1).max(addListBodyListMax1)).min(1).max(addListBodyListMax2)
})

```