### PR TITLE
docs: unify spelling to OpenAPI

### DIFF
--- a/docs/src/pages/guides/angular.md
+++ b/docs/src/pages/guides/angular.md
@@ -3,7 +3,7 @@ id: angular
 title: Angular
 ---
 
-You should have an OpenApi specification and an Orval config where you define the mode as Angular.
+You should have an OpenAPI specification and an Orval config where you define the mode as Angular.
 
 #### Example with angular
 

--- a/docs/src/pages/guides/basics.md
+++ b/docs/src/pages/guides/basics.md
@@ -3,7 +3,7 @@ id: basics
 title: Basics
 ---
 
-You should define a OpenApi specification (example <a href="https://github.com/anymaniax/orval/blob/master/samples/basic/petstore.yaml" target="_blank"> petstore.yaml</a>).
+You should define a OpenAPI specification (example <a href="https://github.com/anymaniax/orval/blob/master/samples/basic/petstore.yaml" target="_blank"> petstore.yaml</a>).
 
 And then create a file `orval.config.js` at root of your project:
 

--- a/docs/src/pages/guides/react-query.md
+++ b/docs/src/pages/guides/react-query.md
@@ -3,7 +3,7 @@ id: react-query
 title: React query
 ---
 
-You should have an OpenApi specification and an Orval config where you define the mode as react-query.
+You should have an OpenAPI specification and an Orval config where you define the mode as react-query.
 
 #### Example with React query
 
@@ -26,7 +26,7 @@ module.exports = {
 
 Checkout the [orval config](../reference/configuration/full-example) reference to see all available options.
 
-The React query model will generate an implementation file with one custom hook per path in your OpenApi Specification.
+The React query model will generate an implementation file with one custom hook per path in your OpenAPI Specification.
 
 Like the following example from this <a href="https://github.com/anymaniax/orval/blob/master/samples/react-query/basic/petstore.yaml" target="_blank">swagger</a>:
 

--- a/docs/src/pages/guides/svelte-query.md
+++ b/docs/src/pages/guides/svelte-query.md
@@ -3,7 +3,7 @@ id: svelte-query
 title: Svelte query
 ---
 
-You should have an OpenApi specification and an Orval config where you define the mode as svelte-query.
+You should have an OpenAPI specification and an Orval config where you define the mode as svelte-query.
 
 #### Example with svelte query
 
@@ -26,7 +26,7 @@ module.exports = {
 
 Checkout the [orval config](../reference/configuration/full-example) reference to see all available options.
 
-The svelte query model will generate an implementation file with one custom hook per path in your OpenApi Specification.
+The svelte query model will generate an implementation file with one custom hook per path in your OpenAPI Specification.
 
 Like the following example from this <a href="https://github.com/anymaniax/orval/blob/master/samples/svelte-query/petstore.yaml" target="_blank">swagger</a>:
 

--- a/docs/src/pages/guides/swr.md
+++ b/docs/src/pages/guides/swr.md
@@ -3,7 +3,7 @@ id: swr
 title: SWR
 ---
 
-You should have an OpenApi specification and an Orval config where you define the mode as swr.
+You should have an OpenAPI specification and an Orval config where you define the mode as swr.
 
 #### Example with SWR
 
@@ -26,7 +26,7 @@ module.exports = {
 
 Checkout the [orval config](../reference/configuration/full-example) reference to see all available options.
 
-The SWR model will generate an implementation file with one custom hook per path in your OpenApi Specification.
+The SWR model will generate an implementation file with one custom hook per path in your OpenAPI Specification.
 
 Like the following example from this <a href="https://github.com/anymaniax/orval/blob/master/samples/react-app-with-swr/petstore.yaml" target="_blank">swagger</a>:
 

--- a/docs/src/pages/guides/vue-query.md
+++ b/docs/src/pages/guides/vue-query.md
@@ -3,7 +3,7 @@ id: vue-query
 title: Vue query
 ---
 
-You should have an OpenApi specification and an Orval config where you define the mode as vue-query.
+You should have an OpenAPI specification and an Orval config where you define the mode as vue-query.
 
 #### Example with Vue query
 
@@ -26,7 +26,7 @@ module.exports = {
 
 Checkout the [orval config](../reference/configuration/full-example) reference to see all available options.
 
-The Vue query model will generate an implementation file with one custom hook per path in your OpenApi Specification.
+The Vue query model will generate an implementation file with one custom hook per path in your OpenAPI Specification.
 
 Like the following example from this <a href="https://github.com/anymaniax/orval/blob/master/samples/vue-query/petstore.yaml" target="_blank">swagger</a>:
 

--- a/docs/src/pages/reference/cli.md
+++ b/docs/src/pages/reference/cli.md
@@ -19,7 +19,7 @@ $ orval
 
 ### Input
 
-The `--input` option, shorthand `-i`, can be used to set the path or link to your OpenApi specification.
+The `--input` option, shorthand `-i`, can be used to set the path or link to your OpenAPI specification.
 
 ```bash
 $ orval --input ./petstore.yaml

--- a/docs/src/pages/reference/configuration/input.md
+++ b/docs/src/pages/reference/configuration/input.md
@@ -90,7 +90,7 @@ Type: `Object`.
 
 Default Value: `{}`.
 
-Orval convert Swagger 2.0 definitions into OpenApi 3.0.x. You can use the converterOptions property to provide custom config for that. Check [here](https://github.com/anymaniax/orval/blob/next/src/types/swagger2openapi.d.ts#L10) available options.
+Orval convert Swagger 2.0 definitions into OpenAPI 3.0.x. You can use the converterOptions property to provide custom config for that. Check [here](https://github.com/anymaniax/orval/blob/next/src/types/swagger2openapi.d.ts#L10) available options.
 
 ```js
 module.exports = {

--- a/docs/src/pages/reference/configuration/output.md
+++ b/docs/src/pages/reference/configuration/output.md
@@ -153,7 +153,7 @@ For Angular:
 
 #### Value: tags
 
-Use this mode if you want one file by tag. Tag is a reference of the OpenApi specification tag. If you have a `pets` tag for all your pet calls then Orval will generate a file pets.ts in the target folder
+Use this mode if you want one file by tag. Tag is a reference of the OpenAPI specification tag. If you have a `pets` tag for all your pet calls then Orval will generate a file pets.ts in the target folder
 
 ```js
 module.exports = {


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

Update inconsistent  from  "OpenApi" to "OpenAPI"  on the document.

## Related PRs

none

## Todos

- [x] Tests
- [x] Documentation
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce

none
