### PR TITLE
feat: possible to generate a function using `useSWRInfinite` on the `swr` client.

### DIFF
--- a/docs/src/pages/reference/configuration/output.md
+++ b/docs/src/pages/reference/configuration/output.md
@@ -778,6 +778,37 @@ Default Value: `'root'`.
 
 Can be used to set the value of `providedIn` on the generated Angular services. If `false`, no `providedIn` will be set. If `true` or not specified, it will fall back to the default value: `root`.
 
+#### swr
+
+Type: `Object`.
+
+Give options to the generated `swr` client. It is also possible to extend the generated functions.
+
+```js
+module.exports = {
+  petstore: {
+    output: {
+      ...
+      override: {
+        swr: {
+          useInfinite: true,
+          options: {
+            dedupingInterval: 10000,
+          },
+        },
+      },
+    },
+    ...
+  },
+};
+```
+
+##### useInfinite
+
+Type: `Boolean`.
+
+Use to generate a <a href="https://swr.vercel.app/docs/pagination#useswrinfinite" target="_blank">useSWRInfinite</a> custom hook.
+
 #### mock
 
 Type: `Object`.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -356,6 +356,7 @@ export type AngularOptions = {
 
 export type SwrOptions = {
   options?: any;
+  useInfinite?: boolean;
 };
 
 export type InputTransformerFn = (spec: OpenAPIObject) => OpenAPIObject;

--- a/packages/swr/src/index.ts
+++ b/packages/swr/src/index.ts
@@ -70,6 +70,17 @@ const SWR_DEPENDENCIES: GeneratorDependency[] = [
   },
 ];
 
