### PR TITLE
fix(query): usePrefetch should only work for Query/Infinite types

### DIFF
--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -1075,7 +1075,7 @@ ${doc}export const ${camel(
   return ${queryResultVarName};
 }\n
 ${
-  usePrefetch
+  usePrefetch && (type === QueryType.QUERY || type === QueryType.INFINITE)
     ? `${doc}export const ${camel(
         `prefetch-${name}`,
       )} = async <TData = Awaited<ReturnType<${dataType}>>, TError = ${errorType}>(\n queryClient: QueryClient, ${queryProps} ${queryArguments}\n  ): Promise<QueryClient> => {


### PR DESCRIPTION
## Status

**READY**

## Description

Make sure we only generate prefetch calls for `QUERY` and `INFINITE` types, as it isn't possible to prefetch any other types.

Fixes #1234

## Steps to Test or Reproduce

```ts
export default defineConfig({
  client: {
    input: '...',
    output: {
      client: 'react-query',
      override: {
        query: {
          usePrefetch: true,
          useQuery: true,
          useSuspenseQuery: true,
        },
      },
      ...output,
    },
  },
});
```

Verified strictly `await queryClient.prefetchQuery(queryOptions)` calls were generated