### PR TITLE
fix: overridden non-GET queries not generating hooks

### DIFF
--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -1208,7 +1208,7 @@ const generateQueryHook = async (
       .join(',');
 
     const queries = [
-      ...(query?.useInfinite
+      ...(query?.useInfinite || operationQueryOptions?.useInfinite
         ? [
             {
               name: camel(`${operationName}-infinite`),
@@ -1218,7 +1218,7 @@ const generateQueryHook = async (
             },
           ]
         : []),
-      ...(query?.useQuery
+      ...(operationQueryOptions?.useQuery || query.useQuery
         ? [
             {
               name: operationName,
@@ -1227,7 +1227,7 @@ const generateQueryHook = async (
             },
           ]
         : []),
-      ...(query?.useSuspenseQuery
+      ...(query?.useSuspenseQuery || operationQueryOptions?.useSuspenseQuery
         ? [
             {
               name: camel(`${operationName}-suspense`),
@@ -1236,7 +1236,8 @@ const generateQueryHook = async (
             },
           ]
         : []),
-      ...(query?.useSuspenseInfiniteQuery
+      ...(query?.useSuspenseInfiniteQuery ||
+      operationQueryOptions?.useSuspenseInfiniteQuery
         ? [
             {
               name: camel(`${operationName}-suspense-infinite`),

--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -1218,7 +1218,7 @@ const generateQueryHook = async (
             },
           ]
         : []),
-      ...(operationQueryOptions?.useQuery || query.useQuery
+      ...(query?.useQuery || operationQueryOptions?.useQuery
         ? [
             {
               name: operationName,


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

Fix https://github.com/anymaniax/orval/issues/1247

## Description

As described in https://github.com/anymaniax/orval/issues/1247 hooks for queries with a verb other than `GET` did not get generated even though an operation override was present.

Seems like the `isQuery` variable was changed in https://github.com/anymaniax/orval/pull/1212 but the `queries` list containing which queries to generate hooks for still used the old condition.

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

Outline the steps to test or reproduce the PR here.

```bash
> git pull --prune
> git checkout <branch>
> grunt jasmine
```

1. Described in issue https://github.com/anymaniax/orval/issues/1247
