### PR TITLE
feat: show error stack traces

### DIFF
--- a/packages/core/src/utils/logger.ts
+++ b/packages/core/src/utils/logger.ts
@@ -17,7 +17,18 @@ export const startMessage = ({
     }`,
   );
 
-export const errorMessage = (err: string) => log(chalk.red(err));
+export const logError = (err: unknown, tag?: string) =>
+  log(
+    chalk.red(
+      [
+        '🛑',
+        tag ? `${tag} - ` : undefined,
+        err instanceof Error ? err.stack : err,
+      ]
+        .filter(Boolean)
+        .join(' '),
+    ),
+  );
 
 export const mismatchArgsMessage = (mismatchArgs: string[]) =>
   log(

--- a/packages/orval/src/bin/orval.ts
+++ b/packages/orval/src/bin/orval.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { isString, log, startMessage } from '@orval/core';
+import { isString, logError, startMessage } from '@orval/core';
 import { cac } from 'cac';
 import chalk from 'chalk';
 import { generateConfig, generateSpec } from '../generate';
@@ -63,7 +63,7 @@ cli
             try {
               await generateSpec(process.cwd(), normalizedOptions);
             } catch (e) {
-              log(chalk.red(`🛑  ${e}`));
+              logError(e);
             }
           },
           normalizedOptions.input.target as string,
@@ -72,7 +72,7 @@ cli
         try {
           await generateSpec(process.cwd(), normalizedOptions);
         } catch (e) {
-          log(chalk.red(`🛑  ${e}`));
+          logError(e);
         }
       }
     } else {

--- a/packages/orval/src/generate.ts
+++ b/packages/orval/src/generate.ts
@@ -2,7 +2,7 @@ import {
   asyncReduce,
   ConfigExternal,
   upath,
-  errorMessage,
+  logError,
   getFileInfo,
   GlobalOptions,
   isFunction,
@@ -60,11 +60,11 @@ export const generateSpecs = async (
       try {
         await generateSpec(workspace, options, projectName);
       } catch (e) {
-        log(chalk.red(`🛑  ${projectName ? `${projectName} - ` : ''}${e}`));
+        logError(e, projectName);
         process.exit(1);
       }
     } else {
-      errorMessage('Project not found');
+      logError('Project not found');
       process.exit(1);
     }
     return;
@@ -78,7 +78,7 @@ export const generateSpecs = async (
         acc.push(await generateSpec(workspace, options, projectName));
       } catch (e) {
         hasErrors = true;
-        log(chalk.red(`🛑  ${projectName ? `${projectName} - ` : ''}${e}`));
+        logError(e, projectName);
       }
       return acc;
     },

--- a/packages/orval/src/index.ts
+++ b/packages/orval/src/index.ts
@@ -1,7 +1,7 @@
 import {
   GlobalOptions,
   isString,
-  log,
+  logError,
   Options,
   OptionsExport,
 } from '@orval/core';
@@ -32,13 +32,7 @@ const generate = async (
         try {
           await generateSpec(workspace, normalizedOptions);
         } catch (e) {
-          log(
-            chalk.red(
-              `🛑  ${
-                options?.projectName ? `${options?.projectName} - ` : ''
-              }${e}`,
-            ),
-          );
+          logError(e, options?.projectName);
         }
       },
       normalizedOptions.input.target as string,
@@ -47,11 +41,7 @@ const generate = async (
     try {
       return await generateSpec(workspace, normalizedOptions);
     } catch (e) {
-      log(
-        chalk.red(
-          `🛑  ${options?.projectName ? `${options?.projectName} - ` : ''}${e}`,
-        ),
-      );
+      logError(e, options?.projectName);
     }
   }
 };

--- a/packages/orval/src/utils/executeHook.ts
+++ b/packages/orval/src/utils/executeHook.ts
@@ -3,6 +3,7 @@ import {
   isFunction,
   isString,
   log,
+  logError,
   NormalizedHookCommand,
 } from '@orval/core';
 import chalk from 'chalk';
@@ -23,7 +24,7 @@ export const executeHook = async (
       try {
         await execa(cmd, _args);
       } catch (e) {
-        log(chalk.red(`🛑 Failed to run ${name} hook: ${e}`));
+        logError(e, `Failed to run ${name} hook`);
       }
     } else if (isFunction(command)) {
       await command(args);

--- a/packages/orval/src/utils/watcher.ts
+++ b/packages/orval/src/utils/watcher.ts
@@ -1,4 +1,4 @@
-import { log } from '@orval/core';
+import { log, logError } from '@orval/core';
 import chalk from 'chalk';
 
 export const startWatcher = async (
@@ -38,7 +38,7 @@ export const startWatcher = async (
     try {
       await watchFn();
     } catch (e) {
-      log(chalk.red(e));
+      logError(e);
     }
   });
 };


### PR DESCRIPTION
## Status

**READY**

## Description

Shows stack traces for internal errors. e.g.:

```
🛑 myproject -  Error: All arrays must have an `items` key define
    at getArray (/Users/eric/Source/orval/packages/core/dist/index.js:41318:11)
    at getScalar (/Users/eric/Source/orval/packages/core/dist/index.js:41841:34)
    at resolveValue (/Users/eric/Source/orval/packages/core/dist/index.js:41200:18)
    at resolveObjectOriginal (/Users/eric/Source/orval/packages/core/dist/index.js:41215:25)
    at resolveObject (/Users/eric/Source/orval/packages/core/dist/index.js:41284:18)
    at items.reduce.values (/Users/eric/Source/orval/packages/core/dist/index.js:41969:30)
    at Array.reduce (<anonymous>)
    at combineSchemas (/Users/eric/Source/orval/packages/core/dist/index.js:41963:30)
    at getObject (/Users/eric/Source/orval/packages/core/dist/index.js:41677:12)
    at getScalar (/Users/eric/Source/orval/packages/core/dist/index.js:41908:34)
```

## Related PRs

List related PRs against other branches:

| branch              | PR       |
| ------------------- | -------- |
| other_pr_production | [link]() |
| other_pr_master     | [link]() |

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

Outline the steps to test or reproduce the PR here.

```bash
> git pull --prune
> git checkout <branch>
> grunt jasmine
```

1.
