### PR TITLE
fix: strictly check dependencies import judgment using regular expressions

### DIFF
--- a/packages/core/src/generators/imports.ts
+++ b/packages/core/src/generators/imports.ts
@@ -181,9 +181,12 @@ export const addDependency = ({
   hasSchemaDir: boolean;
   isAllowSyntheticDefaultImports: boolean;
 }) => {
-  const toAdds = exports.filter((e) =>
-    implementation.includes(e.alias || e.name),
-  );
+  const toAdds = exports.filter((e) => {
+    const searchWords = [e.alias, e.name].filter((p) => p?.length).join('|');
+    const pattern = new RegExp(`\\b(${searchWords})\\b`, 'g');
+
+    return implementation.match(pattern);
+  });
 
   if (!toAdds.length) {
     return undefined;


### PR DESCRIPTION
## Status

**READY**

## Description

fix https://github.com/anymaniax/orval/issues/1145

>The current judgment logic uses a simple condition of whether the string exists.
Therefore, for example, if the variable useKey is used, Key will be imported, but this may be an unnecessary import.

I achieved this by using regular expressions to determine.

## Related PRs

none

## Todos

- [x] Tests
- [x] Documentation
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce

1. prepare OpenAPI definition for pet store
2. execute `orval`

```
orval
```

3. We have confirmed that the existing generation process is not destroyed using the pet store.
