### PR TITLE
fix: swr mutation fetcher - name param __ in case of no body arg

### DIFF
--- a/packages/swr/src/index.ts
+++ b/packages/swr/src/index.ts
@@ -693,9 +693,15 @@ export const ${swrKeyFnName} = (${queryKeyProps}) => [\`${route}\`${
     const swrMutationFetcherOptions =
       !mutator && isRequestOptions ? 'options?: AxiosRequestConfig' : '';
 
+    const swrMutationFetcherArg = props.some(
+      (prop) => prop.type === GetterPropType.BODY,
+    )
+      ? '{ arg }'
+      : '__';
+
     const swrMutationFetcherFn = `
 export const ${swrMutationFetcherName} = (${swrProps} ${swrMutationFetcherOptions}) => {
-  return (_: string, { arg }: { arg: Arguments }): ${swrMutationFetcherType} => {
+  return (_: string, ${swrMutationFetcherArg}: { arg: Arguments }): ${swrMutationFetcherType} => {
     return ${operationName}(${httpFnProperties}${
       swrMutationFetcherOptions.length ? ', options' : ''
     });

--- a/tests/specifications/petstore.yaml
+++ b/tests/specifications/petstore.yaml
@@ -155,6 +155,27 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+    delete:
+      summary: Deletes a specific pet
+      operationId: deletePetById
+      tags:
+        - pets
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to delete
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Expected response to a valid request
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /health:
     get:
       summary: health check


### PR DESCRIPTION
## Status

**READY**

## Description

Fixes #1261 by naming the parameter __ when it is not used in the function

## Related PRs

N/A

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

1. yarn build
2. cd tests
3. yarn generate:swr
4. generated code should contain a `getDeletePetByIdMutationFetcher` function containing `__: { arg: Arguments }` and a `getCreatePetsMutationFetcher` function containing `{ arg }: { arg: Arguments }`
