### PR TITLE
feat(msw): possible to overwrite value when creating an `object` with `msw` mock

### DIFF
--- a/packages/mock/src/faker/getters/object.ts
+++ b/packages/mock/src/faker/getters/object.ts
@@ -77,7 +77,8 @@ export const getMockObject = ({
         : '';
     let imports: GeneratorImport[] = [];
     let includedProperties: string[] = [];
-    value += Object.entries(item.properties)
+
+    const properyScalars = Object.entries(item.properties)
       .sort((a, b) => {
         return a[0].localeCompare(b[0]);
       })
@@ -123,14 +124,18 @@ export const getMockObject = ({
 
         return `${keyDefinition}: ${resolvedValue.value}`;
       })
-      .filter(Boolean)
-      .join(', ');
+      .filter(Boolean);
+
+    properyScalars.push('...overrideResponse');
+
+    value += properyScalars.join(', ');
     value +=
       !combine ||
       combine?.separator === 'oneOf' ||
       combine?.separator === 'anyOf'
         ? '}'
         : '';
+
     return {
       value,
       imports,

--- a/packages/mock/src/faker/getters/object.ts
+++ b/packages/mock/src/faker/getters/object.ts
@@ -13,6 +13,8 @@ import { MockDefinition, MockSchemaObject } from '../../types';
 import { combineSchemasMock } from './combine';
 import { DEFAULT_OBJECT_KEY_MOCK } from '../constants';
 
+export const overrideVarName = 'overrideResponse';
+
 export const getMockObject = ({
   item,
   mockOptions,
@@ -126,7 +128,7 @@ export const getMockObject = ({
       })
       .filter(Boolean);
 
-    properyScalars.push('...overrideResponse');
+    properyScalars.push(`...${overrideVarName}`);
 
     value += properyScalars.join(', ');
     value +=

--- a/packages/mock/src/msw/index.ts
+++ b/packages/mock/src/msw/index.ts
@@ -7,7 +7,7 @@ import {
   isFunction,
   pascal,
 } from '@orval/core';
-import { getRouteMSW } from '../faker/getters';
+import { getRouteMSW, overrideVarName } from '../faker/getters';
 import { getMockDefinition, getMockOptionsDataOverride } from './mocks';
 import { getDelay } from '../delay';
 
@@ -72,7 +72,7 @@ export const generateMSW = (
     value = definitions[0];
   }
 
-  const isResponseOverridable = value.includes('...overrideResponse');
+  const isResponseOverridable = value.includes(overrideVarName);
 
   const isTextPlain = response.contentTypes.includes('text/plain');
 

--- a/packages/mock/src/msw/index.ts
+++ b/packages/mock/src/msw/index.ts
@@ -63,6 +63,7 @@ export const generateMSW = (
   const mockData = getMockOptionsDataOverride(operationId, override);
 
   let value = '';
+  let isResponseOverridable = false;
 
   if (mockData) {
     value = mockData;
@@ -70,6 +71,8 @@ export const generateMSW = (
     value = `faker.helpers.arrayElement(${definition})`;
   } else if (definitions[0]) {
     value = definitions[0];
+
+    isResponseOverridable = response.types.success[0].type === 'object';
   }
 
   const isTextPlain = response.contentTypes.includes('text/plain');
@@ -80,7 +83,7 @@ export const generateMSW = (
     implementation: {
       function:
         value && value !== 'undefined'
-          ? `export const ${functionName} = () => (${value})\n\n`
+          ? `export const ${functionName} = (${isResponseOverridable ? `overrideResponse?: any` : ''}) => (${value})\n\n`
           : '',
       handler: `http.${verb}('${route}', async () => {
         await delay(${getDelay(

--- a/packages/mock/src/msw/index.ts
+++ b/packages/mock/src/msw/index.ts
@@ -63,7 +63,6 @@ export const generateMSW = (
   const mockData = getMockOptionsDataOverride(operationId, override);
 
   let value = '';
-  let isResponseOverridable = false;
 
   if (mockData) {
     value = mockData;
@@ -71,9 +70,9 @@ export const generateMSW = (
     value = `faker.helpers.arrayElement(${definition})`;
   } else if (definitions[0]) {
     value = definitions[0];
-
-    isResponseOverridable = response.types.success[0].type === 'object';
   }
+
+  const isResponseOverridable = value.includes('...overrideResponse');
 
   const isTextPlain = response.contentTypes.includes('text/plain');
 


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

I responded to part of https://github.com/anymaniax/orval/issues/822

If there is only one response case and the type is `object`, the returned value can be overwritten externally by specifying `overrideResponse` as an argument.
In order to handle the case where it is an `array` of `object` such as `Pets`, after calculating the return value, we determine whether overwriting is possible based on whether `overrideResponse` is included in it.

## Todos

- [x] Tests
- [x] Documentation
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce

1. Specify basic pet schema as input
2. execute `orval`

```
orval
```

3. generated mock function bellow: 

```typescript
export const getListPetsMock = (overrideResponse?: any) => (Array.from({
  length: faker.number.int({ min: 1, max: 10 }) }, (_, i) => i + 1).map(() => ({
    id: faker.number.int({min: undefined, max: undefined}),
    name: faker.word.sample(),
    tag: faker.helpers.arrayElement([faker.word.sample(), undefined]),
    ...overrideResponse
  }))
)

export const getShowPetByIdMock = (overrideResponse?: any) => ({
  id: faker.number.int({min: undefined, max: undefined}),
  name: faker.word.sample(),
  tag: faker.helpers.arrayElement([faker.word.sample(), undefined]), ...overrideResponse
})
```

4. usage

```typescript

import { getListPetsMock, getShowPetByIdMock } from 'gen/pets.msw'

const pets = getListPetsMock({name: 'orverride'})
console.log(pets)
// => [{ id: 645061935104000, name: "orverride", tag: undefined }, { id: 83169910980608, name: "orverride", tag: undefined }]
​​
const pet = getShowPetByIdMock({name: 'orverride'})
console.log(pet)
// => { id: 7272122785202176, ​name: "orverride", tag: undefined }
```