### PR TITLE
fix(msw): mock blobs as blobs instead of strings

### DIFF
--- a/packages/mock/src/faker/constants.ts
+++ b/packages/mock/src/faker/constants.ts
@@ -5,6 +5,8 @@ export const DEFAULT_FORMAT_MOCK: Record<
   string
 > = {
   bic: 'faker.finance.bic()',
+  binary:
+    "new Blob(faker.helpers.arrayElements(faker.word.words(10).split(' ')))",
   city: 'faker.location.city()',
   country: 'faker.location.country()',
   date: "faker.date.past().toISOString().split('T')[0]",

--- a/tests/configs/swr.config.ts
+++ b/tests/configs/swr.config.ts
@@ -131,4 +131,18 @@ export default defineConfig({
       target: '../specifications/petstore.yaml',
     },
   },
+  blobFile: {
+    output: {
+      target: '../generated/swr/blob-file/endpoints.ts',
+      schemas: '../generated/swr/blob-file/model',
+      client: 'swr',
+      mock: true,
+    },
+    input: {
+      target: '../specifications/blob-file.yaml',
+      override: {
+        transformer: '../transformers/add-version.js',
+      },
+    },
+  },
 });

--- a/tests/specifications/blob-file.yaml
+++ b/tests/specifications/blob-file.yaml
@@ -1,0 +1,25 @@
+openapi: 3.1.0
+info:
+  title: Blob File
+  description: 'Blobs'
+  version: 1.0.0
+tags:
+  - name: blobs
+    description: Blobs
+servers:
+  - url: http://localhost
+paths:
+  /binary-blob:
+    get:
+      tags:
+        - blobs
+      summary: Binary Blob response
+      operationId: getBinaryBlob
+      responses:
+        200:
+          description: Successful Operation
+          content:
+            application/json:
+              schema:
+                type: 'string'
+                format: 'binary'


### PR DESCRIPTION
## Status

**WIP**

Fix https://github.com/anymaniax/orval/issues/1259

## Description

Mock blobs, as proposed in my comment of issue #1259 

## Todos

- [x] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

yarn build
cd tests
yarn generate:swr
check generated/swr/blob-file `export const getGetBinaryBlobResponseMock`