### PR TITLE
chore: remove `@types-prettier` package

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "@release-it-plugins/workspaces": "^4.0.0",
     "@release-it/conventional-changelog": "^5.0.0",
     "@types/node": "^20.10.3",
-    "@types/prettier": "^2.7.0",
     "@typescript-eslint/eslint-plugin": "^5.54.0",
     "@typescript-eslint/parser": "^5.33.0",
     "dotenv-cli": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1128,11 +1128,6 @@
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz#56e2cc26c397c038fab0e3a917a12d5c5909e901"
   integrity sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==
 
-"@types/prettier@^2.7.0":
-  version "2.7.3"
-  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.7.3.tgz#3e51a17e291d01d17d3fc61422015a933af7a08f"
-  integrity sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA==
-
 "@types/ps-tree@^1.1.2":
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/@types/ps-tree/-/ps-tree-1.1.6.tgz#fbb22dabe3d64b79295f37ce0afb7320a26ac9a6"


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

`prettier` includes `@types-prettier` from v3, so i removed this due to dependencies.

Ref: https://www.npmjs.com/package/@types/prettier

## Related PRs

https://github.com/prettier/prettier/pull/14212

## Todos

- [x] Tests
- [x] Documentation
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce

none