### PR TITLE
fix(swr): error type is correct even when it's the same type as success type

### DIFF
--- a/packages/core/src/getters/res-req-types.ts
+++ b/packages/core/src/getters/res-req-types.ts
@@ -1,5 +1,7 @@
 import { keyword } from 'esutils';
+import type { ValueIteratee } from 'lodash';
 import uniqBy from 'lodash.uniqby';
+
 import {
   MediaTypeObject,
   ReferenceObject,
@@ -48,6 +50,7 @@ export const getResReqTypes = (
   name: string,
   context: ContextSpecs,
   defaultType = 'unknown',
+  uniqueKey: ValueIteratee<ResReqTypesValue> = 'value',
 ): ResReqTypesValue[] => {
   const typesArray = responsesOrRequests
     .filter(([_, res]) => Boolean(res))
@@ -213,7 +216,7 @@ export const getResReqTypes = (
 
   return uniqBy(
     typesArray.flatMap((it) => it),
-    'value',
+    uniqueKey,
   );
 };
 

--- a/packages/core/src/getters/response.ts
+++ b/packages/core/src/getters/response.ts
@@ -37,6 +37,7 @@ export const getResponse = ({
     operationName,
     context,
     'void',
+    (type) => type.key.startsWith('2') + type.value,
   );
 
   const filteredTypes = contentType

--- a/tests/configs/swr.config.ts
+++ b/tests/configs/swr.config.ts
@@ -167,4 +167,15 @@ export default defineConfig({
       target: '../specifications/enums.yaml',
     },
   },
+  errors: {
+    output: {
+      target: '../generated/swr/errors/endpoints.ts',
+      schemas: '../generated/swr/errors/model',
+      client: 'swr',
+      mock: true,
+    },
+    input: {
+      target: '../specifications/errors.yaml',
+    },
+  },
 });

--- a/tests/specifications/errors.yaml
+++ b/tests/specifications/errors.yaml
@@ -1,0 +1,37 @@
+openapi: '3.0.0'
+info:
+  version: 1.0.0
+  title: Swagger Errors
+  license:
+    name: MIT
+paths:
+  /error:
+    get:
+      summary: Get an Error Item
+      operationId: createItems
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Item'
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Item'
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Item'
+components:
+  schemas:
+    Item:
+      type: object
+      properties:
+        prop:
+          type: string


### PR DESCRIPTION
## Status

**READY**

## Description

Fixes #1256 
Problem was that the error type was getting filtered out as it was equal to the success type, resulting in error being unknown.

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

1. cd tests
2. yarn generate:swr
3. check generated/swr/errors/endpoints.ts
4. `export type CreateItemsQueryError = AxiosError<Item>`
5. compared to previous build, where it would be `export type CreateItemsQueryError = AxiosError<unknown>`