### PR TITLE
fix(core): distinguish the value when it is blank only in `interface`

### DIFF
--- a/packages/core/src/generators/interface.ts
+++ b/packages/core/src/generators/interface.ts
@@ -46,7 +46,10 @@ export const generateInterface = ({
     scalar.type === 'object' &&
     !context?.output.override?.useTypeOverInterfaces
   ) {
-    model += `export interface ${name} ${scalar.value}\n`;
+    // If `scalar.value` is 'unknown', replace it with `{}` to avoid type error
+    const blankIntefaceValue = scalar.value === 'unknown' ? '{}' : scalar.value;
+
+    model += `export interface ${name} ${blankIntefaceValue}\n`;
   } else {
     model += `export type ${name} = ${scalar.value};\n`;
   }

--- a/packages/core/src/generators/interface.ts
+++ b/packages/core/src/generators/interface.ts
@@ -47,9 +47,10 @@ export const generateInterface = ({
     !context?.output.override?.useTypeOverInterfaces
   ) {
     // If `scalar.value` is 'unknown', replace it with `{}` to avoid type error
-    const blankIntefaceValue = scalar.value === 'unknown' ? '{}' : scalar.value;
+    const blankInterfaceValue =
+      scalar.value === 'unknown' ? '{}' : scalar.value;
 
-    model += `export interface ${name} ${blankIntefaceValue}\n`;
+    model += `export interface ${name} ${blankInterfaceValue}\n`;
   } else {
     model += `export type ${name} = ${scalar.value};\n`;
   }

--- a/packages/core/src/getters/object.ts
+++ b/packages/core/src/getters/object.ts
@@ -202,16 +202,10 @@ export const getObject = ({
     };
   }
 
-  const useTypeOverInterfaces = context?.output.override?.useTypeOverInterfaces;
-  const blankValue =
-    item.type === 'object'
-      ? '{ [key: string]: any }'
-      : useTypeOverInterfaces
-        ? 'unknown'
-        : '{}';
-
   return {
-    value: blankValue + nullable,
+    value:
+      (item.type === 'object' ? '{ [key: string]: any }' : 'unknown') +
+      nullable,
     imports: [],
     schemas: [],
     isEnum: false,

--- a/tests/specifications/regressions.yaml
+++ b/tests/specifications/regressions.yaml
@@ -19,6 +19,11 @@ components:
             items:
               type: string
               nullable: true
+    BlankSchema: {}
+    NotDifinedType:
+      properties:
+        id:
+          description: not defined type schema
 paths:
   /endpointA:
     get:


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

fix https://github.com/anymaniax/orval/issues/1227

When I responded to #1219, it caused unintended destruction, so I revert #1219.
This issue occurs when the doesn't have `type` like a bellow:

```yaml
NotDifinedType:
  properties:
    id:
      description: not defined type schema
```

And, the issue where the interface definition results in an error when interface is an blank schema is resolved by replacing the value only in the case of interfaces.

## Related PRs

- https://github.com/anymaniax/orval/pull/1219

## Todos

- [x] Tests
- [x] Documentation
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce

1. prepared openapi woth blank object 

```yaml
openapi: 3.0.3
info:
  description: test
  title: test
  version: test
components:
  schemas:
    DbNotificationID: {}
```

2. execute `orval`
3. check generated definition is valid