### PR TITLE
feat: add optional configuration parameter to generate native Typescript enums

### DIFF
--- a/docs/src/pages/reference/configuration/output.md
+++ b/docs/src/pages/reference/configuration/output.md
@@ -1279,3 +1279,25 @@ module.exports = {
   },
 };
 ```
+
+#### useNativeEnums
+
+Type: `Boolean`
+
+Valid values: true or false. Defaults to false.
+
+Use this property to generate native Typescript `enum` instead of `type` and `const` combo.
+
+Example:
+
+```js
+module.exports = {
+  petstore: {
+    output: {
+      override: {
+        useNativeEnums: true,
+      },
+    },
+  },
+};
+```

--- a/packages/core/src/generators/schema-definition.ts
+++ b/packages/core/src/generators/schema-definition.ts
@@ -1,6 +1,6 @@
 import isEmpty from 'lodash.isempty';
 import { SchemaObject, SchemasObject } from 'openapi3-ts';
-import { getEnum, resolveDiscriminators } from '../getters';
+import { getEnum, getNativeEnum, resolveDiscriminators } from '../getters';
 import { resolveRef, resolveValue } from '../resolvers';
 import { ContextSpecs, GeneratorSchema } from '../types';
 import { upath, isReference, jsDoc, pascal, sanitize } from '../utils';
@@ -55,11 +55,19 @@ export const generateSchemasDefinition = (
         output += jsDoc(schema);
 
         if (resolvedValue.isEnum && !resolvedValue.isRef) {
-          output += getEnum(
-            resolvedValue.value,
-            schemaName,
-            resolvedValue.originalSchema?.['x-enumNames'],
-          );
+          if (context.override.useNativeEnums) {
+            output += getNativeEnum(
+              resolvedValue.value,
+              schemaName,
+              resolvedValue.originalSchema?.['x-enumNames'],
+            );
+          } else {
+            output += getEnum(
+              resolvedValue.value,
+              schemaName,
+              resolvedValue.originalSchema?.['x-enumNames'],
+            );
+          }
         } else if (schemaName === resolvedValue.value && resolvedValue.isRef) {
           // Don't add type if schema has same name and the referred schema will be an interface
           const { schema: referredSchema } = resolveRef(schema, context);

--- a/packages/core/src/generators/schema-definition.ts
+++ b/packages/core/src/generators/schema-definition.ts
@@ -1,6 +1,6 @@
 import isEmpty from 'lodash.isempty';
 import { SchemaObject, SchemasObject } from 'openapi3-ts';
-import { getEnum, getNativeEnum, resolveDiscriminators } from '../getters';
+import { getEnum, resolveDiscriminators } from '../getters';
 import { resolveRef, resolveValue } from '../resolvers';
 import { ContextSpecs, GeneratorSchema } from '../types';
 import { upath, isReference, jsDoc, pascal, sanitize } from '../utils';
@@ -55,19 +55,12 @@ export const generateSchemasDefinition = (
         output += jsDoc(schema);
 
         if (resolvedValue.isEnum && !resolvedValue.isRef) {
-          if (context.override.useNativeEnums) {
-            output += getNativeEnum(
-              resolvedValue.value,
-              schemaName,
-              resolvedValue.originalSchema?.['x-enumNames'],
-            );
-          } else {
-            output += getEnum(
-              resolvedValue.value,
-              schemaName,
-              resolvedValue.originalSchema?.['x-enumNames'],
-            );
-          }
+          output += getEnum(
+            resolvedValue.value,
+            schemaName,
+            resolvedValue.originalSchema?.['x-enumNames'],
+            context.override.useNativeEnums,
+          );
         } else if (schemaName === resolvedValue.value && resolvedValue.isRef) {
           // Don't add type if schema has same name and the referred schema will be an interface
           const { schema: referredSchema } = resolveRef(schema, context);

--- a/packages/core/src/getters/enum.ts
+++ b/packages/core/src/getters/enum.ts
@@ -1,7 +1,23 @@
 import { keyword } from 'esutils';
 import { isNumeric, sanitize } from '../utils';
 
-export const getEnum = (value: string, enumName: string, names?: string[]) => {
+export const getEnum = (
+  value: string,
+  enumName: string,
+  names?: string[],
+  useNativeEnums?: boolean,
+) => {
+  const enumValue = useNativeEnums
+    ? getNativeEnum(value, enumName, names)
+    : getTypeConstEnum(value, enumName, names);
+  return enumValue;
+};
+
+const getTypeConstEnum = (
+  value: string,
+  enumName: string,
+  names?: string[],
+) => {
   let enumValue = `export type ${enumName} = typeof ${enumName}[keyof typeof ${enumName}]`;
 
   if (value.endsWith(' | null')) {
@@ -59,11 +75,7 @@ export const getEnumImplementation = (value: string, names?: string[]) => {
   }, '');
 };
 
-export const getNativeEnum = (
-  value: string,
-  enumName: string,
-  names?: string[],
-) => {
+const getNativeEnum = (value: string, enumName: string, names?: string[]) => {
   const enumItems = getNativeEnumItems(value, names);
   const enumValue = `export enum ${enumName} {\n${enumItems}\n}`;
 

--- a/packages/core/src/getters/enum.ts
+++ b/packages/core/src/getters/enum.ts
@@ -59,6 +59,53 @@ export const getEnumImplementation = (value: string, names?: string[]) => {
   }, '');
 };
 
+export const getNativeEnum = (
+  value: string,
+  enumName: string,
+  names?: string[],
+) => {
+  const enumItems = getNativeEnumItems(value, names);
+  const enumValue = `export enum ${enumName} {\n${enumItems}\n}`;
+
+  return enumValue;
+};
+
+const getNativeEnumItems = (value: string, names?: string[]) => {
+  if (value === '') return '';
+
+  return [...new Set(value.split(' | '))].reduce((acc, val, index) => {
+    const name = names?.[index];
+    if (name) {
+      return (
+        acc +
+        `  ${keyword.isIdentifierNameES5(name) ? name : `'${name}'`}: ${val},\n`
+      );
+    }
+
+    let key = val.startsWith("'") ? val.slice(1, -1) : val;
+
+    const isNumber = isNumeric(key);
+
+    if (isNumber) {
+      key = toNumberKey(key);
+    }
+
+    if (key.length > 1) {
+      key = sanitize(key, {
+        whitespace: '_',
+        underscore: true,
+        dash: true,
+        special: true,
+      });
+    }
+
+    return (
+      acc +
+      `  ${keyword.isIdentifierNameES5(key) ? key : `'${key}'`}= ${val},\n`
+    );
+  }, '');
+};
+
 const toNumberKey = (value: string) => {
   if (value[0] === '-') {
     return `NUMBER_MINUS_${value.slice(1)}`;

--- a/packages/core/src/getters/query-params.ts
+++ b/packages/core/src/getters/query-params.ts
@@ -8,7 +8,7 @@ import {
   GetterQueryParam,
 } from '../types';
 import { jsDoc, pascal, sanitize } from '../utils';
-import { getEnum } from './enum';
+import { getEnum, getNativeEnum } from './enum';
 import { getKey } from './keys';
 
 type QueryParamsType = {
@@ -68,12 +68,21 @@ const getQueryParamsTypes = (
 
     if (resolvedValue.isEnum && !resolvedValue.isRef) {
       const enumName = queryName;
+      let enumValue: string;
 
-      const enumValue = getEnum(
-        resolvedValue.value,
-        enumName,
-        resolvedValue.originalSchema?.['x-enumNames'],
-      );
+      if (context.override.useNativeEnums) {
+        enumValue = getNativeEnum(
+          resolvedValue.value,
+          enumName,
+          resolvedValue.originalSchema?.['x-enumNames'],
+        );
+      } else {
+        enumValue = getEnum(
+          resolvedValue.value,
+          enumName,
+          resolvedValue.originalSchema?.['x-enumNames'],
+        );
+      }
 
       return {
         definition: `${doc}${key}${

--- a/packages/core/src/getters/query-params.ts
+++ b/packages/core/src/getters/query-params.ts
@@ -8,7 +8,7 @@ import {
   GetterQueryParam,
 } from '../types';
 import { jsDoc, pascal, sanitize } from '../utils';
-import { getEnum, getNativeEnum } from './enum';
+import { getEnum } from './enum';
 import { getKey } from './keys';
 
 type QueryParamsType = {
@@ -68,21 +68,12 @@ const getQueryParamsTypes = (
 
     if (resolvedValue.isEnum && !resolvedValue.isRef) {
       const enumName = queryName;
-      let enumValue: string;
-
-      if (context.override.useNativeEnums) {
-        enumValue = getNativeEnum(
-          resolvedValue.value,
-          enumName,
-          resolvedValue.originalSchema?.['x-enumNames'],
-        );
-      } else {
-        enumValue = getEnum(
-          resolvedValue.value,
-          enumName,
-          resolvedValue.originalSchema?.['x-enumNames'],
-        );
-      }
+      const enumValue = getEnum(
+        resolvedValue.value,
+        enumName,
+        resolvedValue.originalSchema?.['x-enumNames'],
+        context.override.useNativeEnums,
+      );
 
       return {
         definition: `${doc}${key}${

--- a/packages/core/src/resolvers/object.ts
+++ b/packages/core/src/resolvers/object.ts
@@ -1,5 +1,5 @@
 import { ReferenceObject, SchemaObject } from 'openapi3-ts';
-import { getEnum, getNativeEnum } from '../getters/enum';
+import { getEnum } from '../getters/enum';
 import { ContextSpecs, ResolverValue } from '../types';
 import { jsDoc } from '../utils';
 import { resolveValue } from './value';
@@ -48,20 +48,12 @@ export const resolveObject = ({
   }
 
   if (propName && resolvedValue.isEnum && !combined && !resolvedValue.isRef) {
-    let enumValue: string;
-    if (context.override.useNativeEnums) {
-      enumValue = getNativeEnum(
-        resolvedValue.value,
-        propName,
-        resolvedValue.originalSchema?.['x-enumNames'],
-      );
-    } else {
-      enumValue = getEnum(
-        resolvedValue.value,
-        propName,
-        resolvedValue.originalSchema?.['x-enumNames'],
-      );
-    }
+    const enumValue = getEnum(
+      resolvedValue.value,
+      propName,
+      resolvedValue.originalSchema?.['x-enumNames'],
+      context.override.useNativeEnums,
+    );
 
     return {
       value: propName,

--- a/packages/core/src/resolvers/object.ts
+++ b/packages/core/src/resolvers/object.ts
@@ -1,5 +1,5 @@
 import { ReferenceObject, SchemaObject } from 'openapi3-ts';
-import { getEnum } from '../getters/enum';
+import { getEnum, getNativeEnum } from '../getters/enum';
 import { ContextSpecs, ResolverValue } from '../types';
 import { jsDoc } from '../utils';
 import { resolveValue } from './value';
@@ -48,11 +48,20 @@ export const resolveObject = ({
   }
 
   if (propName && resolvedValue.isEnum && !combined && !resolvedValue.isRef) {
-    const enumValue = getEnum(
-      resolvedValue.value,
-      propName,
-      resolvedValue.originalSchema?.['x-enumNames'],
-    );
+    let enumValue: string;
+    if (context.override.useNativeEnums) {
+      enumValue = getNativeEnum(
+        resolvedValue.value,
+        propName,
+        resolvedValue.originalSchema?.['x-enumNames'],
+      );
+    } else {
+      enumValue = getEnum(
+        resolvedValue.value,
+        propName,
+        resolvedValue.originalSchema?.['x-enumNames'],
+      );
+    }
 
     return {
       value: propName,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -111,6 +111,7 @@ export type NormalizedOverrideOutput = {
   useDeprecatedOperations?: boolean;
   useBigInt?: boolean;
   useNamedParameters?: boolean;
+  useNativeEnums?: boolean;
 };
 
 export type NormalizedMutator = {
@@ -302,6 +303,7 @@ export type OverrideOutput = {
   useDeprecatedOperations?: boolean;
   useBigInt?: boolean;
   useNamedParameters?: boolean;
+  useNativeEnums?: boolean;
 };
 
 export type OverrideOutputContentType = {

--- a/packages/orval/src/utils/options.ts
+++ b/packages/orval/src/utils/options.ts
@@ -199,6 +199,7 @@ export const normalizeOptions = async (
         useDates: outputOptions.override?.useDates || false,
         useDeprecatedOperations:
           outputOptions.override?.useDeprecatedOperations ?? true,
+        useNativeEnums: outputOptions.override?.useNativeEnums ?? false,
       },
     },
     hooks: options.hooks ? normalizeHooks(options.hooks) : {},


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description
Fix #907

As requested in issue #907 this PR adds a new optional configuration parameter to generate native Typescript enums.

The new parameter `useNativeEnums` is set in the `output.override` configuration block and when set to `true` (defaults to `false`) Orval will generate a native Typescript `enum` instead of the `type` and `const` combo.