### PR TITLE
fix(angular): avoid `Angular` type error when `nullable`

### DIFF
--- a/packages/core/src/getters/scalar.ts
+++ b/packages/core/src/getters/scalar.ts
@@ -1,5 +1,5 @@
 import { SchemaObject } from 'openapi3-ts/oas30';
-import { ContextSpecs, ScalarValue } from '../types';
+import { ContextSpecs, ScalarValue, OutputClient } from '../types';
 import { escape, isString } from '../utils';
 import { getArray } from './array';
 import { getObject } from './object';
@@ -20,7 +20,10 @@ export const getScalar = ({
   name?: string;
   context: ContextSpecs;
 }): ScalarValue => {
-  const nullable = item.nullable ? ' | null' : '';
+  // NOTE: Angular client does not support nullable types
+  const isAngularClient = context.output.client === OutputClient.ANGULAR;
+  const nullable = item.nullable && !isAngularClient ? ' | null' : '';
+
   const enumItems = item.enum?.filter((enumItem) => enumItem !== null);
 
   if (!item.type && item.items) {


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

If we specify `nullable: true` in `OpenAPI`, `| null`" is added to the parameter type, but [`httpParams`](https://angular.jp/api/common/http/HttpParams) type in `Angular` doesn't support the `null` type.

As a result, the following type error will occur.

```typescript
Type 'number | null' is not assignable to type 'string | number | boolean | readonly (string | number | boolean)[]'.
```

See also https://github.com/angular/angular/issues/20564

So I fixed it so that it doesn't add the `nullable` type when the client is `angular`.

## Related PRs

## Todos

- [x] Tests
- [x] Documentation
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce

Outline the steps to test or reproduce the PR here.

1. Specify `nullable: true` for the parameter

```yaml
paths:
  /pets:
    get:
      summary: List all pets
      operationId: listPets
      tags:
        - pets
      parameters:
        - name: limit
          in: query
          description: How many items to return at one time (max 100)
          schema:
            type: integer
            nullable: true
            maximum: 100
            format: int32
      responses:
        '200':
          description: A paged array of pets
          headers:
            x-next:
              description: A link to the next page of responses
              schema:
                type: string
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/Pets'
        default:
          description: unexpected error
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/Error'
components:
  schemas:
    Pet:
      type: object
      required:
        - id
        - name
      properties:
        id:
          type: integer
          format: int64
        name:
          type: string
        tag:
          type: string
    Pets:
      type: array
      maxItems: 100
      items:
        $ref: '#/components/schemas/Pet'
    Error:
      type: object
      required:
        - code
        - message
      properties:
        code:
          type: integer
          format: int32
        message:
          type: string
```

2. specify `angular` to `client`

```javascript
module.exports = {
  'petstore-file': {
    input: {
      target: './petstore.yaml',
    },
    output: {
      mode: 'tags-split',
      client: 'angular',
      target: 'src/gen/endpoints',
      schemas: 'src/gen/model',
    },
  },
};
```

3 execute `orval`

```
orval
```

4. check the generated code

### Before

```typescript
export type ListPetsParams = {
  /**
   * How many items to return at one time (max 100)
   */
  limit?: number | null;
};
```

### After

```typescript
export type ListPetsParams = {
  /**
   * How many items to return at one time (max 100)
   */
  limit?: number;
};
```