### PR TITLE
feat(swr): add `swrInfiniteOptions` property to `output.override.swr`

### DIFF
--- a/docs/src/pages/reference/configuration/output.md
+++ b/docs/src/pages/reference/configuration/output.md
@@ -865,6 +865,30 @@ module.exports = {
 };
 ```
 
+##### swrInfiniteOptions
+
+Type: `Object`.
+
+Use to override the `useSWRInfinite` options. Check available options [here](https://swr.vercel.app/docs/pagination#parameters)
+
+Example:
+
+```js
+module.exports = {
+  petstore: {
+    output: {
+      override: {
+        swr: {
+          swrInfiniteOptions: {
+            initialSize: 10,
+          },
+        },
+      },
+    },
+  },
+};
+```
+
 #### mock
 
 Type: `Object`.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -364,6 +364,7 @@ export type SwrOptions = {
   useInfinite?: boolean;
   swrOptions?: any;
   swrMutationOptions?: any;
+  swrInfiniteOptions?: any;
 };
 
 export type InputTransformerFn = (spec: OpenAPIObject) => OpenAPIObject;

--- a/packages/swr/src/index.ts
+++ b/packages/swr/src/index.ts
@@ -363,9 +363,9 @@ ${doc}export const ${camel(
   });
 
   const ${queryResultVarName} = useSWRInfinite<Awaited<ReturnType<typeof swrFn>>, TError>(swrKeyLoader, swrFn, ${
-    swrOptions.options
+    swrOptions.swrInfiniteOptions
       ? `{
-    ${stringify(swrOptions.options)?.slice(1, -1)}
+    ${stringify(swrOptions.swrInfiniteOptions)?.slice(1, -1)}
     ...swrOptions
   }`
       : 'swrOptions'

--- a/tests/configs/swr.config.ts
+++ b/tests/configs/swr.config.ts
@@ -121,6 +121,9 @@ export default defineConfig({
           swrMutationOptions: {
             revalidate: true,
           },
+          swrInfiniteOptions: {
+            initialSize: 10,
+          },
         },
       },
     },


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

This PR is a follow up to #1223 and #1225
I added a property `swrInfiniteOptions` to `output.override.swr` that extends only the options of `useSWRInfinite`.

## Related PRs

List related PRs against other branches:

- #1223
- #1225

## Todos

- [x] Tests
- [x] Documentation
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce

1. check generated hooks in tests

tests/generated/swr/petstore-override-swr/endpoints.ts:

```typescript
/**
 * @summary Info for a specific pet
 */
export const useShowPetByIdInfinite = <TError = AxiosError<Error>>(
  petId: string, options?: { swr?:SWRInfiniteConfiguration<Awaited<ReturnType<typeof showPetById>>, TError> & { swrKeyLoader?: SWRInfiniteKeyLoader, enabled?: boolean }, axios?: AxiosRequestConfig }
) => {
  const {swr: swrOptions, axios: axiosOptions} = options ?? {}

  const isEnabled = swrOptions?.enabled !== false && !!(petId)
  const swrKeyLoader = swrOptions?.swrKeyLoader ?? (() => isEnabled ? getShowPetByIdInfiniteKeyLoader(petId) : null);
  const swrFn = () => showPetById(petId, axiosOptions);

  const query = useSWRInfinite<Awaited<ReturnType<typeof swrFn>>, TError>(swrKeyLoader, swrFn, {
     initialSize: 10, 
    ...swrOptions
  })

  return {
    swrKeyLoader,
    ...query
  }
}
```