### PR TITLE
fix(msw): return mock as array of enums if array is the correct type

### DIFF
--- a/packages/mock/src/faker/getters/scalar.ts
+++ b/packages/mock/src/faker/getters/scalar.ts
@@ -232,7 +232,9 @@ export const getMockScalar = ({
           ];
         }
 
-        value = `faker.helpers.arrayElement(${enumValue})`;
+        value = item.path?.endsWith('[]')
+          ? `faker.helpers.arrayElements(${enumValue})`
+          : `faker.helpers.arrayElement(${enumValue})`;
       }
 
       return {

--- a/tests/configs/swr.config.ts
+++ b/tests/configs/swr.config.ts
@@ -156,4 +156,15 @@ export default defineConfig({
       target: '../specifications/arrays.yaml',
     },
   },
+  enums: {
+    output: {
+      target: '../generated/swr/enums/endpoints.ts',
+      schemas: '../generated/swr/enums/model',
+      client: 'swr',
+      mock: true,
+    },
+    input: {
+      target: '../specifications/enums.yaml',
+    },
+  },
 });

--- a/tests/specifications/enums.yaml
+++ b/tests/specifications/enums.yaml
@@ -1,0 +1,134 @@
+openapi: 3.0.3
+info:
+  title: Arrays
+  version: 1.0.0
+paths:
+  /api/cat:
+    get:
+      summary: sample cat
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Cat'
+  /api/required-cat:
+    get:
+      summary: sample required cat
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RequiredCat'
+  /api/dog:
+    get:
+      summary: sample dog
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Dog'
+  /api/required-dog:
+    get:
+      summary: sample required dog
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RequiredDog'
+  /api/duck:
+    get:
+      summary: sample duck
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Duck'
+components:
+  schemas:
+    Siamese:
+      type: object
+      properties:
+        colours:
+          type: array
+          items:
+            type: string
+            enum:
+              - BLACK
+              - BROWN
+              - WHITE
+              - GREY
+    RequiredSiamese:
+      type: object
+      required: ['colours']
+      properties:
+        colours:
+          type: array
+          items:
+            type: string
+            enum:
+              - BLACK
+              - BROWN
+              - WHITE
+              - GREY
+    Cat:
+      type: object
+      properties:
+        petsRequested:
+          type: array
+          items:
+            $ref: '#/components/schemas/Siamese'
+    RequiredCat:
+      type: object
+      properties:
+        petsRequested:
+          type: array
+          items:
+            $ref: '#/components/schemas/RequiredSiamese'
+    Bulldog:
+      type: object
+      properties:
+        colour:
+          type: string
+          enum:
+            - BLACK
+            - BROWN
+    RequiredBulldog:
+      type: object
+      required: ['colour']
+      properties:
+        colour:
+          type: string
+          enum:
+            - BLACK
+            - BROWN
+    Dog:
+      type: object
+      properties:
+        petsRequested:
+          type: array
+          items:
+            $ref: '#/components/schemas/Bulldog'
+    RequiredDog:
+      type: object
+      properties:
+        petsRequested:
+          type: array
+          items:
+            $ref: '#/components/schemas/RequiredBulldog'
+    Duck:
+      type: object
+      properties:
+        petsRequested:
+          type: array
+          items:
+            type: string


### PR DESCRIPTION
## Status

**READY**

Fix https://github.com/anymaniax/orval/issues/1262

## Description

Proposed fix for issue #1262 
Other ideas, should the map method be typed? E.g.
```ts
export const getGetApiDogResponseMock = (overrideResponse: any = {}): Dog => ({
  petsRequested: faker.helpers.arrayElement([
    Array.from(
      { length: faker.number.int({ min: 1, max: 10 }) },
      (_, i) => i + 1,
    ).map<Bulldog>(() => ({
      //     ^ change here
      colour: faker.helpers.arrayElement([
        faker.helpers.arrayElement(['BLACK', 'BROWN'] as const),
        undefined,
      ]),
      ...overrideResponse,
    })),
    undefined,
  ]),
  ...overrideResponse,
});
```

## Todos

- [x] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

1. yarn build
2. cd tests
3. yarn generate:swr
4. check in generated/swr/enums/endpoints, mocks of Cat should be `("BLACK" | "BROWN" | "WHITE" | "GREY")[] | undefined` or `("BLACK" | "BROWN" | "WHITE" | "GREY")[]`, while mocks of Dog should be `"BLACK" | "BROWN" | undefined` or `"BLACK" | "BROWN"`