### PR TITLE
feat(swr): add `swrOptions` property to `output.override.swr`

### DIFF
--- a/docs/src/pages/reference/configuration/output.md
+++ b/docs/src/pages/reference/configuration/output.md
@@ -817,6 +817,30 @@ Type: `Boolean`.
 
 Use to generate a <a href="https://swr.vercel.app/docs/pagination#useswrinfinite" target="_blank">useSWRInfinite</a> custom hook.
 
+##### swrOptions
+
+Type: `Object`.
+
+Use to override the `useSwr` options. Check available options [here](https://swr.vercel.app/docs/api#options)
+
+Example:
+
+```js
+module.exports = {
+  petstore: {
+    output: {
+      override: {
+        swr: {
+          swrOptions: {
+            dedupingInterval: 10000,
+          },
+        },
+      },
+    },
+  },
+};
+```
+
 #### mock
 
 Type: `Object`.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -362,6 +362,7 @@ export type AngularOptions = {
 export type SwrOptions = {
   options?: any;
   useInfinite?: boolean;
+  swrOptions?: any;
 };
 
 export type InputTransformerFn = (spec: OpenAPIObject) => OpenAPIObject;

--- a/packages/swr/src/index.ts
+++ b/packages/swr/src/index.ts
@@ -378,6 +378,8 @@ ${doc}export const ${camel(
 }\n`
     : '';
 
+  const defaultSwrOptions = { ...swrOptions.swrOptions, ...swrOptions.options };
+
   const useSwrImplementation = `
 export type ${pascal(
     operationName,
@@ -418,9 +420,9 @@ ${doc}export const ${camel(`use-${operationName}`)} = <TError = ${errorType}>(
   });
 
   const ${queryResultVarName} = useSwr<Awaited<ReturnType<typeof swrFn>>, TError>(swrKey, swrFn, ${
-    swrOptions.options
+    defaultSwrOptions
       ? `{
-    ${stringify(swrOptions.options)?.slice(1, -1)}
+    ${stringify(defaultSwrOptions)?.slice(1, -1)}
     ...swrOptions
   }`
       : 'swrOptions'

--- a/tests/configs/swr.config.ts
+++ b/tests/configs/swr.config.ts
@@ -107,4 +107,22 @@ export default defineConfig({
       },
     },
   },
+  petstoreOverrideSwr: {
+    output: {
+      target: '../generated/swr/petstore-override-swr/endpoints.ts',
+      schemas: '../generated/swr/petstore-override-swr/model',
+      client: 'swr',
+      override: {
+        swr: {
+          useInfinite: true,
+          swrOptions: {
+            dedupingInterval: 10000,
+          },
+        },
+      },
+    },
+    input: {
+      target: '../specifications/petstore.yaml',
+    },
+  },
 });


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

As of `v6.24.0`, the 'swr' client now generates 'useSWRInfinite' and 'useSWRMutation' hooks. Therefore, since `output.override.swr.options` cannot be used in common for each hook, we will separate the options for each hook. First, this PR adds an option.to extend only `useSwr`.

## Related PRs

- https://github.com/anymaniax/orval/pull/1148
- https://github.com/anymaniax/orval/pull/1138

## Todos

- [x] Tests
- [x] Documentation
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce

1. check generated hooks in tests

tests/generated/swr/petstore-override-swr/endpoints.ts:

```typescript
/**
 * @summary Info for a specific pet
 */
export const useShowPetById = <TError = AxiosError<Error>>(
  petId: string, options?: { swr?:SWRConfiguration<Awaited<ReturnType<typeof showPetById>>, TError> & { swrKey?: Key, enabled?: boolean }, axios?: AxiosRequestConfig }
) => {
  const {swr: swrOptions, axios: axiosOptions} = options ?? {}

  const isEnabled = swrOptions?.enabled !== false && !!(petId)
  const swrKey = swrOptions?.swrKey ?? (() => isEnabled ? getShowPetByIdKey(petId) : null);
  const swrFn = () => showPetById(petId, axiosOptions);

  const query = useSwr<Awaited<ReturnType<typeof swrFn>>, TError>(swrKey, swrFn, {
     dedupingInterval: 10000, 
    ...swrOptions
  })

  return {
    swrKey,
    ...query
  }
}
```