### PR TITLE
fix: avoid duplicate variable name in `swr` function

### DIFF
--- a/packages/swr/src/index.ts
+++ b/packages/swr/src/index.ts
@@ -14,6 +14,7 @@ import {
   GeneratorOptions,
   GeneratorVerbOptions,
   GetterParams,
+  GetterProp,
   GetterProps,
   GetterPropType,
   GetterResponse,
@@ -235,6 +236,12 @@ const generateSwrImplementation = ({
   doc?: string;
 }) => {
   const swrProps = toObjectString(props, 'implementation');
+
+  const hasParamReservedWord = props.some(
+    (prop: GetterProp) => prop.name === 'query',
+  );
+  const queryResultVarName = hasParamReservedWord ? '_query' : 'query';
+
   const httpFunctionProps = swrProperties;
 
   const swrKeyImplementation = `const isEnabled = swrOptions?.enabled !== false${
@@ -291,7 +298,7 @@ ${doc}export const ${camel(
       : ''
   });
 
-  const query = useSwr<Awaited<ReturnType<typeof swrFn>>, TError>(swrKey, swrFn, ${
+  const ${queryResultVarName} = useSwr<Awaited<ReturnType<typeof swrFn>>, TError>(swrKey, swrFn, ${
     swrOptions.options
       ? `{
     ${stringify(swrOptions.options)?.slice(1, -1)}
@@ -302,7 +309,7 @@ ${doc}export const ${camel(
 
   return {
     swrKey,
-    ...query
+    ...${queryResultVarName}
   }
 }\n`;
 };


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

fix https://github.com/anymaniax/orval/issues/800

When using `query` for an API parameter defined in `OpenAPI`, the name of the argument in the automatically generated function and the name of the argument within the function collide.
In that case, we changed the variable name `query` to `_query`.
Variables other than `query` are not considered because they are rarely used as parameters.

Similar problems occur with `client` other than `swr`, so we will deal with them in order once this PR is merged.

## Related PRs

none

## Todos

- [x] Tests
- [x] Documentation
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce

1. Specify `query` in the parameter name as below:

```yaml
openapi: '3.0.0'
info:
  version: 1.0.0
  title: Swagger
  license:
    name: MIT
paths:
  /pets/{query}:
    get:
      summary: Info for a specific pet
      operationId: showPetById
      tags:
        - pets
      parameters:
        - name: query
          in: path
          required: true
          description: The id of the pet to retrieve
          schema:
            type: string
      responses:
        '200':
          description: Expected response to a valid request
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/Pet'
        default:
          description: unexpected error
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/Error'
components:
  schemas:
    Pet:
      type: object
      required:
        - id
        - name
      properties:
        id:
          type: integer
          format: int64
        name:
          type: string
        tag:
          type: string
    Error:
      type: object
      required:
        - code
        - message
      properties:
        code:
          type: integer
          format: int32
        message:
          type: string
```

2. Specify `swr` for `client` in `orval.config.js` as bellow:

```javascript
module.exports = {
  'petstore-file': {
    input: {
      target: './petstore.yaml',
    },
    output: {
      mode: 'tags-split',
      client: 'swr',
      target: 'src/gen/endpoints',
      schemas: 'src/gen/model',
      indexFiles: false,
    },
  },
};
```

3. `orval` execute

```bash
orval
```

4. The function is output where the name of the variable is replaced from `query` to `_query`

```typescript
export const useShowPetById = <TError = AxiosError<Error>>(
  query: string,
  options?: {
    swr?: SWRConfiguration<Awaited<ReturnType<typeof showPetById>>, TError> & {
      swrKey?: Key;
      enabled?: boolean;
    };
    axios?: AxiosRequestConfig;
  },
) => {
  const { swr: swrOptions, axios: axiosOptions } = options ?? {};

  const isEnabled = swrOptions?.enabled !== false && !!query;
  const swrKey =
    swrOptions?.swrKey ?? (() => (isEnabled ? getShowPetByIdKey(query) : null));
  const swrFn = () => showPetById(query, axiosOptions);

  const _query = useSwr<Awaited<ReturnType<typeof swrFn>>, TError>(
    swrKey,
    swrFn,
    swrOptions,
  );

  return {
    swrKey,
    ..._query,
  };
};
```