### PR TITLE
fix: process exit on import spec failure

### DIFF
--- a/packages/orval/src/import-specs.ts
+++ b/packages/orval/src/import-specs.ts
@@ -61,34 +61,43 @@ export const importSpecs = async (
   const { input, output } = options;
 
   if (isObject(input.target)) {
-    return importOpenApi({
-      data: { [workspace]: input.target },
-      // @ts-expect-error // FIXME
-      input,
-      output,
-      target: workspace,
-      workspace,
-    });
+    try {
+      return importOpenApi({
+        data: { [workspace]: input.target },
+        input,
+        output,
+        target: workspace,
+        workspace,
+      });
+    } catch {
+      process.exit(1)
+    }
   }
 
-  // @ts-expect-error // FIXME
+  if (typeof input.target !== 'string') {
+    throw new Error(
+      `The input.target option needs to be either of the type Object or String`,
+    );
+  }
+
   const isPathUrl = isUrl(input.target);
 
-  const data = await resolveSpecs(
-    // @ts-expect-error // FIXME
-    input.target,
-    input.parserOptions,
-    isPathUrl,
-    !output.target,
-  );
-
-  return importOpenApi({
-    data,
-    // @ts-expect-error // FIXME
-    input,
-    output,
-    // @ts-expect-error // FIXME
-    target: input.target,
-    workspace,
-  });
+  try {
+    const data = await resolveSpecs(
+      input.target,
+      input.parserOptions,
+      isPathUrl,
+      !output.target,
+    );
+  
+    return importOpenApi({
+      data,
+      input,
+      output,
+      target: input.target,
+      workspace,
+    });
+  } catch {
+    process.exit(1)
+  }
 };


### PR DESCRIPTION
We're having a bunch of issues with Orval in our ci/cd, where Orval doesn't exit the process when the request for retrieving our spec fails. It feels like a sensible default to exit the process with code 1 when this happens, as currently the Github workflow job reports no errors even though Orval never was actually able to generate a proper output.


For reference, this is what our config looks like:


```
import { defineConfig } from 'orval';

const config: ReturnType<typeof defineConfig> = defineConfig({
  client: {
    output: {
      client: 'axios',
      target: './src/integrations/service/service.api.generated.ts',
      override: {
        mutator: {
          path: './src/integrations/service/service-axios-client.ts',
          name: 'client',
        },
      },
      schemas: './src/integrations/service/service.types.generated/',
      indexFiles: true,
    },
    input: {
      target: 'https://service.something/swagger.json',
      parserOptions: {
        resolve: {
          http: {
            timeout: 30_000,
          },
        },
      },
    },
  },
});

export default config;

```

Happy to adjust this PR where you would see fit, also happy to adjust the process existing based on a config option/flag. 