### PR TITLE
chore: remove unnecessary import in writer schemas

### DIFF
--- a/packages/core/src/writers/schemas.ts
+++ b/packages/core/src/writers/schemas.ts
@@ -2,7 +2,6 @@ import fs from 'fs-extra';
 import { generateImports } from '../generators';
 import { GeneratorSchema } from '../types';
 import { camel, upath } from '../utils';
-import { getOrvalGeneratedTypes } from './types';
 
 const getSchema = ({
   schema: { imports, model },


### PR DESCRIPTION
## Status

**READY**

## Description

Inside `packages/core/src/writers/schemas.ts` we are importing `getOrvalGeneratedTypes`, but it is unused and unnecessary so I removed it.

## Related PRs

none

## Todos

- [x] Tests
- [x] Documentation
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce

```bash
$ git grep getOrvalGeneratedTypes -- packages/core/src/writers/schemas.ts #=> None
```
