### PR TITLE
fix(swr): make sure to not include comma when not valid while generating swrMutationFetcher

### DIFF
--- a/packages/swr/src/index.ts
+++ b/packages/swr/src/index.ts
@@ -703,7 +703,9 @@ export const ${swrKeyFnName} = (${queryKeyProps}) => [\`${route}\`${
 export const ${swrMutationFetcherName} = (${swrProps} ${swrMutationFetcherOptions}) => {
   return (_: string, ${swrMutationFetcherArg}: { arg: Arguments }): ${swrMutationFetcherType} => {
     return ${operationName}(${httpFnProperties}${
-      swrMutationFetcherOptions.length ? ', options' : ''
+      swrMutationFetcherOptions.length
+        ? (httpFnProperties.length ? ', ' : '') + 'options'
+        : ''
     });
   }
 }\n`;

--- a/tests/configs/swr.config.ts
+++ b/tests/configs/swr.config.ts
@@ -145,4 +145,15 @@ export default defineConfig({
       },
     },
   },
+  nestedArrays: {
+    output: {
+      target: '../generated/swr/nested-arrays/endpoints.ts',
+      schemas: '../generated/swr/nested-arrays/model',
+      client: 'swr',
+      mock: true,
+    },
+    input: {
+      target: '../specifications/arrays.yaml',
+    },
+  },
 });


### PR DESCRIPTION
## Status

**READY**

## Description

Fixes #1270 

## Todos

- [x] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

1. Build and then generate swr
2. Check tests\generated\swr\nested-arrays\endpoints.ts for errors
