### PR TITLE
fix(mock): `null` is excluded instead of being converted to an empty string `''`

### DIFF
--- a/packages/mock/src/faker/getters/scalar.ts
+++ b/packages/mock/src/faker/getters/scalar.ts
@@ -212,7 +212,12 @@ export const getMockScalar = ({
         // By default the value isn't a reference, so we don't have the object explicitly defined.
         // So we have to create an array with the enum values and force them to be a const.
         let enumValue =
-          "['" + item.enum.map((e) => escape(e)).join("','") + "'] as const";
+          "['" +
+          item.enum
+            .filter(Boolean)
+            .map((e) => escape(e))
+            .join("','") +
+          "'] as const";
 
         // But if the value is a reference, we can use the object directly via the imports and using Object.values.
         if (item.isRef) {

--- a/packages/mock/src/faker/getters/scalar.ts
+++ b/packages/mock/src/faker/getters/scalar.ts
@@ -211,13 +211,12 @@ export const getMockScalar = ({
       if (item.enum) {
         // By default the value isn't a reference, so we don't have the object explicitly defined.
         // So we have to create an array with the enum values and force them to be a const.
-        let enumValue =
-          "['" +
-          item.enum
-            .filter(Boolean)
-            .map((e) => escape(e))
-            .join("','") +
-          "'] as const";
+        const joindEnumValues = item.enum
+          .filter(Boolean)
+          .map((e) => escape(e))
+          .join("','");
+
+        let enumValue = `['${joindEnumValues}'] as const`;
 
         // But if the value is a reference, we can use the object directly via the imports and using Object.values.
         if (item.isRef) {


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

If `null` exists in `enum`, the generated `enum` type will not include `null` or the empty string `''`.
For example bellow generated by https://github.com/anymaniax/orval/blob/master/tests/specifications/null-type-v3-0.yaml#L91

```typescript
export type NullableStringEnum = typeof NullableStringEnum[keyof typeof NullableStringEnum] | null;

export const NullableStringEnum = {
  ONE: 'ONE',
  TWO: 'TWO',
  THREE: 'THREE',
} as const;
```

Therefore, they are unnecessary, including the value patterns generated by mock. In fact, specifying the type causes an error.

```typescript
export const getFetchNullableEnumsMock = () => (
  faker.helpers.arrayElement([faker.helpers.arrayElement(['ONE','TWO','THREE', ''] as const), null])
)
const mock: NullableStringEnum = getFetchNullableEnumsMock()
// => error TS2322: Type '"" | "ONE" | "TWO" | "THREE" | null' is not assignable to type 'NullableStringEnum'.
//    Type '""' is not assignable to type 'NullableStringEnum'.
```

So I fixed it so that it doesn't contain the empty string ''''.

```typescript
export const getFetchNullableEnumsMock = () => (
  faker.helpers.arrayElement([faker.helpers.arrayElement(['ONE','TWO','THREE'] as const), null])
)
const mock: NullableStringEnum = getFetchNullableEnumsMock()
// => not error
```

## Related PRs

none

## Todos

- [ ] Tests
- [x] Documentation
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce

1. `cd test`
2. `yarn generate:default`
3. Check the `getFetchNullableEnumsMock` function in `tests/generated/default/null-type-v3-0/endpoints.ts`