### PR TITLE
feat(swr): add `swrMutationOptions` property to `output.override.swr`

### DIFF
--- a/docs/src/pages/reference/configuration/output.md
+++ b/docs/src/pages/reference/configuration/output.md
@@ -841,6 +841,30 @@ module.exports = {
 };
 ```
 
+##### swrMutationOptions
+
+Type: `Object`.
+
+Use to override the `useSWRMutation` options. Check available options [here](https://swr.vercel.app/docs/mutation#useswrmutation-parameters)
+
+Example:
+
+```js
+module.exports = {
+  petstore: {
+    output: {
+      override: {
+        swr: {
+          swrMutationOptions: {
+            revalidate: true,
+          },
+        },
+      },
+    },
+  },
+};
+```
+
 #### mock
 
 Type: `Object`.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -363,6 +363,7 @@ export type SwrOptions = {
   options?: any;
   useInfinite?: boolean;
   swrOptions?: any;
+  swrMutationOptions?: any;
 };
 
 export type InputTransformerFn = (spec: OpenAPIObject) => OpenAPIObject;

--- a/packages/swr/src/index.ts
+++ b/packages/swr/src/index.ts
@@ -518,9 +518,9 @@ ${doc}export const ${camel(`use-${operationName}`)} = <TError = ${errorType}>(
   });
 
   const ${queryResultVarName} = useSWRMutation(swrKey, swrFn, ${
-    swrOptions.options
+    swrOptions.swrMutationOptions
       ? `{
-    ${stringify(swrOptions.options)?.slice(1, -1)}
+    ${stringify(swrOptions.swrMutationOptions)?.slice(1, -1)}
     ...swrOptions
   }`
       : 'swrOptions'

--- a/tests/configs/swr.config.ts
+++ b/tests/configs/swr.config.ts
@@ -118,6 +118,9 @@ export default defineConfig({
           swrOptions: {
             dedupingInterval: 10000,
           },
+          swrMutationOptions: {
+            revalidate: false,
+          },
         },
       },
     },

--- a/tests/configs/swr.config.ts
+++ b/tests/configs/swr.config.ts
@@ -119,7 +119,7 @@ export default defineConfig({
             dedupingInterval: 10000,
           },
           swrMutationOptions: {
-            revalidate: false,
+            revalidate: true,
           },
         },
       },


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

This PR is a follow up to https://github.com/anymaniax/orval/pull/1223
I added a property `swrMutationOptions` to `output.override.swr` that extends only the options of `useSWRMutation`.
## Related PRs

List related PRs against other branches:

https://github.com/anymaniax/orval/pull/1223

## Todos

- [x] Tests
- [x] Documentation
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce

1. check generated hooks in tests

tests/generated/swr/petstore-override-swr/endpoints.ts:

```typescript
/**
 * @summary Create a pet
 */
export const useCreatePets = <TError = AxiosError<Error>>(
  params: CreatePetsParams, options?: { swr?:SWRMutationConfiguration<Awaited<ReturnType<typeof createPets>>, TError, string, Arguments, Awaited<ReturnType<typeof createPets>>> & { swrKey?: string }, axios?: AxiosRequestConfig }
) => {

  const {swr: swrOptions, axios: axiosOptions} = options ?? {}

  const swrKey = swrOptions?.swrKey ?? getCreatePetsMutationKey();
  const swrFn = getCreatePetsMutationFetcher(params,axiosOptions);

  const query = useSWRMutation(swrKey, swrFn, {
     revalidate: true, 
    ...swrOptions
  })

  return {
    swrKey,
    ...query
  }
}
```