### PR TITLE
fix: define default value for `msw` mock orverride

### DIFF
--- a/packages/mock/src/msw/index.ts
+++ b/packages/mock/src/msw/index.ts
@@ -106,7 +106,7 @@ export const ${handlerName} = http.${verb}('${route}', async () => {
     implementation: {
       function:
         value && value !== 'undefined'
-          ? `export const ${functionName} = (${isResponseOverridable ? `overrideResponse?: any` : ''}): ${returnType} => (${value})\n\n`
+          ? `export const ${functionName} = (${isResponseOverridable ? `overrideResponse: any = {}` : ''}): ${returnType} => (${value})\n\n`
           : '',
       handlerName: handlerName,
       handler: handlerImplementation,


### PR DESCRIPTION
## Status

**READY**

## Description

fix https://github.com/anymaniax/orval/pull/1165#discussion_r1468472063
Error occurs when`eslint` if tries spread `undefined` so, i fix it.

## Related PRs

I received a comment at https://github.com/anymaniax/orval/pull/1165

## Todos

- [ ] Tests
- [x] Documentation
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce

1. execute `orval`
2. check for `overrideResponse: any = {}`  in generated `msw` mock