### PR TITLE
feat: implement function generation using `useSWRMutation`

### DIFF
--- a/packages/swr/src/index.ts
+++ b/packages/swr/src/index.ts
@@ -629,12 +629,23 @@ export const ${swrKeyFnName} = (${queryKeyProps}) => [\`${route}\`${
     const swrMutationFetcherType = mutator
       ? `Promise<${response.definition.success || 'unknown'}>`
       : `Promise<AxiosResponse<${response.definition.success || 'unknown'}>>`;
+    const swrMutationFetcherArgType = props
+      .filter(
+        (prop) =>
+          prop.type === GetterPropType.QUERY_PARAM ||
+          prop.type === GetterPropType.BODY,
+      )
+      .map((prop) => prop.implementation.split(': ')[1])
+      .join(' & ');
+
     const swrMutationFetcherFn = `
 export const ${swrMutateFetcherName} = (${swrMutationFetcherOptions}) => {
   return (url: string, { arg }: { arg: Arguments }): ${swrMutationFetcherType} => {
     return axios${
       !isSyntheticDefaultImportsAllowed ? '.default' : ''
-    }.${verb}(url, arg${swrMutationFetcherOptions.length ? ', options' : ''});
+    }.${verb}(url, arg as ${swrMutationFetcherArgType}${
+      swrMutationFetcherOptions.length ? ', options' : ''
+    });
   }
 }\n`;
 

--- a/packages/swr/src/index.ts
+++ b/packages/swr/src/index.ts
@@ -81,6 +81,17 @@ const SWR_INFINITE_DEPENDENCIES: GeneratorDependency[] = [
   },
 ];
 
+const SWR_MUTATION_DEPENDENCIES: GeneratorDependency[] = [
+  {
+    exports: [
+      { name: 'useSWRMutation', values: true, default: true },
+      { name: 'SWRMutationConfiguration' },
+      { name: 'SWRMutationKey' },
+    ],
+    dependency: 'swr/mutation',
+  },
+];
+
 export const getSwrDependencies: ClientDependenciesBuilder = (
   hasGlobalMutator: boolean,
   hasParamsSerializerOptions: boolean,
@@ -89,6 +100,7 @@ export const getSwrDependencies: ClientDependenciesBuilder = (
   ...(hasParamsSerializerOptions ? PARAMS_SERIALIZER_DEPENDENCIES : []),
   ...SWR_DEPENDENCIES,
   ...SWR_INFINITE_DEPENDENCIES,
+  ...SWR_MUTATION_DEPENDENCIES,
 ];
 
 const generateSwrRequestFunction = (


### PR DESCRIPTION
## Status

**READY**

## Description

fix https://github.com/anymaniax/orval/issues/1013

Originally, in `generateSwrHook`, if `verb` was other than `Verbs.GET`, processing was skipped, but we implemented a function to generate a function using [`useSWRMutation`](https://swr.vercel.app/docs/mutation#useswrmutation). 

Since the processing required for `mutation` is different from `query`, we have newly added `generateSwrMutationImplementation`, which is a function for generating the string of the function itself, and `generateSwrMutationArguments`, which generates arguments.
Also, since `useSWRMutation` requires a dedicated `Fetcher` as the second argument, I reused it by wrapping the http function. This allows reuse of `mock` and customization of http client using global mutator.

## Related PRs

none

## Todos

- [x] Tests
- [x] Documentation
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce

1. Prepare an `OpenAPI` definition for petstore that defines `mutation`.

```yaml
openapi: '3.0.0'
info:
  version: 1.0.0
  title: Swagger Petstore
  license:
    name: MIT
servers:
  - url: http://petstore.swagger.io/v1
paths:
  /pets:
    post:
      summary: Create a pet
      operationId: createPets
      tags:
        - pets
      requestBody:
        description: post body
        required: true
        content:
          application/json:
            schema:
              $ref: '#/components/schemas/PetParams'
      responses:
        '201':
          description: Null response
        default:
          description: unexpected error
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/Error'
  /pets/{petId}:
    patch:
      summary: Update for a specific pet
      operationId: updatePetByParams
      tags:
        - pets
      parameters:
        - name: petId
          in: path
          required: true
          description: The id of the pet to retrieve
          schema:
            type: string
      requestBody:
        description: post body
        required: true
        content:
          application/json:
            schema:
              $ref: '#/components/schemas/PetParams'
      responses:
        '200':
          description: Expected response to a valid request
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/Pet'
        default:
          description: unexpected error
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/Error'
components:
  schemas:
    PetParams:
      type: object
      required:
        - name
      properties:
        name:
          type: string
        tag:
          type: string
    Pet:
      type: object
      required:
        - id
        - name
      properties:
        id:
          type: integer
          format: int64
        name:
          type: string
        tag:
          type: string
    Error:
      type: object
      required:
        - code
        - message
      properties:
        code:
          type: integer
          format: int32
        message:
          type: string
```

2. Prepare `orval.config.js`

```javascript
module.exports = {
  'petstore-file': {
    input: {
      target: './petstore.yaml',
    },
    output: {
      mode: 'tags-split',
      client: 'swr',
      baseUrl: 'http://localhost:8000',
      target: 'src/gen/endpoints',
      schemas: 'src/gen/model',
    },
  },
};
```

3. execute `orval`

```
orval
```

4. generated custom hook

for example: 

```
export const getCreatePetsMutationFetcher = (options?: AxiosRequestConfig) => {
  return (
    _: string,
    { arg }: { arg: Arguments },
  ): Promise<AxiosResponse<void>> => {
    return createPets(arg as PetParams, options);
  };
};
export const getCreatePetsMutationKey = () =>
  `http://localhost:8000/pets` as const;

export type CreatePetsMutationResult = NonNullable<
  Awaited<ReturnType<typeof createPets>>
>;
export type CreatePetsMutationError = AxiosError<Error>;

/**
 * @summary Create a pet
 */
export const useCreatePets = <TError = AxiosError<Error>>(options?: {
  swr?: SWRMutationConfiguration<
    Awaited<ReturnType<typeof createPets>>,
    TError,
    string,
    Arguments,
    Awaited<ReturnType<typeof createPets>>
  > & { swrKey?: string };
  axios?: AxiosRequestConfig;
}) => {
  const { swr: swrOptions, axios: axiosOptions } = options ?? {};

  const swrKey = swrOptions?.swrKey ?? getCreatePetsMutationKey();
  const swrFn = getCreatePetsMutationFetcher(axiosOptions);

  const query = useSWRMutation(swrKey, swrFn, swrOptions);

  return {
    swrKey,
    ...query,
  };
};
```