### PR TITLE
fix(core): improve NonReadonly type

### DIFF
--- a/packages/core/src/writers/types.ts
+++ b/packages/core/src/writers/types.ts
@@ -1,27 +1,28 @@
 export const getOrvalGeneratedTypes = () => `
-// https://stackoverflow.com/questions/49579094/typescript-conditional-types-filter-out-readonly-properties-pick-only-requir/49579497#49579497
-type IfEquals<X, Y, A = X, B = never> = (<T>() => T extends X ? 1 : 2) extends <
-T,
->() => T extends Y ? 1 : 2
-? A
-: B;
-
-type WritableKeys<T> = {
-[P in keyof T]-?: IfEquals<
-  { [Q in P]: T[P] },
-  { -readonly [Q in P]: T[P] },
-  P
->;
-}[keyof T];
-
-type UnionToIntersection<U> =
-  (U extends any ? (k: U)=>void : never) extends ((k: infer I)=>void) ? I : never;
-type DistributeReadOnlyOverUnions<T> = T extends any ? NonReadonly<T> : never;
-
-type Writable<T> = Pick<T, WritableKeys<T>>;
-type NonReadonly<T> = [T] extends [UnionToIntersection<T>] ? {
-  [P in keyof Writable<T>]: T[P] extends object
-    ? NonReadonly<NonNullable<T[P]>>
-    : T[P];
-} : DistributeReadOnlyOverUnions<T>;
+type IsAny<T> = 0 extends 1 & T ? true : false;
+type IsUnknown<T> = IsAny<T> extends true ? false : unknown extends T ? true : false;
+type Primitive = string | number | boolean | bigint | symbol | undefined | null;
+type isBuiltin = Primitive | Function | Date | Error | RegExp;
+type NonReadonly<T> =
+  T extends Exclude<isBuiltin, Error>
+  ? T
+  : T extends Map<infer Key, infer Value>
+  ? Map<NonReadonly<Key>, NonReadonly<Value>>
+  : T extends ReadonlyMap<infer Key, infer Value>
+  ? Map<NonReadonly<Key>, NonReadonly<Value>>
+  : T extends WeakMap<infer Key, infer Value>
+  ? WeakMap<NonReadonly<Key>, NonReadonly<Value>>
+  : T extends Set<infer Values>
+  ? Set<NonReadonly<Values>>
+  : T extends ReadonlySet<infer Values>
+  ? Set<NonReadonly<Values>>
+  : T extends WeakSet<infer Values>
+  ? WeakSet<NonReadonly<Values>>
+  : T extends Promise<infer Value>
+  ? Promise<NonReadonly<Value>>
+  : T extends {}
+  ? { -readonly [Key in keyof T]: NonReadonly<T[Key]> }
+  : IsUnknown<T> extends true
+  ? unknown
+  : T;
 `;

--- a/samples/angular-app/src/api/endpoints/pets/pets.msw.ts
+++ b/samples/angular-app/src/api/endpoints/pets/pets.msw.ts
@@ -19,7 +19,7 @@ export const getListPetsResponseMock = (overrideResponse: any = {}): Pets =>
     ...overrideResponse,
   }));
 