+const SWR_INFINITE_DEPENDENCIES: GeneratorDependency[] = [
+  {
+    exports: [
+      { name: 'useSWRInfinite', values: true, default: true },
+      { name: 'SWRInfiniteConfiguration' },
+      { name: 'SWRInfiniteKeyLoader' },
+    ],
+    dependency: 'swr/infinite',
+  },
+];
+
 export const getSwrDependencies: ClientDependenciesBuilder = (
   hasGlobalMutator: boolean,
   hasParamsSerializerOptions: boolean,
@@ -77,6 +88,7 @@ export const getSwrDependencies: ClientDependenciesBuilder = (
   ...(!hasGlobalMutator ? AXIOS_DEPENDENCIES : []),
   ...(hasParamsSerializerOptions ? PARAMS_SERIALIZER_DEPENDENCIES : []),
   ...SWR_DEPENDENCIES,
+  ...SWR_INFINITE_DEPENDENCIES,
 ];
 
 const generateSwrRequestFunction = (

--- a/packages/swr/src/index.ts
+++ b/packages/swr/src/index.ts
@@ -291,13 +291,13 @@ export type ${pascal(operationName)}InfiniteError = ${errorType}
 
 ${doc}export const ${camel(
     `use-${operationName}-infinite`,
-  )} = <TError = ${errorType}>(\n ${swrProps} ${generateSwrArguments({
+  )} = <TError = ${errorType}>(
+  ${swrProps} ${generateSwrArguments({
     operationName,
     mutator,
     isRequestOptions,
     isInfinite: true,
-  })}\n  ) => {
-
+  })}) => {
   ${
     isRequestOptions
       ? `const {swr: swrOptions${
@@ -345,15 +345,13 @@ export type ${pascal(
   )}QueryResult = NonNullable<Awaited<ReturnType<typeof ${operationName}>>>
 export type ${pascal(operationName)}QueryError = ${errorType}
 
-${doc}export const ${camel(
-    `use-${operationName}`,
-  )} = <TError = ${errorType}>(\n ${swrProps} ${generateSwrArguments({
+${doc}export const ${camel(`use-${operationName}`)} = <TError = ${errorType}>(
+  ${swrProps} ${generateSwrArguments({
     operationName,
     mutator,
     isRequestOptions,
     isInfinite: false,
-  })}\n  ) => {
-
+  })}) => {
   ${
     isRequestOptions
       ? `const {swr: swrOptions${

--- a/packages/swr/src/index.ts
+++ b/packages/swr/src/index.ts
@@ -267,19 +267,13 @@ const generateSwrImplementation = ({
 
   const httpFunctionProps = swrProperties;
 
-  const swrKeyImplementation = `const isEnabled = swrOptions?.enabled !== false${
+  const enabledImplementation = `const isEnabled = swrOptions?.enabled !== false${
     params.length
       ? ` && !!(${params.map(({ name }) => name).join(' && ')})`
       : ''
-  }
-    const swrKey = swrOptions?.swrKey ?? (() => isEnabled ? ${swrKeyFnName}(${swrKeyProperties}) : null);`;
-
-  const swrKeyLoaderImplementation = `const isEnabled = swrOptions?.enabled !== false${
-    params.length
-      ? ` && !!(${params.map(({ name }) => name).join(' && ')})`
-      : ''
-  }
-    const swrKeyLoader = swrOptions?.swrKeyLoader ?? (() => isEnabled ? ${swrKeyLoaderFnName}(${swrKeyProperties}) : null);`;
+  }`;
+  const swrKeyImplementation = `const swrKey = swrOptions?.swrKey ?? (() => isEnabled ? ${swrKeyFnName}(${swrKeyProperties}) : null);`;
+  const swrKeyLoaderImplementation = `const swrKeyLoader = swrOptions?.swrKeyLoader ?? (() => isEnabled ? ${swrKeyLoaderFnName}(${swrKeyProperties}) : null);`;
 
   let errorType = `AxiosError<${response.definition.errors || 'unknown'}>`;
 
@@ -316,6 +310,7 @@ ${doc}export const ${camel(
       : ''
   }
 
+  ${enabledImplementation}
   ${swrKeyLoaderImplementation}
   const swrFn = () => ${operationName}(${httpFunctionProps}${
     httpFunctionProps ? ', ' : ''
@@ -371,6 +366,7 @@ ${doc}export const ${camel(
       : ''
   }
 
+  ${enabledImplementation}
   ${swrKeyImplementation}
   const swrFn = () => ${operationName}(${httpFunctionProps}${
     httpFunctionProps ? ', ' : ''

--- a/packages/swr/src/index.ts
+++ b/packages/swr/src/index.ts
@@ -283,21 +283,22 @@ const generateSwrImplementation = ({
       : response.definition.errors || 'unknown';
   }
 
-  const useSWRInfiniteImplementation = `
+  const useSWRInfiniteImplementation = swrOptions.useInfinite
+    ? `
 export type ${pascal(
-    operationName,
-  )}InfiniteQueryResult = NonNullable<Awaited<ReturnType<typeof ${operationName}>>>
+        operationName,
+      )}InfiniteQueryResult = NonNullable<Awaited<ReturnType<typeof ${operationName}>>>
 export type ${pascal(operationName)}InfiniteError = ${errorType}
 
 ${doc}export const ${camel(
-    `use-${operationName}-infinite`,
-  )} = <TError = ${errorType}>(
+        `use-${operationName}-infinite`,
+      )} = <TError = ${errorType}>(
   ${swrProps} ${generateSwrArguments({
-    operationName,
-    mutator,
-    isRequestOptions,
-    isInfinite: true,
-  })}) => {
+        operationName,
+        mutator,
+        isRequestOptions,
+        isInfinite: true,
+      })}) => {
   ${
     isRequestOptions
       ? `const {swr: swrOptions${
@@ -313,31 +314,32 @@ ${doc}export const ${camel(
   ${enabledImplementation}
   ${swrKeyLoaderImplementation}
   const swrFn = () => ${operationName}(${httpFunctionProps}${
-    httpFunctionProps ? ', ' : ''
-  }${
-    isRequestOptions
-      ? !mutator
-        ? `axiosOptions`
-        : mutator?.hasSecondArg
-        ? 'requestOptions'
-        : ''
-      : ''
-  });
+        httpFunctionProps ? ', ' : ''
+      }${
+        isRequestOptions
+          ? !mutator
+            ? `axiosOptions`
+            : mutator?.hasSecondArg
+            ? 'requestOptions'
+            : ''
+          : ''
+      });
 
   const ${queryResultVarName} = useSWRInfinite<Awaited<ReturnType<typeof swrFn>>, TError>(swrKeyLoader, swrFn, ${
-    swrOptions.options
-      ? `{
+        swrOptions.options
+          ? `{
     ${stringify(swrOptions.options)?.slice(1, -1)}
     ...swrOptions
   }`
-      : 'swrOptions'
-  })
+          : 'swrOptions'
+      })
 
   return {
     swrKeyLoader,
     ...${queryResultVarName}
   }
-}\n`;
+}\n`
+    : '';
 
   const useSwrImplementation = `
 export type ${pascal(

--- a/packages/swr/src/index.ts
+++ b/packages/swr/src/index.ts
@@ -378,24 +378,25 @@ const generateSwrHook = (
 
   const doc = jsDoc({ summary, deprecated });
 
-  return `export const ${swrKeyFnName} = (${queryKeyProps}) => [\`${route}\`${
+  const swrKeyFn = `export const ${swrKeyFnName} = (${queryKeyProps}) => [\`${route}\`${
     queryParams ? ', ...(params ? [params]: [])' : ''
   }${body.implementation ? `, ${body.implementation}` : ''}] as const;
+  `;
 
-    ${generateSwrImplementation({
-      operationName,
-      swrKeyFnName,
-      swrProperties,
-      swrKeyProperties,
-      params,
-      props,
-      mutator,
-      isRequestOptions,
-      response,
-      swrOptions: override.swr,
-      doc,
-    })}
-`;
+  const swrImplementation = generateSwrImplementation({
+    operationName,
+    swrKeyFnName,
+    swrProperties,
+    swrKeyProperties,
+    params,
+    props,
+    mutator,
+    isRequestOptions,
+    response,
+    swrOptions: override.swr,
+    doc,
+  });
+  return swrKeyFn + swrImplementation;
 };
 
 export const generateSwrHeader: ClientHeaderBuilder = ({

--- a/packages/swr/src/index.ts
+++ b/packages/swr/src/index.ts
@@ -272,7 +272,7 @@ const generateSwrImplementation = ({
       : response.definition.errors || 'unknown';
   }
 
-  return `
+  const useSwrImplementation = `
 export type ${pascal(
     operationName,
   )}QueryResult = NonNullable<Awaited<ReturnType<typeof ${operationName}>>>
@@ -325,6 +325,8 @@ ${doc}export const ${camel(
     ...${queryResultVarName}
   }
 }\n`;
+
+  return useSwrImplementation;
 };
 
 const generateSwrHook = (


### PR DESCRIPTION
### Happy New Year everyone 🙌

## Status

**READY**

I squash commits if necessary when all reviews are complete.

## Description

fix https://github.com/anymaniax/orval/issues/796

I enabled the `swr` client to define functions using [`useSWRInfinite`](https://swr.vercel.app/docs/pagination#useswrinfinite). These are generated by specifying them in the configuration file using the `override` option as shown below:

```javascript
output: {
  client: 'swr',
  target: 'src/gen/endpoints',
  schemas: 'src/gen/model',
  override: {
    swr: {
      useInfinite: true,
    },
  },
},
```

Along with this, we are also making some refactorings:

- Most of the implementations were combined in one string definition, but I decided to separate them as variables and combine them in the end.
- The `isEnabled` judgment process and the `key` definition have been separated.

## Related PRs

none

## Todos

- [x] Tests
- [x] Documentation
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce

1. Please define `override.swr.useInfinite` to `true` in the configuration file as below:

```javascript
output: {
  client: 'swr',
  target: 'src/gen/endpoints',
  schemas: 'src/gen/model',
  override: {
    swr: {
      useInfinite: true,
    },
  },
},
```

2. `orval` execite

```
orval
```

3. An implementation definition using `useSWRInfinite` is generated

```typescript
export const getListPetsInfiniteKeyLoader = (params?: ListPetsParams,) => {
  return (_: number, previousPageData: Awaited<ReturnType<typeof listPets>>) => {
    if (previousPageData && !previousPageData.data) return null

    return [`http://localhost:8000/pets`, ...(params ? [params]: [])] as const;
  }
}

export type ListPetsInfiniteQueryResult = NonNullable<Awaited<ReturnType<typeof listPets>>>
export type ListPetsInfiniteError = AxiosError<Error>

/**
 * @summary List all pets
 */
export const useListPetsInfinite = <TError = AxiosError<Error>>(
  params?: ListPetsParams, options?: { swr?:SWRInfiniteConfiguration<Awaited<ReturnType<typeof listPets>>, TError> & { swrKeyLoader?: SWRInfiniteKeyLoader, enabled?: boolean }, axios?: AxiosRequestConfig }
) => {
  const {swr: swrOptions, axios: axiosOptions} = options ?? {}

  const isEnabled = swrOptions?.enabled !== false
  const swrKeyLoader = swrOptions?.swrKeyLoader ?? (() => isEnabled ? getListPetsInfiniteKeyLoader(params) : null);
  const swrFn = () => listPets(params, axiosOptions);

  const query = useSWRInfinite<Awaited<ReturnType<typeof swrFn>>, TError>(swrKeyLoader, swrFn, swrOptions)

  return {
    swrKeyLoader,
    ...query
  }
}
```