### PR TITLE
fix(core): use non-barrel schema file imports when using split-tags mode

### DIFF
--- a/packages/core/src/writers/split-tags-mode.ts
+++ b/packages/core/src/writers/split-tags-mode.ts
@@ -11,6 +11,7 @@ import {
 import { generateTargetForTags } from './target-tags';
 import { getOrvalGeneratedTypes } from './types';
 import { getMockFileExtensionByTypeName } from '../utils/fileExtensions';
+import uniqBy from 'lodash.uniqby';
 
 export const writeSplitTagsMode = async ({
   builder,
@@ -52,10 +53,17 @@ export const writeSplitTagsMode = async ({
             upath.relativeSafe(dirname, getFileInfo(output.schemas).dirname)
           : '../' + filename + '.schemas';
 
+        const importsForBuilder = output.schemas
+          ? uniqBy(imports, 'name').map((i) => ({
+              exports: [i],
+              dependency: upath.join(relativeSchemasPath, camel(i.name)),
+            }))
+          : [{ exports: imports, dependency: relativeSchemasPath }];
+
         implementationData += builder.imports({
           client: output.client,
           implementation,
-          imports: [{ exports: imports, dependency: relativeSchemasPath }],
+          imports: importsForBuilder,
           specsName,
           hasSchemaDir: !!output.schemas,
           isAllowSyntheticDefaultImports,


### PR DESCRIPTION
## Status

**READY**

## Description

Fixes bad code generation when using `indexFiles: false`.

## Related PRs

N/A

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

Run orval with a configuration like:

```js
{
  mode: "tags-split",
  target: "src/gen/endpoints/api.ts",
  schemas: "src/gen/model",
  indexFiles: false,
}
```