### PR TITLE
fix(core): Fixed condition for using `barrel` import in `split-tags` mode

### DIFF
--- a/packages/core/src/writers/split-tags-mode.ts
+++ b/packages/core/src/writers/split-tags-mode.ts
@@ -53,12 +53,13 @@ export const writeSplitTagsMode = async ({
             upath.relativeSafe(dirname, getFileInfo(output.schemas).dirname)
           : '../' + filename + '.schemas';
 
-        const importsForBuilder = output.schemas
-          ? uniqBy(imports, 'name').map((i) => ({
-              exports: [i],
-              dependency: upath.join(relativeSchemasPath, camel(i.name)),
-            }))
-          : [{ exports: imports, dependency: relativeSchemasPath }];
+        const importsForBuilder =
+          output.schemas && !output.indexFiles
+            ? uniqBy(imports, 'name').map((i) => ({
+                exports: [i],
+                dependency: upath.join(relativeSchemasPath, camel(i.name)),
+              }))
+            : [{ exports: imports, dependency: relativeSchemasPath }];
 
         implementationData += builder.imports({
           client: output.client,


### PR DESCRIPTION
## Status

**READY**

## Description

Due to the changes in [this PR](https://github.com/anymaniax/orval/pull/1110), `barrel` is no longer used for `import` of `schema` files when the following conditions are met:

- `tags-split` is specified for `mode`
- specified `schemas`

It looks like you are expecting `barrel` to not be used for `import` of `schema` if `indexFiles` is `false`.

But, as a result, `barrel` is no longer used for `import` of `schema` files even if the value of `indexFiles` is `true`. Incidentally, by default the value of `indexFiles` is `true`.

I made a small change because if `indexFiles` is `true`, I want to use `barrel` for `import` as before.

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

### when `indexFiles` is `false`, `barrel` is not used for `import` of `schema`

1. Specify `false` for `indexFiles` in `orval.config.js` as shown below:

```json:orval.config.js
module.exports = {
  'petstore-file': {
    input: {
      target: './petstore.yaml'
    },
    output: {
      mode: 'tags-split',
      target: "src/gen/endpoints",
      schemas: "src/gen/model",
      indexFiles: false
    }
  },
};
```

2. `orval` execution

```bash
yarn orval
```

3. `barrel` is not used in `gen/endpoints/pets/pets.ts`

```typescript
import type {
  ListPetsParams
} from '../../model/listPetsParams'
import type {
  Pet
} from '../../model/pet'
import type {
  Pets
} from '../../model/pets'
```

### when `indexFiles` is `true`, `barrel` is used for `import` of `schema`

1. Specify `true` for `indexFiles` in `orval.config.js` as shown below:

```json:orval.config.js
module.exports = {
  'petstore-file': {
    input: {
      target: './petstore.yaml'
    },
    output: {
      mode: 'tags-split',
      target: "src/gen/endpoints",
      schemas: "src/gen/model",
      indexFiles: true,
    }
  },
};
```

2. `orval` execution

```bash
yarn orval
```

3. `barrel` is used in `gen/endpoints/pets/pets.ts`

```typescript
import type {
  ListPetsParams,
  Pet,
  Pets
} from '../../model'
```
