### PR TITLE
fix: enum string escape can be nullable

### DIFF
--- a/packages/core/src/utils/string.ts
+++ b/packages/core/src/utils/string.ts
@@ -137,8 +137,8 @@ export const getNumberWord = (num: number) => {
   return arrayOfNumber.reduce((acc, n) => acc + NUMBERS[n], '');
 };
 
-export const escape = (str: string, char: string = "'") =>
-  str.replace(char, `\\${char}`);
+export const escape = (str: string | null, char: string = "'") =>
+  str?.replace(char, `\\${char}`);
 
 /**
  * Escape all characters not included in SingleStringCharacters and

--- a/tests/configs/default.config.ts
+++ b/tests/configs/default.config.ts
@@ -60,6 +60,7 @@ export default defineConfig({
   'null-type-v-3-0': {
     input: '../specifications/null-type-v3-0.yaml',
     output: {
+      mock: true,
       schemas: '../generated/default/null-type-v3-0/model',
       target: '../generated/default/null-type-v3-0/endpoints.ts',
     },

--- a/tests/specifications/null-type-v3-0.yaml
+++ b/tests/specifications/null-type-v3-0.yaml
@@ -49,6 +49,19 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/NullableAnyObject'
+  /nullable-string-enum:
+    get:
+      tags:
+        - nullables
+      summary: Nullable string enums
+      operationId: fetchNullableEnums
+      responses:
+        200:
+          description: Successful Operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NullableStringEnum'
 components:
   schemas:
     ObjectWithNullableItems:


### PR DESCRIPTION
## Status

Ready

Fix #1082 

## Description

Enum can be optional within openAPI 3.0.0. This PR adds support for optional enum and mocks. [https://swagger.io/docs/specification/data-models/enums/](https://swagger.io/docs/specification/data-models/enums/).

## Todos

- [x] Tests
- [ ] Changelog Entry (unreleased) - not sure what to do?

## Steps to Test or Reproduce

I added a mock option within the default configuration and included it with the used URL's. This PR contains a fix for the same problem.
