### PR TITLE
fix(zod): fixes #1253 removing resolver for `null` type

### DIFF
--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -42,8 +42,6 @@ const resolveZodType = (schemaTypeValue: SchemaObject['type']) => {
   switch (schemaTypeValue) {
     case 'integer':
       return 'number';
-    case 'null':
-      return 'mixed';
     default:
       return schemaTypeValue ?? 'any';
   }

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -10,6 +10,7 @@ const queryParams: ZodValidationSchemaDefinitionInput = {
     functions: [
       ['number', undefined],
       ['optional', undefined],
+      ['null', undefined],
     ],
     consts: [],
   },
@@ -36,7 +37,7 @@ describe('parseZodValidationSchemaDefinition', () => {
       const parseResult = parseZodValidationSchemaDefinition(queryParams);
 
       expect(parseResult.zod).toBe(
-        'zod.object({\n  "limit": zod.number().optional(),\n  "q": zod.array(zod.string()).optional()\n})',
+        'zod.object({\n  "limit": zod.number().optional().null(),\n  "q": zod.array(zod.string()).optional()\n})',
       );
     });
   });
@@ -46,7 +47,7 @@ describe('parseZodValidationSchemaDefinition', () => {
       const parseResult = parseZodValidationSchemaDefinition(queryParams, true);
 
       expect(parseResult.zod).toBe(
-        'zod.object({\n  "limit": zod.coerce.number().optional(),\n  "q": zod.array(zod.coerce.string()).optional()\n})',
+        'zod.object({\n  "limit": zod.coerce.number().optional().null(),\n  "q": zod.array(zod.coerce.string()).optional()\n})',
       );
     });
   });


### PR DESCRIPTION
## Status

**READY**

## Description

* Fixes #1253 by removing resolver for `null` type. `zod.null()` is a valid method.
* Changes test case to contain `null` type.

## Related PRs
N/A

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

N/A
