### PR TITLE
fix(core): implement `{}` insterd of `unknown` for blank schema interface

### DIFF
--- a/packages/core/src/getters/object.ts
+++ b/packages/core/src/getters/object.ts
@@ -202,10 +202,16 @@ export const getObject = ({
     };
   }
 
+  const useTypeOverInterfaces = context?.output.override?.useTypeOverInterfaces;
+  const blankValue =
+    item.type === 'object'
+      ? '{ [key: string]: any }'
+      : useTypeOverInterfaces
+        ? 'unknown'
+        : '{}';
+
   return {
-    value:
-      (item.type === 'object' ? '{ [key: string]: any }' : 'unknown') +
-      nullable,
+    value: blankValue + nullable,
     imports: [],
     schemas: [],
     isEnum: false,


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY/**

## Description

fix #1207

If the definition schema is blank object and `output.override.use TypeOver Interfaces` is `false`, the generated definition is incorrect.
I fixed it to create `{}` when using `interface`.

### Before

```typescript
export interface DbNotificationID unknown
```

### After

```typescript
export interface DbNotificationID = {}
```

## Related PRs

none

## Todos

- [ ] Tests
- [x] Documentation
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce

1. prepared openapi woth blank object 

```yaml
openapi: 3.0.3
info:
  description: test
  title: test
  version: test
paths:
  /ping:
    get:
      summary: test
      responses:
        '200':
          description: ok
components:
  schemas:
    DbNotificationID: {}
```

2. execute `orval`
3. check generated definition is valid