### PR TITLE
fix(msw): changed naming convention for response mock functions to avoid function name conflicts

### DIFF
--- a/packages/mock/src/msw/index.ts
+++ b/packages/mock/src/msw/index.ts
@@ -77,11 +77,11 @@ export const generateMSW = (
   const isReturnHttpResponse = value && value !== 'undefined';
 
   const returnType = response.definition.success;
-  const functionName = `get${pascal(operationId)}Mock`;
+  const getResponseMockFunctionName = `get${pascal(operationId)}ResponseMock`;
   const handlerName = `get${pascal(operationId)}MockHandler`;
 
   const mockImplementation = isReturnHttpResponse
-    ? `export const ${functionName} = (${isResponseOverridable ? `overrideResponse: any = {}` : ''}): ${returnType} => (${value})\n\n`
+    ? `export const ${getResponseMockFunctionName} = (${isResponseOverridable ? `overrideResponse: any = {}` : ''}): ${returnType} => (${value})\n\n`
     : '';
 
   const handlerImplementation = `
@@ -91,8 +91,8 @@ export const ${handlerName} = (${isReturnHttpResponse && !isTextPlain ? `overrid
     return new HttpResponse(${
       isReturnHttpResponse
         ? isTextPlain
-          ? `${functionName}()`
-          : `JSON.stringify(overrideResponse ? overrideResponse : ${functionName}())`
+          ? `${getResponseMockFunctionName}()`
+          : `JSON.stringify(overrideResponse ? overrideResponse : ${getResponseMockFunctionName}())`
         : null
     },
       {


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

fix #1106

This issue is occur when the path name and `operationId` are the same. So a rare case because `operationId` is usually used like `addXX` or `getXXX`, but i will fix it because it causes unintended problems for users.

`orval` gets the mock name from `title`, which is the same naming convention as the response mock.

### response mock function naming

```
`get${pascal(operationId)}Mock`;
```

### mock function naming

```
`get${pascal(title)}Mock`,
```

Ref: https://github.com/anymaniax/orval/blob/master/packages/orval/src/client.ts#L172 

Therefore, I changed the response mock function name.
It's a breaking change, but out of all my ideas, I decided to do this because it has the least impact.

## Related PRs


## Todos

- [ ] Tests
- [x] Documentation
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce

1. specify `mock: true` in `orval.config.js`
2. execute `orval`
3. check the name change in the generated mock function