### PR TITLE
fix(query): suspense query generation

### DIFF
--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -1132,9 +1132,14 @@ const generateQueryHook = async (
 
   const isQuery =
     (Verbs.GET === verb &&
-      (override.query.useQuery || override.query.useInfinite)) ||
+      (override.query.useQuery ||
+        override.query.useSuspenseQuery ||
+        override.query.useInfinite ||
+        override.query.useSuspenseInfiniteQuery)) ||
     operationQueryOptions?.useInfinite ||
-    operationQueryOptions?.useQuery;
+    operationQueryOptions?.useSuspenseInfiniteQuery ||
+    operationQueryOptions?.useQuery ||
+    operationQueryOptions?.useSuspenseQuery;
 
   if (isQuery) {
     const queryKeyMutator = query.queryKey
@@ -1195,7 +1200,7 @@ const generateQueryHook = async (
             },
           ]
         : []),
-      ...((!query?.useQuery && !query?.useInfinite) || query?.useQuery
+      ...(query?.useQuery
         ? [
             {
               name: operationName,


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

Fix #1098

## Description

There was a bug that didn't allow the generation of strictly the Suspense query variants. i.e. it wouldn't generate anything if `useQuery: false` was passed

## Steps to Test or Reproduce

```js
module.exports = {
  api: {
    input: '../docs/swagger.json',
    output: {
      target: 'api.ts',
      mode: 'split',
      client: 'react-query',
      override: {
        query: {
          useQuery: false,
          useInfinite: false,
          useSuspenseQuery: true,
          useSuspenseInfiniteQuery: true,
        },
      },
      workspace: 'src/api',
    },
  },
};
```
 - Verified strictly `useSuspenseQuery` and `useSuspenseInfiniteQuery` hooks were generated