### PR TITLE
feat(msw): separated mock handler and made it reusable

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -526,6 +526,7 @@ export type GeneratorTargetFull = {
   implementationMock: {
     function: string;
     handler: string;
+    handlerName: string;
   };
   importsMock: GeneratorImport[];
   mutators?: GeneratorMutator[];
@@ -538,7 +539,11 @@ export type GeneratorTargetFull = {
 export type GeneratorOperation = {
   imports: GeneratorImport[];
   implementation: string;
-  implementationMock: { function: string; handler: string };
+  implementationMock: {
+    function: string;
+    handler: string;
+    handlerName: string;
+  };
   importsMock: GeneratorImport[];
   tags: string[];
   mutator?: GeneratorMutator;

--- a/packages/core/src/writers/target-tags.ts
+++ b/packages/core/src/writers/target-tags.ts
@@ -39,6 +39,7 @@ const generateTargetTags = (
         implementationMock: {
           function: operation.implementationMock.function,
           handler: operation.implementationMock.handler,
+          handlerName: '  ' + operation.implementationMock.handlerName,
         },
       };
 
@@ -57,6 +58,10 @@ const generateTargetTags = (
         handler:
           currentOperation.implementationMock.handler +
           operation.implementationMock.handler,
+        handlerName:
+          currentOperation.implementationMock.handlerName +
+          ',\n  ' +
+          operation.implementationMock.handlerName,
       },
       mutators: operation.mutator
         ? [...(currentOperation.mutators ?? []), operation.mutator]
@@ -150,9 +155,11 @@ export const generateTargetForTags = (
               implementationMock: {
                 function: target.implementationMock.function,
                 handler:
-                  header.implementationMock +
                   target.implementationMock.handler +
+                  header.implementationMock +
+                  target.implementationMock.handlerName +
                   footer.implementationMock,
+                handlerName: target.implementationMock.handlerName,
               },
               imports: target.imports,
               importsMock: target.importsMock,

--- a/packages/core/src/writers/target.ts
+++ b/packages/core/src/writers/target.ts
@@ -30,6 +30,13 @@ export const generateTarget = (
       acc.implementation += operation.implementation + '\n';
       acc.implementationMock.function += operation.implementationMock.function;
       acc.implementationMock.handler += operation.implementationMock.handler;
+
+      const handlerNameSeparator = acc.implementationMock.handlerName.length
+        ? ',\n  '
+        : '  ';
+      acc.implementationMock.handlerName +=
+        handlerNameSeparator + operation.implementationMock.handlerName;
+
       if (operation.mutator) {
         acc.mutators.push(operation.mutator);
       }
@@ -70,9 +77,12 @@ export const generateTarget = (
           titles,
           output: options,
         });
+
         acc.implementation = header.implementation + acc.implementation;
         acc.implementationMock.handler =
-          header.implementationMock + acc.implementationMock.handler;
+          acc.implementationMock.handler +
+          header.implementationMock +
+          acc.implementationMock.handlerName;
 
         const footer = builder.footer({
           outputClient: options?.client,

--- a/packages/core/src/writers/target.ts
+++ b/packages/core/src/writers/target.ts
@@ -93,6 +93,7 @@ export const generateTarget = (
       implementationMock: {
         function: '',
         handler: '',
+        handlerName: '',
       },
       importsMock: [],
       mutators: [],

--- a/packages/orval/src/client.ts
+++ b/packages/orval/src/client.ts
@@ -121,7 +121,7 @@ export const generateClientFooter: GeneratorClientFooter = ({
   if (!footer) {
     return {
       implementation: '',
-      implementationMock: `]\n`,
+      implementationMock: `\n]\n`,
     };
   }
 


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description
Fix #822

I separate mock handler functions and aggregate functions. That way you can just use separate handlers. This will result in more reusable mocks.

### Before

```typescript
export const getPetsMock = () => [
  http.get('*/pets', async () => {
    await delay(1000);
    return new HttpResponse(JSON.stringify(getListPetsMock()),
      { 
        status: 200,
        headers: {
          'Content-Type': 'application/json',
        }
      }
    )
  }),
  http.post('*/pets', async () => {
    await delay(1000);
    return new HttpResponse(null,
      { 
        status: 200,
        headers: {
          'Content-Type': 'application/json',
        }
      }
    )
  }),
  http.get('*/pets/:petId', async () => {
    await delay(1000);
    return new HttpResponse(JSON.stringify(getShowPetByIdMock()),
      { 
        status: 200,
        headers: {
          'Content-Type': 'application/json',
        }
      }
    )
  })
]
```


### After

```typescript
// Individual handler
export const getListPetsMockHandler = http.get('*/pets', async () => {
  await delay(1000);
  return new HttpResponse(JSON.stringify(getListPetsMock()),
    { 
      status: 200,
      headers: {
        'Content-Type': 'application/json',
      }
    }
  )
})

export const getCreatePetsMockHandler = http.post('*/pets', async () => {
  await delay(1000);
  return new HttpResponse(null,
    { 
      status: 200,
      headers: {
        'Content-Type': 'application/json',
      }
    }
  )
})

export const getShowPetByIdMockHandler = http.get('*/pets/:petId', async () => {
  await delay(1000);
  return new HttpResponse(JSON.stringify(getShowPetByIdMock()),
    { 
      status: 200,
      headers: {
        'Content-Type': 'application/json',
      }
    }
  )
})

// handlers aggregation
export const getPetsMock = () => [
  getListPetsMockHandler,
  getCreatePetsMockHandler,
  getShowPetByIdMockHandler
]
```


## Related PRs

https://github.com/anymaniax/orval/issues/822

## Todos

- [x] Tests
- [x] Documentation
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce

1. use basic pet store difinition
2. execute `orval`
3. check generate `msw` mocks
