### PR TITLE
feat(swr): remove `output.orverride.swr.options` property

### DIFF
--- a/docs/src/pages/reference/configuration/output.md
+++ b/docs/src/pages/reference/configuration/output.md
@@ -800,9 +800,6 @@ module.exports = {
       override: {
         swr: {
           useInfinite: true,
-          options: {
-            dedupingInterval: 10000,
-          },
         },
       },
     },

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -127,9 +127,7 @@ export type NormalizedOperationOptions = {
   contentType?: OverrideOutputContentType;
   query?: NormalizedQueryOptions;
   angular?: Required<AngularOptions>;
-  swr?: {
-    options?: any;
-  };
+  swr?: SwrOptions;
   operationName?: (
     operation: OperationObject,
     route: string,
@@ -360,7 +358,6 @@ export type AngularOptions = {
 };
 
 export type SwrOptions = {
-  options?: any;
   useInfinite?: boolean;
   swrOptions?: any;
   swrMutationOptions?: any;

--- a/packages/swr/src/index.ts
+++ b/packages/swr/src/index.ts
@@ -378,8 +378,6 @@ ${doc}export const ${camel(
 }\n`
     : '';
 
-  const defaultSwrOptions = { ...swrOptions.swrOptions, ...swrOptions.options };
-
   const useSwrImplementation = `
 export type ${pascal(
     operationName,
@@ -420,9 +418,9 @@ ${doc}export const ${camel(`use-${operationName}`)} = <TError = ${errorType}>(
   });
 
   const ${queryResultVarName} = useSwr<Awaited<ReturnType<typeof swrFn>>, TError>(swrKey, swrFn, ${
-    defaultSwrOptions
+    swrOptions.swrOptions
       ? `{
-    ${stringify(defaultSwrOptions)?.slice(1, -1)}
+    ${stringify(swrOptions.swrOptions)?.slice(1, -1)}
     ...swrOptions
   }`
       : 'swrOptions'


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

This PR is a sequel to #1223, #1225, and #1245.
Since the `swr` option is different for each query function, i fixed it to separate the options in #1223, #1225, and #1245.
Therefore, "output.override.swr.options" is no longer needed, so remove it.

## Related PRs

List related PRs against other branches:

- #1223
- #1225
- #1245

## Todos

- [x] Tests
- [x] Documentation
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce

1. Check the options defined in each query function in the tests generated hook

tests/generated/swr/petstore-override-swr/endpoints.ts:

