### PR TITLE
fix(msw): refactor to include duplication of mock imports in mocks in `split` and `split-tags` modes

### DIFF
--- a/packages/core/src/writers/split-mode.ts
+++ b/packages/core/src/writers/split-mode.ts
@@ -62,10 +62,7 @@ export const writeSplitMode = async ({
 
     mockData += builder.importsMock({
       implementation: implementationMock,
-      imports: [
-        { exports: imports, dependency: relativeSchemasPath },
-        { exports: importsMock, dependency: relativeSchemasPath },
-      ],
+      imports: [{ exports: importsMock, dependency: relativeSchemasPath }],
       specsName,
       hasSchemaDir: !!output.schemas,
       isAllowSyntheticDefaultImports,

--- a/packages/core/src/writers/split-tags-mode.ts
+++ b/packages/core/src/writers/split-tags-mode.ts
@@ -75,10 +75,7 @@ export const writeSplitTagsMode = async ({
         });
         mockData += builder.importsMock({
           implementation: implementationMock,
-          imports: [
-            ...importsForBuilder,
-            { exports: importsMock, dependency: relativeSchemasPath },
-          ],
+          imports: [{ exports: importsMock, dependency: relativeSchemasPath }],
           specsName,
           hasSchemaDir: !!output.schemas,
           isAllowSyntheticDefaultImports,

--- a/packages/mock/src/msw/index.ts
+++ b/packages/mock/src/msw/index.ts
@@ -80,11 +80,6 @@ export const generateMSW = (
   const functionName = `get${pascal(operationId)}Mock`;
   const handlerName = `get${pascal(operationId)}MockHandler`;
 
-  const includeReturnTypeImports =
-    isReturnHttpResponse && !isTextPlain
-      ? [...imports, { name: returnType, values: true }]
-      : imports;
-
   const mockImplementation = isReturnHttpResponse
     ? `export const ${functionName} = (${isResponseOverridable ? `overrideResponse: any = {}` : ''}): ${returnType} => (${value})\n\n`
     : '';
@@ -109,6 +104,11 @@ export const ${handlerName} = (${isReturnHttpResponse && !isTextPlain ? `overrid
     )
   })
 }\n`;
+
+  const includeReturnTypeImports =
+    isReturnHttpResponse && !isTextPlain
+      ? [...imports, { name: returnType, values: true }]
+      : imports;
 
   return {
     implementation: {

--- a/packages/mock/src/msw/index.ts
+++ b/packages/mock/src/msw/index.ts
@@ -85,6 +85,10 @@ export const generateMSW = (
       ? [...imports, { name: returnType, values: true }]
       : imports;
 
+  const mockImplementation = isReturnHttpResponse
+    ? `export const ${functionName} = (${isResponseOverridable ? `overrideResponse: any = {}` : ''}): ${returnType} => (${value})\n\n`
+    : '';
+
   const handlerImplementation = `
 export const ${handlerName} = (${isReturnHttpResponse && !isTextPlain ? `overrideResponse?: ${returnType}` : ''}) => {
   return http.${verb}('${route}', async () => {
@@ -108,9 +112,7 @@ export const ${handlerName} = (${isReturnHttpResponse && !isTextPlain ? `overrid
 
   return {
     implementation: {
-      function: isReturnHttpResponse
-        ? `export const ${functionName} = (${isResponseOverridable ? `overrideResponse: any = {}` : ''}): ${returnType} => (${value})\n\n`
-        : '',
+      function: mockImplementation,
       handlerName: handlerName,
       handler: handlerImplementation,
     },

--- a/packages/mock/src/msw/index.ts
+++ b/packages/mock/src/msw/index.ts
@@ -105,9 +105,9 @@ export const ${handlerName} = (${isReturnHttpResponse && !isTextPlain ? `overrid
   })
 }\n`;
 
-  const includeReturnTypeImports =
+  const includeResponseImports =
     isReturnHttpResponse && !isTextPlain
-      ? [...imports, { name: returnType, values: true }]
+      ? [...imports, ...response.imports]
       : imports;
 
   return {
@@ -116,6 +116,6 @@ export const ${handlerName} = (${isReturnHttpResponse && !isTextPlain ? `overrid
       handlerName: handlerName,
       handler: handlerImplementation,
     },
-    imports: includeReturnTypeImports,
+    imports: includeResponseImports,
   };
 };

--- a/packages/mock/src/msw/index.ts
+++ b/packages/mock/src/msw/index.ts
@@ -80,6 +80,11 @@ export const generateMSW = (
   const functionName = `get${pascal(operationId)}Mock`;
   const handlerName = `get${pascal(operationId)}MockHandler`;
 
+  const includeReturnTypeImports =
+    isReturnHttpResponse && !isTextPlain
+      ? [...imports, { name: returnType, values: true }]
+      : imports;
+
   const handlerImplementation = `
 export const ${handlerName} = (${isReturnHttpResponse && !isTextPlain ? `overrideResponse?: ${returnType}` : ''}) => {
   return http.${verb}('${route}', async () => {
@@ -109,6 +114,6 @@ export const ${handlerName} = (${isReturnHttpResponse && !isTextPlain ? `overrid
       handlerName: handlerName,
       handler: handlerImplementation,
     },
-    imports,
+    imports: includeReturnTypeImports,
   };
 };


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

In `split` and `split-tags` modes, a hooks import is included to import the return type into `mock`.
However, we can get around that by getting the return type from `response.imports` and including it in the `mock` import, so we fixed it.

## Related PRs

none

## Todos

- [x] Tests
- [x] Documentation
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce

pass test
