### PR TITLE
chore(zod): add petstore tests for each mode to `zod`

### DIFF
--- a/tests/configs/zod.config.ts
+++ b/tests/configs/zod.config.ts
@@ -10,6 +10,56 @@ export default defineConfig({
       target: '../specifications/circular.yaml',
     },
   },
+  petstore: {
+    output: {
+      target: '../generated/zod/petstore/endpoints.ts',
+      schemas: '../generated/zod/petstore/model',
+      client: 'zod',
+      mock: true,
+    },
+    input: {
+      target: '../specifications/petstore.yaml',
+      override: {
+        transformer: '../transformers/add-version.js',
+      },
+    },
+  },
+  petstoreTagsSplit: {
+    output: {
+      target: '../generated/zod/petstore-tags-split/endpoints.ts',
+      schemas: '../generated/zod/petstore-tags-split/model',
+      mock: true,
+      mode: 'tags-split',
+      client: 'zod',
+    },
+    input: {
+      target: '../specifications/petstore.yaml',
+    },
+  },
+  petstoreSplit: {
+    output: {
+      target: '../generated/zod/split/endpoints.ts',
+      schemas: '../generated/zod/split/model',
+      mock: true,
+      mode: 'split',
+      client: 'zod',
+    },
+    input: {
+      target: '../specifications/petstore.yaml',
+    },
+  },
+  petstoreTags: {
+    output: {
+      target: '../generated/zod/tags/endpoints.ts',
+      schemas: '../generated/zod/tags/model',
+      mock: true,
+      mode: 'tags',
+      client: 'zod',
+    },
+    input: {
+      target: '../specifications/petstore.yaml',
+    },
+  },
   nestedArrays: {
     output: {
       target: '../generated/zod',


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

I wanted to add a test to `zod` in #1211, but the definition of `zod` does not include response types like `Pet` or `Pets`, so `zod` and `mock` Mock was not working with this combination.
This issue was fixed in #1214, so we added tests for each mode of the petstore to `zod`

## Related PRs


## Todos

- [x] Tests
- [x] Documentation
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce

pass test
