### PR TITLE
fix: freeze problem when $ref is deeply nested

### DIFF
--- a/packages/core/src/resolvers/object.ts
+++ b/packages/core/src/resolvers/object.ts
@@ -4,7 +4,7 @@ import { ContextSpecs, ResolverValue } from '../types';
 import { jsDoc } from '../utils';
 import { resolveValue } from './value';
 
-export const resolveObject = ({
+const resolveObjectOriginal = ({
   schema,
   propName,
   combined = false,
@@ -75,4 +75,40 @@ export const resolveObject = ({
   }
 
   return resolvedValue;
+};
+
+const resolveObjectCacheMap = new Map<string, ResolverValue>();
+
+export const resolveObject = ({
+  schema,
+  propName,
+  combined = false,
+  context,
+}: {
+  schema: SchemaObject | ReferenceObject;
+  propName?: string;
+  combined?: boolean;
+  context: ContextSpecs;
+}): ResolverValue => {
+  const hashKey = JSON.stringify({
+    schema,
+    propName,
+    combined,
+    specKey: context.specKey,
+  });
+
+  if (resolveObjectCacheMap.has(hashKey)) {
+    return resolveObjectCacheMap.get(hashKey)!;
+  }
+
+  const result = resolveObjectOriginal({
+    schema,
+    propName,
+    combined,
+    context,
+  });
+
+  resolveObjectCacheMap.set(hashKey, result);
+
+  return result;
 };

--- a/tests/configs/default.config.ts
+++ b/tests/configs/default.config.ts
@@ -87,4 +87,11 @@ export default defineConfig({
       mock: true,
     },
   },
+  'deeply-nested-refs': {
+    input: '../specifications/deeply-nested-refs.yaml',
+    output: {
+      schemas: '../generated/default/deeply-nested-refs/model',
+      target: '../generated/default/deeply-nested-refs/endpoints.ts',
+    },
+  },
 });

--- a/tests/specifications/deeply-nested-refs.yaml
+++ b/tests/specifications/deeply-nested-refs.yaml
@@ -1,0 +1,105 @@
+openapi: 3.0.0
+info:
+  title: Deeply nested refs
+  description: ''
+  version: 1.0.0
+paths:
+  /deeply-nested:
+    get:
+      summary: deeply nested
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeeplyNestedRefSchema1'
+components:
+  schemas:
+    DeeplyNestedRefSchema1:
+      type: object
+      properties:
+        item1:
+          type: array
+          items:
+            allOf:
+              - $ref: '#/components/schemas/DeeplyNestedRefSchema1'
+        item2:
+          type: array
+          items:
+            allOf:
+              - $ref: '#/components/schemas/DeeplyNestedRefSchema2'
+        item_all:
+          type: array
+          items:
+            allOf:
+              - $ref: '#/components/schemas/DeeplyNestedRefSchema1'
+              - $ref: '#/components/schemas/DeeplyNestedRefSchema2'
+              - $ref: '#/components/schemas/DeeplyNestedRefSchema3'
+              - $ref: '#/components/schemas/DeeplyNestedRefSchema4'
+              - $ref: '#/components/schemas/DeeplyNestedRefSchema5'
+    DeeplyNestedRefSchema2:
+      type: object
+      properties:
+        item3:
+          type: object
+          allOf:
+            - $ref: '#/components/schemas/DeeplyNestedRefSchema3'
+        item_all:
+          type: array
+          items:
+            allOf:
+              - $ref: '#/components/schemas/DeeplyNestedRefSchema1'
+              - $ref: '#/components/schemas/DeeplyNestedRefSchema2'
+              - $ref: '#/components/schemas/DeeplyNestedRefSchema3'
+              - $ref: '#/components/schemas/DeeplyNestedRefSchema4'
+              - $ref: '#/components/schemas/DeeplyNestedRefSchema5'
+    DeeplyNestedRefSchema3:
+      type: object
+      properties:
+        item4:
+          type: object
+          allOf:
+            - $ref: '#/components/schemas/DeeplyNestedRefSchema4'
+        item_all:
+          type: array
+          items:
+            allOf:
+              - $ref: '#/components/schemas/DeeplyNestedRefSchema1'
+              - $ref: '#/components/schemas/DeeplyNestedRefSchema2'
+              - $ref: '#/components/schemas/DeeplyNestedRefSchema3'
+              - $ref: '#/components/schemas/DeeplyNestedRefSchema4'
+              - $ref: '#/components/schemas/DeeplyNestedRefSchema5'
+    DeeplyNestedRefSchema4:
+      type: object
+      properties:
+        item5:
+          type: object
+          allOf:
+            - $ref: '#/components/schemas/DeeplyNestedRefSchema5'
+        item_all:
+          type: array
+          items:
+            allOf:
+              - $ref: '#/components/schemas/DeeplyNestedRefSchema1'
+              - $ref: '#/components/schemas/DeeplyNestedRefSchema2'
+              - $ref: '#/components/schemas/DeeplyNestedRefSchema3'
+              - $ref: '#/components/schemas/DeeplyNestedRefSchema4'
+              - $ref: '#/components/schemas/DeeplyNestedRefSchema5'
+    DeeplyNestedRefSchema5:
+      type: object
+      properties:
+        item1:
+          type: array
+          items:
+            allOf:
+              - $ref: '#/components/schemas/DeeplyNestedRefSchema1'
+        item_all:
+          type: array
+          items:
+            allOf:
+              - $ref: '#/components/schemas/DeeplyNestedRefSchema1'
+              - $ref: '#/components/schemas/DeeplyNestedRefSchema2'
+              - $ref: '#/components/schemas/DeeplyNestedRefSchema3'
+              - $ref: '#/components/schemas/DeeplyNestedRefSchema4'
+              - $ref: '#/components/schemas/DeeplyNestedRefSchema5'


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

Fix #967 
Fix #868

## Description

This may help to resolve the issue in #967.

The current implementation cannot process files with deep $ref nesting.
This PR contains changes to address deeply nested $refs.

### Cause of Freeze
 - schema with many $refs call [combineSchemas](https://github.com/anymaniax/orval/blob/82b3b79ad67c1103fd60f2f16bcfae74555c0b71/packages/core/src/getters/combine.ts#L60) many times via [getObject](https://github.com/anymaniax/orval/blob/82b3b79ad67c1103fd60f2f16bcfae74555c0b71/packages/core/src/getters/object.ts#L14)
- [combineSchemas calls resolveObject in a loop](https://github.com/anymaniax/orval/blob/82b3b79ad67c1103fd60f2f16bcfae74555c0b71/packages/core/src/getters/combine.ts#L82-L87)
- Very many calls to resolveObject causes orval freeze

### Changes I made

Changed to cache the result of resolveObject.

### Test Results

The added test file is shallowly nested and takes a long time, but not so long that it freezes.

However, since the time increases exponentially as $ref nesting is increased, it is believed that increasing the number of nests is causing the freeze.

**Before: 15.37s**
```
% yarn generate:default
yarn run v1.22.19
$ yarn orval --config ./configs/default.config.ts
$ node ../packages/orval/dist/bin/orval.js --config ./configs/default.config.ts
🍻 Start orval v6.21.0 - A swagger client generator for typescript
🎉 petstore - Your OpenAPI spec has been converted into ready to use orval!
🎉 petstore-transfomer - Your OpenAPI spec has been converted into ready to use orval!
🎉 petstore-tslint - Your OpenAPI spec has been converted into ready to use orval!
🎉 endpointParameters - Your OpenAPI spec has been converted into ready to use orval!
🎉 translation - Your OpenAPI spec has been converted into ready to use orval!
🎉 regressions - Your OpenAPI spec has been converted into ready to use orval!
🎉 null-type - Your OpenAPI spec has been converted into ready to use orval!
⚠️  SyntaxError: Swagger schema validation failed.
  #/components/schemas/EmptyEnum/enum must NOT have fewer than 1 items
  #/components/schemas/EmptyEnum must have required property '$ref'
  #/components/schemas/EmptyEnum must match exactly one schema in oneOf

🎉 null-type-v-3-0 - Your OpenAPI spec has been converted into ready to use orval!
🎉 readonly - Your OpenAPI spec has been converted into ready to use orval!
🎉 default-status - Your OpenAPI spec has been converted into ready to use orval!
🎉 circular-v2 - Your OpenAPI spec has been converted into ready to use orval!
🎉 deeply-nested-refs - Your OpenAPI spec has been converted into ready to use orval!
✨  Done in 15.37s.
```

**After: 1.03s**

```
% yarn generate:default
yarn run v1.22.19
$ yarn orval --config ./configs/default.config.ts
$ node ../packages/orval/dist/bin/orval.js --config ./configs/default.config.ts
🍻 Start orval v6.21.0 - A swagger client generator for typescript
🎉 petstore - Your OpenAPI spec has been converted into ready to use orval!
🎉 petstore-transfomer - Your OpenAPI spec has been converted into ready to use orval!
🎉 petstore-tslint - Your OpenAPI spec has been converted into ready to use orval!
🎉 endpointParameters - Your OpenAPI spec has been converted into ready to use orval!
🎉 translation - Your OpenAPI spec has been converted into ready to use orval!
🎉 regressions - Your OpenAPI spec has been converted into ready to use orval!
🎉 null-type - Your OpenAPI spec has been converted into ready to use orval!
⚠️  SyntaxError: Swagger schema validation failed.
  #/components/schemas/EmptyEnum/enum must NOT have fewer than 1 items
  #/components/schemas/EmptyEnum must have required property '$ref'
  #/components/schemas/EmptyEnum must match exactly one schema in oneOf

🎉 null-type-v-3-0 - Your OpenAPI spec has been converted into ready to use orval!
🎉 readonly - Your OpenAPI spec has been converted into ready to use orval!
🎉 default-status - Your OpenAPI spec has been converted into ready to use orval!
🎉 circular-v2 - Your OpenAPI spec has been converted into ready to use orval!
🎉 deeply-nested-refs - Your OpenAPI spec has been converted into ready to use orval!
✨  Done in 1.03s.
```

## Steps to Test or Reproduce

A schema that causes freezes is added to `tests/specifications/deeply-nested-refs.yaml` .
