### PR TITLE
fix: support es6 modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "packages/*"
   ],
   "private": true,
+  "type": "module",
   "scripts": {
     "format": "prettier --write .",
     "format:staged": "pretty-quick --staged",

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -3,13 +3,21 @@
   "version": "6.20.0",
   "license": "MIT",
   "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "files": [
     "dist"
   ],
   "scripts": {
-    "build": "tsup ./src/index.ts --target node12 --clean --dts",
-    "dev": "tsup ./src/index.ts --target node12 --clean --watch src",
+    "build": "tsup ./src/index.ts --clean --dts --format esm,cjs",
+    "dev": "tsup ./src/index.ts --clean --format esm,cjs --watch src",
     "lint": "eslint src/**/*.ts"
   },
   "dependencies": {

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -2,6 +2,7 @@
   "name": "@orval/angular",
   "version": "6.20.0",
   "license": "MIT",
+  "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -15,9 +16,16 @@
   "files": [
     "dist"
   ],
+  "tsup": {
+    "entry": ["./src/index.ts"],
+    "sourcemap": true,
+    "shims": true,
+    "clean": true,
+    "dts": true
+  },
   "scripts": {
-    "build": "tsup ./src/index.ts --clean --dts --format esm,cjs",
-    "dev": "tsup ./src/index.ts --clean --format esm,cjs --watch src",
+    "build": "tsup --format esm,cjs",
+    "dev": "tsup --format esm,cjs --watch src",
     "lint": "eslint src/**/*.ts"
   },
   "dependencies": {

--- a/packages/axios/package.json
+++ b/packages/axios/package.json
@@ -2,6 +2,7 @@
   "name": "@orval/axios",
   "version": "6.20.0",
   "license": "MIT",
+  "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -15,9 +16,16 @@
   "files": [
     "dist"
   ],
+  "tsup": {
+    "entry": ["./src/index.ts"],
+    "sourcemap": true,
+    "shims": true,
+    "clean": true,
+    "dts": true
+  },
   "scripts": {
-    "build": "tsup ./src/index.ts --target node12 --clean --dts --format esm,cjs",
-    "dev": "tsup ./src/index.ts --target node12 --clean --format esm,cjs --watch src",
+    "build": "tsup --format esm,cjs",
+    "dev": "tsup --format esm,cjs --watch src",
     "lint": "eslint src/**/*.ts"
   },
   "dependencies": {

--- a/packages/axios/package.json
+++ b/packages/axios/package.json
@@ -3,13 +3,21 @@
   "version": "6.20.0",
   "license": "MIT",
   "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "files": [
     "dist"
   ],
   "scripts": {
-    "build": "tsup ./src/index.ts --target node12 --clean --dts",
-    "dev": "tsup ./src/index.ts --target node12 --clean --watch src",
+    "build": "tsup ./src/index.ts --target node12 --clean --dts --format esm,cjs",
+    "dev": "tsup ./src/index.ts --target node12 --clean --format esm,cjs --watch src",
     "lint": "eslint src/**/*.ts"
   },
   "dependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,13 +3,21 @@
   "version": "6.20.0",
   "license": "MIT",
   "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "files": [
     "dist"
   ],
   "scripts": {
-    "build": "tsup ./src/index.ts --clean --dts --sourcemap",
-    "dev": "tsup ./src/index.ts --clean --watch src",
+    "build": "tsup ./src/index.ts  --clean --dts --format esm,cjs",
+    "dev": "tsup ./src/index.ts --clean --format esm,cjs --watch src",
     "lint": "eslint src/**/*.ts",
     "test": "vitest --global test.ts"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,6 +2,7 @@
   "name": "@orval/core",
   "version": "6.20.0",
   "license": "MIT",
+  "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -15,9 +16,16 @@
   "files": [
     "dist"
   ],
+  "tsup": {
+    "entry": ["./src/index.ts"],
+    "sourcemap": true,
+    "shims": true,
+    "clean": true,
+    "dts": true
+  },
   "scripts": {
-    "build": "tsup ./src/index.ts  --clean --dts --format esm,cjs",
-    "dev": "tsup ./src/index.ts --clean --format esm,cjs --watch src",
+    "build": "tsup --format esm,cjs",
+    "dev": "tsup  --format esm,cjs --watch src",
     "lint": "eslint src/**/*.ts",
     "test": "vitest --global test.ts"
   },

--- a/packages/msw/package.json
+++ b/packages/msw/package.json
@@ -2,6 +2,7 @@
   "name": "@orval/msw",
   "version": "6.20.0",
   "license": "MIT",
+  "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -15,9 +16,16 @@
   "files": [
     "dist"
   ],
+  "tsup": {
+    "entry": ["./src/index.ts"],
+    "sourcemap": true,
+    "shims": true,
+    "clean": true,
+    "dts": true
+  },
   "scripts": {
-    "build": "tsup ./src/index.ts --clean --dts --format esm,cjs",
-    "dev": "tsup ./src/index.ts --clean --format esm,cjs --watch src",
+    "build": "tsup --format esm,cjs",
+    "dev": "tsup --format esm,cjs --watch src",
     "lint": "eslint src/**/*.ts"
   },
   "dependencies": {

--- a/packages/msw/package.json
+++ b/packages/msw/package.json
@@ -3,13 +3,21 @@
   "version": "6.20.0",
   "license": "MIT",
   "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "files": [
     "dist"
   ],
   "scripts": {
-    "build": "tsup ./src/index.ts --target node12 --clean --dts",
-    "dev": "tsup ./src/index.ts --target node12 --clean --watch src",
+    "build": "tsup ./src/index.ts --clean --dts --format esm,cjs",
+    "dev": "tsup ./src/index.ts --clean --format esm,cjs --watch src",
     "lint": "eslint src/**/*.ts"
   },
   "dependencies": {

--- a/packages/orval/package.json
+++ b/packages/orval/package.json
@@ -7,8 +7,14 @@
     "dist"
   ],
   "bin": "dist/bin/orval.js",
-  "type": "commonjs",
   "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "exports": {
+    ".": {
+      "require": "dist/index.js",
+      "import": "dist/index.mjs"
+    }
+  },
   "keywords": [
     "rest",
     "client",
@@ -41,8 +47,8 @@
     "url": "https://github.com/anymaniax/orval"
   },
   "scripts": {
-    "build": "tsup ./src/bin/orval.ts ./src/index.ts --target node12 --clean --dts",
-    "dev": "tsup ./src/bin/orval.ts ./src/index.ts --target node12 --clean --watch ./src --onSuccess 'yarn generate-api'",
+    "build": "tsup ./src/bin/orval.ts ./src/index.ts --clean --dts --format esm,cjs,iife",
+    "dev": "tsup ./src/bin/orval.ts ./src/index.ts --clean --format esm,cjs,iife --watch ./src --onSuccess 'yarn generate-api'",
     "lint": "eslint src/**/*.ts",
     "generate-api": "node ./dist/bin/orval.js --config ../../samples/react-query/basic/orval.config.ts"
   },

--- a/packages/orval/package.json
+++ b/packages/orval/package.json
@@ -6,6 +6,7 @@
   "files": [
     "dist"
   ],
+  "type": "module",
   "bin": "dist/bin/orval.js",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
@@ -47,8 +48,8 @@
     "url": "https://github.com/anymaniax/orval"
   },
   "scripts": {
-    "build": "tsup ./src/bin/orval.ts ./src/index.ts --clean --dts --format esm,cjs,iife",
-    "dev": "tsup ./src/bin/orval.ts ./src/index.ts --clean --format esm,cjs,iife --watch ./src --onSuccess 'yarn generate-api'",
+    "build": "tsup ./src/bin/orval.ts ./src/index.ts --clean --dts --format esm,cjs",
+    "dev": "tsup ./src/bin/orval.ts ./src/index.ts --clean --format esm,cjs --watch ./src --onSuccess 'yarn generate-api'",
     "lint": "eslint src/**/*.ts",
     "generate-api": "node ./dist/bin/orval.js --config ../../samples/react-query/basic/orval.config.ts"
   },

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -2,6 +2,7 @@
   "name": "@orval/query",
   "version": "6.20.0",
   "license": "MIT",
