### PR TITLE
chore(orval): remove unused `chalk` import

### DIFF
--- a/packages/orval/src/index.ts
+++ b/packages/orval/src/index.ts
@@ -5,7 +5,6 @@ import {
   Options,
   OptionsExport,
 } from '@orval/core';
-import chalk from 'chalk';
 import { generateConfig, generateSpec } from './generate';
 import { defineConfig, normalizeOptions } from './utils/options';
 import { startWatcher } from './utils/watcher';


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

I happened to find an unused `chalk` import, so I removed it.

## Related PRs

## Todos

- [x] Tests
- [x] Documentation
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce

none