### PR TITLE
feat: enhance overrideResponse assignment

### DIFF
--- a/packages/mock/src/createOverrideVariable.ts
+++ b/packages/mock/src/createOverrideVariable.ts
@@ -1,0 +1,23 @@
+export const overrideVarName = 'overrideResponse';
+
+export function createOverrideVariable(path?: string) {
+  let index = 0;
+
+  if (!path) {
+    return overrideVarName;
+  }
+
+  return (
+    overrideVarName +
+    path
+      ?.replace('#.', '')
+      .split('.')
+      .reduce((acc, key) => {
+        if (key !== '[]') {
+          return acc + `?.['${key}']`;
+        } else {
+          return acc + `?.[index_${index++}]`;
+        }
+      }, '')
+  );
+}

--- a/packages/mock/src/faker/getters/object.ts
+++ b/packages/mock/src/faker/getters/object.ts
@@ -13,8 +13,6 @@ import { MockDefinition, MockSchemaObject } from '../../types';
 import { combineSchemasMock } from './combine';
 import { DEFAULT_OBJECT_KEY_MOCK } from '../constants';
 
-export const overrideVarName = 'overrideResponse';
-
 export const getMockObject = ({
   item,
   mockOptions,
@@ -127,8 +125,6 @@ export const getMockObject = ({
         return `${keyDefinition}: ${resolvedValue.value}`;
       })
       .filter(Boolean);
-
-    properyScalars.push(`...${overrideVarName}`);
 
     value += properyScalars.join(', ');
     value +=

--- a/packages/mock/src/faker/getters/scalar.ts
+++ b/packages/mock/src/faker/getters/scalar.ts
@@ -15,6 +15,7 @@ import {
 import { MockDefinition, MockSchemaObject } from '../../types';
 import { getMockObject } from './object';
 import { DEFAULT_FORMAT_MOCK } from '../constants';
+import { createOverrideVariable } from '../../createOverrideVariable';
 
 export const getMockScalar = ({
   item,
@@ -195,10 +196,10 @@ export const getMockScalar = ({
 
       return {
         value:
-          `Array.from({ length: faker.number.int({ ` +
+          `Array.from({ length: Math.max(${createOverrideVariable(item.path)}?.length ?? 0,  faker.number.int({ ` +
           `min: ${mockOptions?.arrayMin}, ` +
-          `max: ${mockOptions?.arrayMax} }) ` +
-          `}, (_, i) => i + 1).map(() => (${mapValue}))`,
+          `max: ${mockOptions?.arrayMax} })) ` +
+          `}, (_, i) => i + 1).map((_, index_${item.path?.match(/\[\]/g)?.length ?? 0}) => (${mapValue}))`,
         imports: resolvedImports,
         name: item.name,
       };

--- a/packages/mock/src/msw/index.ts
+++ b/packages/mock/src/msw/index.ts
@@ -108,10 +108,9 @@ export const ${handlerName} = (${isReturnHttpResponse && !isTextPlain ? `overrid
 
   return {
     implementation: {
-      function:
-        value && value !== 'undefined'
-          ? `export const ${functionName} = (${isResponseOverridable ? `${overrideVarName}: any = {}` : ''}): ${returnType} => ${isResponseOverridable ? `merge((${value}), overrideResponse)` : `(${value}) as any`}\n\n`
-          : '',
+      function: isReturnHttpResponse
+        ? `export const ${functionName} = (${isResponseOverridable ? `${overrideVarName}: any = {}` : ''}): ${returnType} => ${isResponseOverridable ? `merge((${value}), overrideResponse)` : `(${value}) as any`}\n\n`
+        : '',
       handlerName: handlerName,
       handler: handlerImplementation,
     },

--- a/packages/mock/src/msw/index.ts
+++ b/packages/mock/src/msw/index.ts
@@ -7,9 +7,10 @@ import {
   isFunction,
   pascal,
 } from '@orval/core';
-import { getRouteMSW, overrideVarName } from '../faker/getters';
+import { getRouteMSW } from '../faker/getters';
 import { getMockDefinition, getMockOptionsDataOverride } from './mocks';
 import { getDelay } from '../delay';
+import { overrideVarName } from '../createOverrideVariable';
 
 const getMSWDependencies = (locale?: string): GeneratorDependency[] => [
   {
@@ -23,6 +24,10 @@ const getMSWDependencies = (locale?: string): GeneratorDependency[] => [
   {
     exports: [{ name: 'faker', values: true }],
     dependency: locale ? `@faker-js/faker/locale/${locale}` : '@faker-js/faker',
+  },
+  {
+    exports: [{ name: 'merge', default: true, values: true }],
+    dependency: 'lodash/merge',
   },
 ];
 
@@ -103,9 +108,10 @@ export const ${handlerName} = (${isReturnHttpResponse && !isTextPlain ? `overrid
 
   return {
     implementation: {
-      function: isReturnHttpResponse
-        ? `export const ${functionName} = (${isResponseOverridable ? `overrideResponse: any = {}` : ''}): ${returnType} => (${value})\n\n`
-        : '',
+      function:
+        value && value !== 'undefined'
+          ? `export const ${functionName} = (${isResponseOverridable ? `${overrideVarName}: any = {}` : ''}): ${returnType} => ${isResponseOverridable ? `merge((${value}), overrideResponse)` : `(${value}) as any`}\n\n`
+          : '',
       handlerName: handlerName,
       handler: handlerImplementation,
     },

--- a/packages/mock/src/msw/index.ts
+++ b/packages/mock/src/msw/index.ts
@@ -109,7 +109,8 @@ export const ${handlerName} = (${isReturnHttpResponse && !isTextPlain ? `overrid
   return {
     implementation: {
       function: isReturnHttpResponse
-        ? `export const ${functionName} = (${isResponseOverridable ? `${overrideVarName}: any = {}` : ''}): ${returnType} => ${isResponseOverridable ? `merge((${value}), overrideResponse)` : `(${value}) as any`}\n\n`
+        ? // TODO(https://github.com/anymaniax/orval/issues/1210): 'as any' is used to avoid type errors until #1210 is fixed
+          `export const ${functionName} = (${isResponseOverridable ? `${overrideVarName}: any = {}` : ''}): ${returnType} => ${isResponseOverridable ? `merge((${value}), overrideResponse)` : `(${value}) as any`}\n\n`
         : '',
       handlerName: handlerName,
       handler: handlerImplementation,


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

### 1. Apply loadsh/merge

According to the ECMAScript specification [1], The spread syntax does not guarantee deep assignment.

Because the properties will overwrite per each key by CreateDataProperty.

```
1. Let newDesc be the PropertyDescriptor { [[Value]]: V, [[Writable]]: true, [[Enumerable]]: true, [[Configurable]]: true }.
2. Return ? O.[[DefineOwnProperty]](P, newDesc).
```

(Also Object.assign [2] - [[Set]] in this case operation.)

For example:

```javascript
const override = { 
   data: {
          content: "John Doe"
   }
};


const result = { 
   data: {
      type: "NAME",
      content: "Seokho"
      // and the other properties mocked by fackerjs
   },
    ...override
};
```

The `result` will be:

```javascript
{
   data: {
          content: "John Doe"
   }
}

```

The user expectation that presents given properties is only valid on 1depth of the result.

Therefore, apply `loadsh/merge` [3] to assign property recursively.

### 2. Deterministic array length by overrideResponse

The overrideResponse can contain an array property. Currently, the override target generates a random length of it.

The length of the generated array can be shorter than the length in overrideResponse.
That possibly leads to unexpected overriding behavior.


For example:


```javascript
  const generated = [
     {
        content: "Seokho",
        id: "test-id", 
       // and many other properties... include required type
     },
  ]
  // The second one can present a non-deterministic result 
  // between only one property and added other properties per each call.
  const mocked = merge(generated, [{ content: "John Doe"}, { content: "Apple" }])

  
```

Hence, get length information from the array of the given overrideResponse to ensure the length of the generated array is greater than the given parameter.

The result will be looks like:

```javascript

   // ...
    {
      foo: Array.from(
        {
          length: Math.max(
            overrideResponse?.['foo']?.length ?? 0,
            faker.number.int({ min: 1, max: 10 }),
          ),
        },
        (_, i) => i + 1,
      ).map((_, index_0) =>  faker.helpers.arrayElement([
       // ...
            set: faker.helpers.arrayElement([
              {
                 testSet: Array.from(
                  {
                    length: Math.max(
                      overrideResponse?.['foo']?.[index_0]?.['set']?.['testSet']
                        ?.length ?? 0,
                      faker.number.int({ min: 1, max: 10 }),
                    ),
                  },
       // ...
```


[1] https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-runtime-semantics-propertydefinitionevaluation

[2] https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object.assign

FYR: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax#spread_in_object_literals

[3] https://lodash.com/docs/4.17.15#merge


## Related PRs

List related PRs against other branches:

| branch              | PR       |
| ------------------- | -------- |
| other_pr_production | [link]() |
| other_pr_master     | [link]() |

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

Outline the steps to test or reproduce the PR here.

```bash
> git pull --prune
> git checkout <branch>
> grunt jasmine
```