-export const getShowPetByIdResponseMock = (): Pet =>
+export const getShowPetByIdResponseMock = () =>
   (() => ({
     id: faker.number.int({ min: 1, max: 99 }),
     name: faker.person.firstName(),

--- a/samples/react-app-with-swr/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
+++ b/samples/react-app-with-swr/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
@@ -30,7 +30,7 @@ export const getCreatePetsResponseMock = (overrideResponse: any = {}): Pet => ({
   ...overrideResponse,
 });
 
-export const getShowPetByIdResponseMock = (): Pet =>
+export const getShowPetByIdResponseMock = () =>
   (() => ({
     id: faker.number.int({ min: 1, max: 99 }),
     name: faker.person.firstName(),

--- a/samples/react-app/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
+++ b/samples/react-app/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
@@ -19,7 +19,7 @@ export const getListPetsResponseMock = (overrideResponse: any = {}): Pets =>
     ...overrideResponse,
   }));
 
-export const getShowPetByIdResponseMock = (): Pet =>
+export const getShowPetByIdResponseMock = () =>
   (() => ({
     id: faker.number.int({ min: 1, max: 99 }),
     name: faker.person.firstName(),

--- a/samples/react-query/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
+++ b/samples/react-query/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
@@ -217,7 +217,7 @@ export const getUpdatePetsResponseMock = (overrideResponse: any = {}): Pet =>
     },
   ]);
 
-export const getShowPetByIdResponseMock = (): Pet =>
+export const getShowPetByIdResponseMock = () =>
   (() => ({
     id: faker.number.int({ min: 1, max: 99 }),
     name: faker.person.firstName(),

--- a/samples/react-query/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/react-query/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -36,33 +36,33 @@ import type {
 import { customInstance } from '../mutator/custom-instance';
 import type { ErrorType } from '../mutator/custom-instance';
 
-// https://stackoverflow.com/questions/49579094/typescript-conditional-types-filter-out-readonly-properties-pick-only-requir/49579497#49579497
-type IfEquals<X, Y, A = X, B = never> =
-  (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2 ? A : B;
-
-type WritableKeys<T> = {
-  [P in keyof T]-?: IfEquals<
-    { [Q in P]: T[P] },
-    { -readonly [Q in P]: T[P] },
-    P
-  >;
-}[keyof T];
-
-type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (
-  k: infer I,
-) => void
-  ? I
-  : never;
-type DistributeReadOnlyOverUnions<T> = T extends any ? NonReadonly<T> : never;
-
-type Writable<T> = Pick<T, WritableKeys<T>>;
-type NonReadonly<T> = [T] extends [UnionToIntersection<T>]
-  ? {
-      [P in keyof Writable<T>]: T[P] extends object
-        ? NonReadonly<NonNullable<T[P]>>
-        : T[P];
-    }
-  : DistributeReadOnlyOverUnions<T>;
+type IsAny<T> = 0 extends 1 & T ? true : false;
+type IsUnknown<T> =
+  IsAny<T> extends true ? false : unknown extends T ? true : false;
+type Primitive = string | number | boolean | bigint | symbol | undefined | null;
+type isBuiltin = Primitive | Function | Date | Error | RegExp;
+type NonReadonly<T> =
+  T extends Exclude<isBuiltin, Error>
+    ? T
+    : T extends Map<infer Key, infer Value>
+      ? Map<NonReadonly<Key>, NonReadonly<Value>>
+      : T extends ReadonlyMap<infer Key, infer Value>
+        ? Map<NonReadonly<Key>, NonReadonly<Value>>
+        : T extends WeakMap<infer Key, infer Value>
+          ? WeakMap<NonReadonly<Key>, NonReadonly<Value>>
+          : T extends Set<infer Values>
+            ? Set<NonReadonly<Values>>
+            : T extends ReadonlySet<infer Values>
+              ? Set<NonReadonly<Values>>
+              : T extends WeakSet<infer Values>
+                ? WeakSet<NonReadonly<Values>>
+                : T extends Promise<infer Value>
+                  ? Promise<NonReadonly<Value>>
+                  : T extends {}
+                    ? { -readonly [Key in keyof T]: NonReadonly<T[Key]> }
+                    : IsUnknown<T> extends true
+                      ? unknown
+                      : T;
 
 type AwaitedInput<T> = PromiseLike<T> | T;
 

--- a/samples/react-query/custom-client/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
+++ b/samples/react-query/custom-client/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
@@ -52,7 +52,7 @@ export const getCreatePetsResponseMock = (overrideResponse: any = {}): Pet => ({
   ...overrideResponse,
 });
 
-export const getShowPetByIdResponseMock = (): Pet =>
+export const getShowPetByIdResponseMock = () =>
   (() => ({
     id: faker.number.int({ min: 1, max: 99 }),
     name: faker.person.firstName(),

--- a/samples/svelte-query/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
+++ b/samples/svelte-query/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
@@ -19,7 +19,7 @@ export const getListPetsResponseMock = (overrideResponse: any = {}): Pets =>
     ...overrideResponse,
   }));
 
-export const getShowPetByIdResponseMock = (): Pet =>
+export const getShowPetByIdResponseMock = () =>
   (() => ({
     id: faker.number.int({ min: 1, max: 99 }),
     name: faker.person.firstName(),

--- a/samples/vue-query/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
+++ b/samples/vue-query/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
@@ -28,7 +28,7 @@ export const getCreatePetsResponseMock = (overrideResponse: any = {}): Pet => ({
   ...overrideResponse,
 });
 
-export const getShowPetByIdResponseMock = (): Pet =>
+export const getShowPetByIdResponseMock = () =>
   (() => ({
     id: faker.number.int({ min: 1, max: 99 }),
     name: faker.person.firstName(),


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

Fixes https://github.com/anymaniax/orval/issues/1236

Improves the `NonReadonly<T>` type so it actually works now. Note: this implementation was taken from ts-essentials' DeepWritable<T>, which seem to have the most accurate type as of now

## Before
<img width="705" alt="Screenshot 2024-02-25 at 2 58 28 AM" src="https://github.com/anymaniax/orval/assets/368069/3fb94fc6-5f1e-4aff-b341-21ac9a0fbe4d">

## After
![image](https://github.com/anymaniax/orval/assets/368069/7d7b6078-4844-4807-9423-1aff232e0ccb)
