### PR TITLE
RFC: feat(query): add shouldExportMutatorHooks option

### DIFF
--- a/docs/src/pages/reference/configuration/output.md
+++ b/docs/src/pages/reference/configuration/output.md
@@ -727,6 +727,14 @@ Type: `Boolean`.
 
 Use to remove the generation of the abort signal provided by <a href="https://react-query.tanstack.com/" target="_blank">query</a>
 
+##### shouldExportMutatorHooks
+
+Type: `Boolean`.
+
+Default Value: `true`.
+
+Use to stop the export of mutator hooks. Useful if you want to rely soley on useQuery, useSuspenseQuery, etc.
+
 #### angular
 
 Type: `Object`.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -332,6 +332,7 @@ export type NormalizedQueryOptions = {
   queryKey?: NormalizedMutator;
   queryOptions?: NormalizedMutator;
   mutationOptions?: NormalizedMutator;
+  shouldExportMutatorHooks?: boolean;
   signal?: boolean;
   version?: 3 | 4 | 5;
 };
@@ -348,6 +349,7 @@ export type QueryOptions = {
   queryKey?: Mutator;
   queryOptions?: Mutator;
   mutationOptions?: Mutator;
+  shouldExportMutatorHooks?: boolean;
   signal?: boolean;
   version?: 3 | 4 | 5;
 };

--- a/packages/orval/src/utils/options.ts
+++ b/packages/orval/src/utils/options.ts
@@ -201,6 +201,7 @@ export const normalizeOptions = async (
           useQuery: true,
           useMutation: true,
           signal: true,
+          shouldExportMutatorHooks: true,
           ...normalizeQueryOptions(outputOptions.override?.query, workspace),
         },
         swr: {
@@ -439,6 +440,9 @@ const normalizeQueryOptions = (
             queryOptions?.mutationOptions,
           ),
         }
+      : {}),
+    ...(!isUndefined(queryOptions.shouldExportMutatorHooks)
+      ? { shouldExportMutatorHooks: queryOptions.shouldExportMutatorHooks }
       : {}),
     ...(!isUndefined(queryOptions.signal)
       ? { signal: queryOptions.signal }

--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -437,7 +437,9 @@ const generateQueryRequestFunction = (
       : '';
 
     if (mutator.isHook) {
-      return `export const use${pascal(operationName)}Hook = () => {
+      return `${
+        override.query.shouldExportMutatorHooks ? 'export ' : ''
+      }const use${pascal(operationName)}Hook = () => {
         const ${operationName} = ${mutator.name}<${
         response.definition.success || 'unknown'
       }>();

--- a/packages/query/src/utils.ts
+++ b/packages/query/src/utils.ts
@@ -47,6 +47,9 @@ export const normalizeQueryOptions = (
           ),
         }
       : {}),
+    ...(queryOptions.shouldExportMutatorHooks
+      ? { shouldExportMutatorHooks: true }
+      : {}),
     ...(queryOptions.signal ? { signal: true } : {}),
   };
 };


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**HOLD**

## Description

When client is set as react-query, 3 different functions are generated for each  query/mutation. For example:

```ts
export const useCreateUserHook = () => {
  ... 
};

export const useCreateUserMutationOptions = <TError = ErrorType<unknown>, TContext = unknown>(...): ... => {
  ...
};


export const useCreateUser = <TError = ErrorType<unknown>, TContext = unknown>(...) => {
  ....
};
```
**GOAL**: I don't want to export `useCreateUserHook`. This causes confusion for my team and I on which function to use: `useCreateUserHook`, or `useCreateUser`? Ideally we always use the react-query version (`useCreateUser`), but it's easier if we just don't export it at all, so no one can make the mistake

(I arguably don't want `useCreateUserMutationOptions` exported either, but that one is less problematic)

I made this an option to preserve backwards compatibility, but let me know your thoughts

## Steps to Test or Reproduce

### orval.config.js
```ts
module.exports = {
  api: {
    input: {
      target: '../docs/swagger.json',
      override: {
        transformer,
      },
    },
    validation: true,
    output: {
      target: 'api.generated.ts',
      client: 'react-query',
      workspace: 'src/api',
      override: {
        query: {
          useQuery: false,
          useSuspenseQuery: true,
          shouldExportMutatorHooks: false,
        },
      },
    },
  },
};
```
Verified the mutator hook is no longer exported