### PR TITLE
fix(core): add missing properties in subschemas to fix TS error

### DIFF
--- a/samples/react-query/basic/src/api/model/dog.ts
+++ b/samples/react-query/basic/src/api/model/dog.ts
@@ -9,11 +9,11 @@ import type { Dachshund } from './dachshund';
 import type { DogType } from './dogType';
 
 export type Dog =
-  | (Labradoodle & {
+  | (Labradoodle & { length?: never } & {
       barksPerMinute?: number;
       type: DogType;
     })
-  | (Dachshund & {
+  | (Dachshund & { cuteness?: never } & {
       barksPerMinute?: number;
       type: DogType;
     });

--- a/samples/react-query/basic/src/api/model/pet.ts
+++ b/samples/react-query/basic/src/api/model/pet.ts
@@ -10,7 +10,7 @@ import type { PetCallingCode } from './petCallingCode';
 import type { PetCountry } from './petCountry';
 
 export type Pet =
-  | (Dog & {
+  | (Dog & { petsRequested?: never } & {
       '@id'?: string;
       callingCode?: PetCallingCode;
       country?: PetCountry;
@@ -19,7 +19,7 @@ export type Pet =
       name: string;
       tag?: string;
     })
-  | (Cat & {
+  | (Cat & { barksPerMinute?: never } & {
       '@id'?: string;
       callingCode?: PetCallingCode;
       country?: PetCountry;


### PR DESCRIPTION
closes #935

## Status

**READY**

## Description

Fixes TypeScript error when accessing a property from a union of objects with different schema.
Please refer to the provided example error in #935

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

Run locally to observe the generated types changed (now have missing properties declared as `missingProperty?: never` in:
    - `samples/react-query/basic/src/api/model/dog.ts`
    - `samples/react-query/basic/src/api/model/pet.ts`

<details>
  <summary>Screenshots of the changes</summary>
  
<img width="851" alt="Screenshot 2023-12-19 at 9 20 21 AM" src="https://github.com/anymaniax/orval/assets/9992724/2dbfac18-a544-4969-8f1a-98e407db80ba">
<img width="867" alt="Screenshot 2023-12-19 at 9 19 59 AM" src="https://github.com/anymaniax/orval/assets/9992724/9bd5cbc6-2a9d-4d35-820e-846cf6c95b78">
</details>