### PR TITLE
fix: do not use TVariables

### DIFF
--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -625,7 +625,7 @@ const getQueryOptionsDefinition = ({
     isMutatorHook
       ? `ReturnType<typeof use${pascal(operationName)}Hook>`
       : `typeof ${operationName}`
-  }>>, TError,${definitions ? `{${definitions}}` : 'TVariables'}, TContext>`;
+  }>>, TError,${definitions ? `{${definitions}}` : '{}'}, TContext>`;
 };
 
 const generateQueryArguments = ({
@@ -1356,7 +1356,6 @@ const generateQueryHook = async (
       : 'options';
 
     const mutationOptionsFn = `export const ${mutationOptionsFnName} = <TError = ${errorType},
-    ${!definitions ? `TVariables = void,` : ''}
     TContext = unknown>(${mutationArguments}): ${mutationOptionFnReturnType} => {
  ${
    isRequestOptions
@@ -1378,7 +1377,7 @@ const generateQueryHook = async (
 
 
       const mutationFn: MutationFunction<Awaited<ReturnType<${dataType}>>, ${
-      definitions ? `{${definitions}}` : 'TVariables'
+      definitions ? `{${definitions}}` : '{}'
     }> = (${properties ? 'props' : ''}) => {
           ${properties ? `const {${properties}} = props ?? {};` : ''}
 
@@ -1434,7 +1433,6 @@ ${mutationOptionsFn}
     ${doc}export const ${camel(
       `${operationPrefix}-${operationName}`,
     )} = <TError = ${errorType},
-    ${!definitions ? `TVariables = void,` : ''}
     TContext = unknown>(${mutationArguments}) => {
 
       const ${mutationOptionsVarName} = ${mutationOptionsFnName}(${

--- a/samples/vue-query/petstore.yaml
+++ b/samples/vue-query/petstore.yaml
@@ -108,6 +108,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+  /api/v1/user/logout:
+    post:
+      summary: This is required to test case when there are no parameters (this path is ignored in add-version transformer), see https://github.com/anymaniax/orval/issues/857#issuecomment-1835317990
+      responses:
+        200:
+          description: Success
 components:
   schemas:
     Pet:

--- a/samples/vue-query/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
+++ b/samples/vue-query/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
@@ -60,4 +60,13 @@ export const getSwaggerPetstoreMock = () => [
       },
     });
   }),
+  http.post('*/api/v1/user/logout', async () => {
+    await delay(1000);
+    return new HttpResponse(null, {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+  }),
 ];

--- a/samples/vue-query/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/vue-query/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -424,3 +424,63 @@ export const useShowPetById = <
 
   return query;
 };
+
+/**
+ * @summary This is required to test case when there are no parameters (this path is ignored in add-version transformer), see https://github.com/anymaniax/orval/issues/857#issuecomment-1835317990
+ */
+export const postApiV1UserLogout = () => {
+  return customInstance<void>({ url: `/api/v1/user/logout`, method: 'POST' });
+};
+
+export const getPostApiV1UserLogoutMutationOptions = <
+  TError = unknown,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof postApiV1UserLogout>>,
+    TError,
+    {},
+    TContext
+  >;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof postApiV1UserLogout>>,
+  TError,
+  {},
+  TContext
+> => {
+  const { mutation: mutationOptions } = options ?? {};
+
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof postApiV1UserLogout>>,
+    {}
+  > = () => {
+    return postApiV1UserLogout();
+  };
+
+  return { mutationFn, ...mutationOptions };
+};
+
+export type PostApiV1UserLogoutMutationResult = NonNullable<
+  Awaited<ReturnType<typeof postApiV1UserLogout>>
+>;
+
+export type PostApiV1UserLogoutMutationError = unknown;
+
+/**
+ * @summary This is required to test case when there are no parameters (this path is ignored in add-version transformer), see https://github.com/anymaniax/orval/issues/857#issuecomment-1835317990
+ */
+export const usePostApiV1UserLogout = <
+  TError = unknown,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof postApiV1UserLogout>>,
+    TError,
+    {},
+    TContext
+  >;
+}) => {
+  const mutationOptions = getPostApiV1UserLogoutMutationOptions(options);
+
+  return useMutation(mutationOptions);
+};


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

Fixes #857

Looks like something changed in Vue Query typings. Also `void` is known to be problematic in TS, and the general recommendation is to only use it for functions. Clearly `TVariables` wasn't a function, perhaps this is the source of error.

Also adds a route for reproduction. Here's an error without the actual `index.ts` change:
![image](https://github.com/anymaniax/orval/assets/7756211/dad713c1-6633-49bb-806e-2eeac073369f)

## Todos

- [x] Tests
- [x] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

1. clone
2. revert changes to `index.ts`
3. run all tests `cd ~/orval && yarn && yarn build && yarn update-samples && yarn format && yarn test:ci && cd tests && yarn && yarn generate && yarn build && cd ..`