### PR TITLE
fix: avoid duplicate variable name in genrated function for query clients

### DIFF
--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -14,6 +14,7 @@ import {
   GeneratorOptions,
   GeneratorVerbOptions,
   GetterParams,
+  GetterProp,
   GetterProps,
   GetterPropType,
   GetterResponse,
@@ -963,6 +964,11 @@ const generateQueryImplementation = ({
 
   const queryOptionsVarName = isRequestOptions ? 'queryOptions' : 'options';
 
+  const hasParamReservedWord = props.some(
+    (prop: GetterProp) => prop.name === 'query',
+  );
+  const queryResultVarName = hasParamReservedWord ? '_query' : 'query';
+
   const infiniteParam =
     queryParams && queryParam
       ? `, ${queryParams?.schema.name}['${queryParam}']`
@@ -1056,15 +1062,15 @@ ${doc}export const ${camel(
     queryProperties ? ',' : ''
   }${isRequestOptions ? 'options' : 'queryOptions'})
 
-  const query = ${camel(
+  const ${queryResultVarName} = ${camel(
     `${operationPrefix}-${type}`,
   )}(${queryOptionsVarName}) as ${returnType};
 
-  query.queryKey = ${queryOptionsVarName}.queryKey ${
+  ${queryResultVarName}.queryKey = ${queryOptionsVarName}.queryKey ${
     isVue(outputClient) ? 'as QueryKey' : ''
   };
 
-  return query;
+  return ${queryResultVarName};
 }\n
 ${
   usePrefetch


### PR DESCRIPTION
## Status

**READY**

## Description

follow up https://github.com/anymaniax/orval/pull/1130

> When using query for an API parameter defined in OpenAPI, the name of the argument in the automatically generated function and the name of the argument within the function collide.
In that case, we changed the variable name query to _query.
Variables other than query are not considered because they are rarely used as parameters.

I also supported `react-query`, `vue-query`,  and `svelte-query` with this PR

## Related PRs

https://github.com/anymaniax/orval/pull/1130

## Todos

- [x] Tests
- [x] Documentation
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce

1. Specify `query` in the parameter name as below:

```yaml
openapi: '3.0.0'
info:
  version: 1.0.0
  title: Swagger
  license:
    name: MIT
paths:
  /pets/{query}:
    get:
      summary: Info for a specific pet
      operationId: showPetById
      tags:
        - pets
      parameters:
        - name: query
          in: path
          required: true
          description: The id of the pet to retrieve
          schema:
            type: string
      responses:
        '200':
          description: Expected response to a valid request
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/Pet'
        default:
          description: unexpected error
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/Error'
components:
  schemas:
    Pet:
      type: object
      required:
        - id
        - name
      properties:
        id:
          type: integer
          format: int64
        name:
          type: string
        tag:
          type: string
    Error:
      type: object
      required:
        - code
        - message
      properties:
        code:
          type: integer
          format: int32
        message:
          type: string
```

2. Specify `swr` for `client` in `orval.config.js` as bellow:

```javascript
module.exports = {
  'petstore-file': {
    input: {
      target: './petstore.yaml',
    },
    output: {
      mode: 'tags-split',
      client: 'react-query', // or 'vue-query', 'svelte-query'
      target: 'src/gen/endpoints',
      schemas: 'src/gen/model',
      indexFiles: false,
    },
  },
};
```

3. `orval` execute

```bash
orval
```

4. The function is output where the name of the variable is replaced from `query` to `_query`
