### PR TITLE
feat(msw): define the return value type in the `msw` mock function.

### DIFF
--- a/packages/core/src/writers/split-mode.ts
+++ b/packages/core/src/writers/split-mode.ts
@@ -61,12 +61,7 @@ export const writeSplitMode = async ({
     });
     mockData += builder.importsMock({
       implementation: implementationMock,
-      imports: [
-        {
-          exports: importsMock,
-          dependency: relativeSchemasPath,
-        },
-      ],
+      imports: [{ exports: imports, dependency: relativeSchemasPath }],
       specsName,
       hasSchemaDir: !!output.schemas,
       isAllowSyntheticDefaultImports,

--- a/packages/core/src/writers/split-tags-mode.ts
+++ b/packages/core/src/writers/split-tags-mode.ts
@@ -75,12 +75,7 @@ export const writeSplitTagsMode = async ({
         });
         mockData += builder.importsMock({
           implementation: implementationMock,
-          imports: [
-            {
-              exports: importsMock,
-              dependency: relativeSchemasPath,
-            },
-          ],
+          imports: importsForBuilder,
           specsName,
           hasSchemaDir: !!output.schemas,
           isAllowSyntheticDefaultImports,

--- a/packages/core/src/writers/tags-mode.ts
+++ b/packages/core/src/writers/tags-mode.ts
@@ -50,18 +50,20 @@ export const writeTagsMode = async ({
           ? upath.relativeSafe(dirname, getFileInfo(output.schemas).dirname)
           : './' + filename + '.schemas';
 
+        const importsForBuilder = [
+          {
+            exports: imports.filter(
+              (imp) =>
+                !importsMock.some((impMock) => imp.name === impMock.name),
+            ),
+            dependency: schemasPathRelative,
+          },
+        ];
+
         data += builder.imports({
           client: output.client,
           implementation,
-          imports: [
-            {
-              exports: imports.filter(
-                (imp) =>
-                  !importsMock.some((impMock) => imp.name === impMock.name),
-              ),
-              dependency: schemasPathRelative,
-            },
-          ],
+          imports: importsForBuilder,
           specsName,
           hasSchemaDir: !!output.schemas,
           isAllowSyntheticDefaultImports,
@@ -74,9 +76,7 @@ export const writeTagsMode = async ({
         if (output.mock) {
           data += builder.importsMock({
             implementation: implementationMock,
-            imports: [
-              { exports: importsMock, dependency: schemasPathRelative },
-            ],
+            imports: importsForBuilder,
             specsName,
             hasSchemaDir: !!output.schemas,
             isAllowSyntheticDefaultImports,

--- a/packages/mock/src/msw/index.ts
+++ b/packages/mock/src/msw/index.ts
@@ -63,7 +63,6 @@ export const generateMSW = (
   const mockData = getMockOptionsDataOverride(operationId, override);
 
   let value = '';
-  let isResponseOverridable = false;
 
   if (mockData) {
     value = mockData;
@@ -71,8 +70,6 @@ export const generateMSW = (
     value = `faker.helpers.arrayElement(${definition})`;
   } else if (definitions[0]) {
     value = definitions[0];
-
-    isResponseOverridable = response.types.success[0].type === 'object';
   }
 
   const isResponseOverridable = value.includes(overrideVarName);

--- a/packages/mock/src/msw/index.ts
+++ b/packages/mock/src/msw/index.ts
@@ -63,6 +63,7 @@ export const generateMSW = (
   const mockData = getMockOptionsDataOverride(operationId, override);
 
   let value = '';
+  let isResponseOverridable = false;
 
   if (mockData) {
     value = mockData;
@@ -70,6 +71,8 @@ export const generateMSW = (
     value = `faker.helpers.arrayElement(${definition})`;
   } else if (definitions[0]) {
     value = definitions[0];
+
+    isResponseOverridable = response.types.success[0].type === 'object';
   }
 
   const isResponseOverridable = value.includes(overrideVarName);

--- a/packages/mock/src/msw/index.ts
+++ b/packages/mock/src/msw/index.ts
@@ -74,6 +74,8 @@ export const generateMSW = (
 
   const isResponseOverridable = value.includes(overrideVarName);
 
+  const returnType = response.definition.success;
+
   const isTextPlain = response.contentTypes.includes('text/plain');
 
   const functionName = `get${pascal(operationId)}Mock`;
@@ -104,7 +106,7 @@ export const ${handlerName} = http.${verb}('${route}', async () => {
     implementation: {
       function:
         value && value !== 'undefined'
-          ? `export const ${functionName} = (${isResponseOverridable ? `overrideResponse?: any` : ''}) => (${value})\n\n`
+          ? `export const ${functionName} = (${isResponseOverridable ? `overrideResponse?: any` : ''}): ${returnType} => (${value})\n\n`
           : '',
       handlerName: handlerName,
       handler: handlerImplementation,


### PR DESCRIPTION
## Status

**READY**

## Description

Define the return value type in the `msw` mock function.
Since the type of the model is used as the type to return, in `split`, `split-tag`, and `tags` modes, the list of imports required by the mock is similar to the http client.

## Related PRs

none

## Todos

- [ ] Tests
- [x] Documentation
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce

Outline the steps to test or reproduce the PR here.

```bash
> git pull --prune
> git checkout <branch>
> grunt jasmine
```

1. Specify basic pet schema as input
2. execute orval

```
orval
```

3. generated mock function bellow:

The return type is specified.

```typescript
export const getListPetsMock = (overrideResponse?: any): Pets =>
  Array.from(
    { length: faker.number.int({ min: 1, max: 10 }) },
    (_, i) => i + 1,
  ).map(() => ({
    id: faker.number.int({ min: undefined, max: undefined }),
    name: faker.word.sample(),
    tag: faker.helpers.arrayElement([faker.word.sample(), undefined]),
    ...overrideResponse,
  }));

export const getShowPetByIdMock = (overrideResponse?: any): Pet => ({
  id: faker.number.int({ min: undefined, max: undefined }),
  name: faker.word.sample(),
  tag: faker.helpers.arrayElement([faker.word.sample(), undefined]),
  ...overrideResponse,
});
```