### PR TITLE
fix(msw): make sure to not try to include error type in mock implementation

### DIFF
--- a/docs/src/pages/reference/configuration/output.md
+++ b/docs/src/pages/reference/configuration/output.md
@@ -712,7 +712,6 @@ module.exports = {
 };
 ```
 
-
 ##### queryOptions
 
 Type: `String` or `Object`.

--- a/packages/mock/src/msw/index.ts
+++ b/packages/mock/src/msw/index.ts
@@ -107,7 +107,16 @@ export const ${handlerName} = (${isReturnHttpResponse && !isTextPlain ? `overrid
 
   const includeResponseImports =
     isReturnHttpResponse && !isTextPlain
-      ? [...imports, ...response.imports]
+      ? [
+          ...imports,
+          ...response.imports.filter((r) => {
+            // Only include imports which are actually used in mock.
+            const reg = new RegExp(`\\b${r.name}\\b`);
+            return (
+              reg.test(handlerImplementation) || reg.test(mockImplementation)
+            );
+          }),
+        ]
       : imports;
 
   return {


### PR DESCRIPTION
## Status

**READY**

## Description

Fixes #1273 
Mock tried to import the error type, which caused the non-mock implementation to not try and import it. The mock code then filtered out all imports that weren't used in the mock, thus leaving out the error type.

## Todos

- [x] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

1. cd tests
2. yarn generate:swr
3. go to generated/swr/petstore/endpoints.ts
4. see that the Error type is the generated Error model, and not the default js Error
```ts
export type ListPetsQueryError = AxiosError<Error>
//                                            ^ Go to definition leads to generated Error model
```
5. compare to previous version, where go to definition leads you to default js Error type.
