### PR TITLE
chore: define options type for `swr`

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -93,9 +93,7 @@ export type NormalizedOverrideOutput = {
   };
   query: NormalizedQueryOptions;
   angular: Required<AngularOptions>;
-  swr: {
-    options?: any;
-  };
+  swr: SwrOptions;
   operationName?: (
     operation: OperationObject,
     route: string,
@@ -299,9 +297,7 @@ export type OverrideOutput = {
     };
   };
   query?: QueryOptions;
-  swr?: {
-    options?: any;
-  };
+  swr?: SwrOptions;
   angular?: AngularOptions;
   operationName?: (
     operation: OperationObject,
@@ -358,6 +354,10 @@ export type AngularOptions = {
   provideIn?: 'root' | 'any' | boolean;
 };
 
+export type SwrOptions = {
+  options?: any;
+};
+
 export type InputTransformerFn = (spec: OpenAPIObject) => OpenAPIObject;
 
 type InputTransformer = string | InputTransformerFn;
@@ -375,9 +375,7 @@ export type OperationOptions = {
   };
   query?: QueryOptions;
   angular?: Required<AngularOptions>;
-  swr?: {
-    options?: any;
-  };
+  swr?: SwrOptions;
   operationName?: (
     operation: OperationObject,
     route: string,

--- a/packages/swr/src/index.ts
+++ b/packages/swr/src/index.ts
@@ -25,6 +25,7 @@ import {
   Verbs,
   VERBS_WITH_BODY,
   jsDoc,
+  SwrOptions,
 } from '@orval/core';
 
 const AXIOS_DEPENDENCIES: GeneratorDependency[] = [
@@ -232,7 +233,7 @@ const generateSwrImplementation = ({
   props: GetterProps;
   response: GetterResponse;
   mutator?: GeneratorMutator;
-  swrOptions: { options?: any };
+  swrOptions: SwrOptions;
   doc?: string;
 }) => {
   const swrProps = toObjectString(props, 'implementation');


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY/**

## Description

this PR is small refactoring. We expect to add properties that can be specified with `output.override.swr` in future improvements, so we defined the `swr` option as type. For example https://github.com/anymaniax/orval/issues/796

## Related PRs

none

## Todos

- [x] Tests
- [x] Documentation
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce

none
