### PR TITLE
feat(msw): possible to value of the mock handler function overridable

### DIFF
--- a/packages/core/src/writers/target-tags.ts
+++ b/packages/core/src/writers/target-tags.ts
@@ -39,7 +39,7 @@ const generateTargetTags = (
         implementationMock: {
           function: operation.implementationMock.function,
           handler: operation.implementationMock.handler,
-          handlerName: '  ' + operation.implementationMock.handlerName,
+          handlerName: '  ' + operation.implementationMock.handlerName + '()',
         },
       };
 
@@ -61,7 +61,8 @@ const generateTargetTags = (
         handlerName:
           currentOperation.implementationMock.handlerName +
           ',\n  ' +
-          operation.implementationMock.handlerName,
+          operation.implementationMock.handlerName +
+          '()',
       },
       mutators: operation.mutator
         ? [...(currentOperation.mutators ?? []), operation.mutator]

--- a/packages/core/src/writers/target.ts
+++ b/packages/core/src/writers/target.ts
@@ -35,7 +35,7 @@ export const generateTarget = (
         ? ',\n  '
         : '  ';
       acc.implementationMock.handlerName +=
-        handlerNameSeparator + operation.implementationMock.handlerName;
+        handlerNameSeparator + operation.implementationMock.handlerName + '()';
 
       if (operation.mutator) {
         acc.mutators.push(operation.mutator);

--- a/packages/mock/src/msw/index.ts
+++ b/packages/mock/src/msw/index.ts
@@ -103,10 +103,9 @@ export const ${handlerName} = (${isReturnHttpResponse && !isTextPlain ? `overrid
 
   return {
     implementation: {
-      function:
-        value && value !== 'undefined'
-          ? `export const ${functionName} = (${isResponseOverridable ? `overrideResponse: any = {}` : ''}): ${returnType} => (${value})\n\n`
-          : '',
+      function: isReturnHttpResponse
+        ? `export const ${functionName} = (${isResponseOverridable ? `overrideResponse: any = {}` : ''}): ${returnType} => (${value})\n\n`
+        : '',
       handlerName: handlerName,
       handler: handlerImplementation,
     },

--- a/packages/mock/src/msw/index.ts
+++ b/packages/mock/src/msw/index.ts
@@ -73,20 +73,18 @@ export const generateMSW = (
   }
 
   const isResponseOverridable = value.includes(overrideVarName);
+  const isTextPlain = response.contentTypes.includes('text/plain');
+  const isReturnHttpResponse = value && value !== 'undefined';
 
   const returnType = response.definition.success;
-
-  const isTextPlain = response.contentTypes.includes('text/plain');
-
   const functionName = `get${pascal(operationId)}Mock`;
-
   const handlerName = `get${pascal(operationId)}MockHandler`;
 
   const handlerImplementation = `
 export const ${handlerName} = http.${verb}('${route}', async () => {
   await delay(${getDelay(override, !isFunction(mock) ? mock : undefined)});
   return new HttpResponse(${
-    value && value !== 'undefined'
+    isReturnHttpResponse
       ? isTextPlain
         ? `${functionName}()`
         : `JSON.stringify(${functionName}())`

--- a/packages/mock/src/msw/index.ts
+++ b/packages/mock/src/msw/index.ts
@@ -81,24 +81,25 @@ export const generateMSW = (
   const handlerName = `get${pascal(operationId)}MockHandler`;
 
   const handlerImplementation = `
-export const ${handlerName} = http.${verb}('${route}', async () => {
-  await delay(${getDelay(override, !isFunction(mock) ? mock : undefined)});
-  return new HttpResponse(${
-    isReturnHttpResponse
-      ? isTextPlain
-        ? `${functionName}()`
-        : `JSON.stringify(${functionName}())`
-      : null
-  },
-    { 
-      status: 200,
-      headers: {
-        'Content-Type': '${isTextPlain ? 'text/plain' : 'application/json'}',
+export const ${handlerName} = (${isReturnHttpResponse && !isTextPlain ? `overrideResponse?: ${returnType}` : ''}) => {
+  return http.${verb}('${route}', async () => {
+    await delay(${getDelay(override, !isFunction(mock) ? mock : undefined)});
+    return new HttpResponse(${
+      isReturnHttpResponse
+        ? isTextPlain
+          ? `${functionName}()`
+          : `JSON.stringify(overrideResponse ? overrideResponse : ${functionName}())`
+        : null
+    },
+      {
+        status: 200,
+        headers: {
+          'Content-Type': '${isTextPlain ? 'text/plain' : 'application/json'}',
+        }
       }
-    }
-  )
-})
-`;
+    )
+  })
+}\n`;
 
   return {
     implementation: {


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

I made the value of the mock handler function overridable. This makes the handler even more reusable.

## Todos

- [x] Tests
- [x] Documentation
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce

1. Specify basic pet schema as input
2. execute `orval`

```
orval
```

3. generated mock function bellow: 

```typescript
export const getListPetsMockHandler = (overrideResponse?: Pets) => {
  return http.get('*/pets', async () => {
    await delay(1000);
    return new HttpResponse(JSON.stringify(overrideResponse ? overrideResponse : getListPetsMock()),
      {
        status: 200,
        headers: {
          'Content-Type': 'application/json',
        }
      }
    )
  })
}

export const getShowPetByIdMockHandler = (overrideResponse?: Pet) => {
  return http.get('*/pets/:petId', async () => {
    await delay(1000);
    return new HttpResponse(JSON.stringify(overrideResponse ? overrideResponse : getShowPetByIdMock()),
      {
        status: 200,
        headers: {
          'Content-Type': 'application/json',
        }
      }
    )
  })
}
```

4. usage

```typescript
import { Pet } from './gen/model/pet';
import { getListPetsMockHandler, getShowPetByIdMockHandler } from './gen/endpoints/pets/pets.msw';

const pet: Pet = { id: 1, name: 'test', tag: 'test' };

const listPetsMockHandlerhandler = getListPetsMockHandler([pet]);
console.log(listPetsMockHandlerhandler);
// => Object { info: {…}, isUsed: false, resolver: async getListPetsMockHandler(), resolverGenerator: undefined, resolverGeneratorResult: undefined, options: {} }

const showPetByIdMockHandler = getShowPetByIdMockHandler(pet);
console.log(showPetByIdMockHandler);
// => Object { info: {…}, isUsed: false, resolver: async getShowPetByIdMockHandler(), resolverGenerator: undefined, resolverGeneratorResult: undefined, options: {} }
```