### PR TITLE
fix: request bodies should take required property into account

### DIFF
--- a/packages/core/src/getters/body.ts
+++ b/packages/core/src/getters/body.ts
@@ -54,7 +54,7 @@ export const getBody = ({
         context.output.override.components.requestBodies.suffix
       : camel(definition);
 
-  let isOptional = true;
+  let isOptional = false;
   if (implementation) {
     implementation = sanitize(implementation, {
       underscore: '_',
@@ -68,8 +68,10 @@ export const getBody = ({
         requestBody,
         context,
       );
-      isOptional = !bodySchema.required;
-    } else {
+      if (bodySchema.required !== undefined) {
+        isOptional = !bodySchema.required;
+      }
+    } else if (requestBody.required !== undefined) {
       isOptional = !requestBody.required;
     }
   }

--- a/packages/core/src/getters/props.ts
+++ b/packages/core/src/getters/props.ts
@@ -25,10 +25,10 @@ export const getProps = ({
 }): GetterProps => {
   const bodyProp = {
     name: body.implementation,
-    definition: `${body.implementation}: ${body.definition}`,
-    implementation: `${body.implementation}: ${body.definition}`,
+    definition: `${body.implementation}${body.isOptional ? '?' : ''}: ${body.definition}`,
+    implementation: `${body.implementation}${body.isOptional ? '?' : ''}: ${body.definition}`,
     default: false,
-    required: true,
+    required: !body.isOptional,
     type: GetterPropType.BODY,
   };
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -728,6 +728,7 @@ export type GetterBody = {
   formData?: string;
   formUrlEncoded?: string;
   contentType: string;
+  isOptional: boolean;
 };
 
 export type GetterParameters = {

--- a/tests/configs/swr.config.ts
+++ b/tests/configs/swr.config.ts
@@ -178,4 +178,15 @@ export default defineConfig({
       target: '../specifications/errors.yaml',
     },
   },
+  optionalRequestBody: {
+    output: {
+      target: '../generated/swr/optional-request-body/endpoints.ts',
+      schemas: '../generated/swr/optional-request-body/model',
+      client: 'swr',
+      mock: true,
+    },
+    input: {
+      target: '../specifications/optional-request-body.yaml',
+    },
+  },
 });

--- a/tests/specifications/optional-request-body.yaml
+++ b/tests/specifications/optional-request-body.yaml
@@ -2,184 +2,35 @@ openapi: '3.0.0'
 info:
   version: 1.0.0
   title: Swagger Petstore
-  license:
-    name: MIT
-servers:
-  - url: http://petstore.swagger.io/v1
 paths:
   /pets:
     post:
-      summary: Create a pet
       operationId: createPets
-      tags:
-        - pets
-      parameters:
-        - name: limit
-          in: query
-          description: How many items to return at one time (max 100)
-          required: false
-          schema:
-            type: string
-        - name: sort
-          in: query
-          description: |
-            Which property to sort by?
-            Example: name sorts ASC while -name sorts DESC.
-          required: true
-          schema:
-            type: string
-            enum:
-              - name
-              - -name
-              - email
-              - -email
-        - description: Header parameters
-          in: header
-          name: X-EXAMPLE
-          required: true
-          schema:
-            type: string
-            enum:
-              - ONE
-              - TWO
-              - THREE
       requestBody:
         $ref: '#/components/requestBodies/RequiredPetBody'
       responses:
-        '200':
-          description: Created Pet
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Pet'
+        '204':
+          description: Ok
     put:
-      summary: Update a pet
       operationId: updatePets
-      tags:
-        - pets
-      parameters:
-        - name: limit
-          in: query
-          description: How many items to return at one time (max 100)
-          required: false
-          schema:
-            type: string
-        - name: sort
-          in: query
-          description: |
-            Which property to sort by?
-            Example: name sorts ASC while -name sorts DESC.
-          required: true
-          schema:
-            type: string
-            enum:
-              - name
-              - -name
-              - email
-              - -email
-        - description: Header parameters
-          in: header
-          name: X-EXAMPLE
-          required: true
-          schema:
-            type: string
-            enum:
-              - ONE
-              - TWO
-              - THREE
       requestBody:
         $ref: '#/components/requestBodies/OptionalPetBody'
       responses:
-        '200':
-          description: Updated Pet
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Pet'
+        '204':
+          description: Ok
   /cookies:
     post:
-      summary: Create a cookie
       operationId: createCookies
-      tags:
-        - cookies
-      parameters:
-        - name: limit
-          in: query
-          description: How many items to return at one time (max 100)
-          required: false
-          schema:
-            type: string
-        - name: sort
-          in: query
-          description: |
-            Which property to sort by?
-            Example: name sorts ASC while -name sorts DESC.
-          required: true
-          schema:
-            type: string
-            enum:
-              - name
-              - -name
-              - email
-              - -email
-        - description: Header parameters
-          in: header
-          name: X-EXAMPLE
-          required: true
-          schema:
-            type: string
-            enum:
-              - ONE
-              - TWO
-              - THREE
       requestBody:
-        required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/Cookie'
       responses:
-        '200':
-          description: Created Cookie
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Cookie'
+        '204':
+          description: Ok
     put:
-      summary: Update a cookie
       operationId: updateCookies
-      tags:
-        - cookies
-      parameters:
-        - name: limit
-          in: query
-          description: How many items to return at one time (max 100)
-          required: false
-          schema:
-            type: string
-        - name: sort
-          in: query
-          description: |
-            Which property to sort by?
-            Example: name sorts ASC while -name sorts DESC.
-          required: true
-          schema:
-            type: string
-            enum:
-              - name
-              - -name
-              - email
-              - -email
-        - description: Header parameters
-          in: header
-          name: X-EXAMPLE
-          required: true
-          schema:
-            type: string
-            enum:
-              - ONE
-              - TWO
-              - THREE
       requestBody:
         required: false
         content:
@@ -187,23 +38,17 @@ paths:
             schema:
               $ref: '#/components/schemas/Cookie'
       responses:
-        '200':
-          description: Updated Cookie
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Cookie'
+        '204':
+          description: Ok
 components:
   requestBodies:
     OptionalPetBody:
-      description: A JSON object containing pet information
+      required: false
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/Pet'
     RequiredPetBody:
-      description: A JSON object containing pet information
-      required: true
       content:
         application/json:
           schema:
@@ -211,13 +56,5 @@ components:
   schemas:
     Pet:
       type: object
-      properties:
-        id:
-          type: integer
-          format: int64
     Cookie:
       type: object
-      properties:
-        id:
-          type: integer
-          format: int64

--- a/tests/specifications/optional-request-body.yaml
+++ b/tests/specifications/optional-request-body.yaml
@@ -1,0 +1,223 @@
+openapi: '3.0.0'
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pets:
+    post:
+      summary: Create a pet
+      operationId: createPets
+      tags:
+        - pets
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          schema:
+            type: string
+        - name: sort
+          in: query
+          description: |
+            Which property to sort by?
+            Example: name sorts ASC while -name sorts DESC.
+          required: true
+          schema:
+            type: string
+            enum:
+              - name
+              - -name
+              - email
+              - -email
+        - description: Header parameters
+          in: header
+          name: X-EXAMPLE
+          required: true
+          schema:
+            type: string
+            enum:
+              - ONE
+              - TWO
+              - THREE
+      requestBody:
+        $ref: '#/components/requestBodies/RequiredPetBody'
+      responses:
+        '200':
+          description: Created Pet
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+    put:
+      summary: Update a pet
+      operationId: updatePets
+      tags:
+        - pets
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          schema:
+            type: string
+        - name: sort
+          in: query
+          description: |
+            Which property to sort by?
+            Example: name sorts ASC while -name sorts DESC.
+          required: true
+          schema:
+            type: string
+            enum:
+              - name
+              - -name
+              - email
+              - -email
+        - description: Header parameters
+          in: header
+          name: X-EXAMPLE
+          required: true
+          schema:
+            type: string
+            enum:
+              - ONE
+              - TWO
+              - THREE
+      requestBody:
+        $ref: '#/components/requestBodies/OptionalPetBody'
+      responses:
+        '200':
+          description: Updated Pet
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+  /cookies:
+    post:
+      summary: Create a cookie
+      operationId: createCookies
+      tags:
+        - cookies
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          schema:
+            type: string
+        - name: sort
+          in: query
+          description: |
+            Which property to sort by?
+            Example: name sorts ASC while -name sorts DESC.
+          required: true
+          schema:
+            type: string
+            enum:
+              - name
+              - -name
+              - email
+              - -email
+        - description: Header parameters
+          in: header
+          name: X-EXAMPLE
+          required: true
+          schema:
+            type: string
+            enum:
+              - ONE
+              - TWO
+              - THREE
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Cookie'
+      responses:
+        '200':
+          description: Created Cookie
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Cookie'
+    put:
+      summary: Update a cookie
+      operationId: updateCookies
+      tags:
+        - cookies
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          schema:
+            type: string
+        - name: sort
+          in: query
+          description: |
+            Which property to sort by?
+            Example: name sorts ASC while -name sorts DESC.
+          required: true
+          schema:
+            type: string
+            enum:
+              - name
+              - -name
+              - email
+              - -email
+        - description: Header parameters
+          in: header
+          name: X-EXAMPLE
+          required: true
+          schema:
+            type: string
+            enum:
+              - ONE
+              - TWO
+              - THREE
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Cookie'
+      responses:
+        '200':
+          description: Updated Cookie
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Cookie'
+components:
+  requestBodies:
+    OptionalPetBody:
+      description: A JSON object containing pet information
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Pet'
+    RequiredPetBody:
+      description: A JSON object containing pet information
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Pet'
+  schemas:
+    Pet:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+    Cookie:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64


### PR DESCRIPTION
## Status

**READY**

## Description

~~Fixes #1111~~

Takes the required property of request bodies into account. We till make it required by default, but setting it to required: false will make it optional.

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

1. yarn generate:swr
2. check tests/generated/swr/optional-request-body/endpoints.ts. Endpoints without a required property has the request body required. Endpoints with a required: false property has the request body as optional.