+  "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -15,9 +16,16 @@
   "files": [
     "dist"
   ],
+  "tsup": {
+    "entry": ["./src/index.ts"],
+    "sourcemap": true,
+    "shims": true,
+    "clean": true,
+    "dts": true
+  },
   "scripts": {
-    "build": "tsup ./src/index.ts --clean --dts --format esm,cjs",
-    "dev": "tsup ./src/index.ts --clean --format esm,cjs --watch src",
+    "build": "tsup --format esm,cjs",
+    "dev": "tsup --format esm,cjs --watch src",
     "lint": "eslint src/**/*.ts"
   },
   "dependencies": {

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -3,13 +3,21 @@
   "version": "6.20.0",
   "license": "MIT",
   "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "files": [
     "dist"
   ],
   "scripts": {
-    "build": "tsup ./src/index.ts --target node12 --clean --dts",
-    "dev": "tsup ./src/index.ts --target node12 --clean --watch src",
+    "build": "tsup ./src/index.ts --clean --dts --format esm,cjs",
+    "dev": "tsup ./src/index.ts --clean --format esm,cjs --watch src",
     "lint": "eslint src/**/*.ts"
   },
   "dependencies": {

--- a/packages/swr/package.json
+++ b/packages/swr/package.json
@@ -2,6 +2,7 @@
   "name": "@orval/swr",
   "version": "6.20.0",
   "license": "MIT",
+  "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -15,9 +16,16 @@
   "files": [
     "dist"
   ],
+  "tsup": {
+    "entry": ["./src/index.ts"],
+    "sourcemap": true,
+    "shims": true,
+    "clean": true,
+    "dts": true
+  },
   "scripts": {
-    "build": "tsup ./src/index.ts --clean --dts --format esm,cjs",
-    "dev": "tsup ./src/index.ts --clean --format esm,cjs --watch src",
+    "build": "tsup --format esm,cjs",
+    "dev": "tsup --format esm,cjs --watch src",
     "lint": "eslint src/**/*.ts"
   },
   "dependencies": {

--- a/packages/swr/package.json
+++ b/packages/swr/package.json
@@ -3,13 +3,21 @@
   "version": "6.20.0",
   "license": "MIT",
   "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "files": [
     "dist"
   ],
   "scripts": {
-    "build": "tsup ./src/index.ts --target node12 --clean --dts",
-    "dev": "tsup ./src/index.ts --target node12 --clean --watch src",
+    "build": "tsup ./src/index.ts --clean --dts --format esm,cjs",
+    "dev": "tsup ./src/index.ts --clean --format esm,cjs --watch src",
     "lint": "eslint src/**/*.ts"
   },
   "dependencies": {

--- a/packages/zod/package.json
+++ b/packages/zod/package.json
@@ -3,13 +3,21 @@
   "version": "6.20.0",
   "license": "MIT",
   "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "files": [
     "dist"
   ],
   "scripts": {
-    "build": "tsup ./src/index.ts --target node12 --clean --dts --sourcemap",
-    "dev": "tsup ./src/index.ts --target node12 --clean --watch src",
+    "build": "tsup ./src/index.ts --clean --dts --format esm,cjs --sourcemap",
+    "dev": "tsup ./src/index.ts --clean --format esm,cjs --watch src",
     "lint": "eslint src/**/*.ts",
     "test": "vitest --global test.ts"
   },

--- a/packages/zod/package.json
+++ b/packages/zod/package.json
@@ -2,6 +2,7 @@
   "name": "@orval/zod",
   "version": "6.20.0",
   "license": "MIT",
+  "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -15,9 +16,16 @@
   "files": [
     "dist"
   ],
+  "tsup": {
+    "entry": ["./src/index.ts"],
+    "sourcemap": true,
+    "shims": true,
+    "clean": true,
+    "dts": true
+  },
   "scripts": {
-    "build": "tsup ./src/index.ts --clean --dts --format esm,cjs --sourcemap",
-    "dev": "tsup ./src/index.ts --clean --format esm,cjs --watch src",
+    "build": "tsup --format esm,cjs",
+    "dev": "tsup --format esm,cjs --watch src",
     "lint": "eslint src/**/*.ts",
     "test": "vitest --global test.ts"
   },


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY/WIP/HOLD**

## Description

Fix so projects using ES6 modules can use Orval.

Fix #886

fix: support es6 modules