### PR TITLE
fix: reproducible typescript output (#1159)

### DIFF
--- a/packages/orval/src/import-specs.ts
+++ b/packages/orval/src/import-specs.ts
@@ -43,7 +43,9 @@ const resolveSpecs = async (
 
     // normalizing slashes after SwaggerParser
     return Object.fromEntries(
-      Object.entries(data).map(([key, value]) => [upath.resolve(key), value]),
+      Object.entries(data)
+        .sort()
+        .map(([key, value]) => [upath.resolve(key), value]),
     );
   } catch {
     const file = await fs.readFile(path, 'utf8');


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

Sort schemas after reading input files and before generating output.

## Related PRs

Fixes #1159

## Todos

- [ ] Tests
- [ ] Documentation (N/A)
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

Extract the workspace from [reproduce.tar.gz](https://github.com/anymaniax/orval/files/14030695/reproduce.tar.gz)

```bash
# generate the OpenApi schema
> python3 gen.py

# generate Typescript using orval
> npx orval

# Make a copy of the output
> cp gen/reproduce.ts gen/reproduce-one.ts

# Rerun the generator
> npx orval

# diff the two outputs
> diff gen/reproduce-one.ts gen/reproduce.ts
```

The two output files should be identical.