### PR TITLE
feat: support runtime delay functions

### DIFF
--- a/docs/src/pages/reference/configuration/output.md
+++ b/docs/src/pages/reference/configuration/output.md
@@ -300,6 +300,13 @@ Default Value: `1000`.
 
 Use to specify the delay time for the mock. It can either be a fixed number or a function that returns a number.
 
+#### delayCalcRuntime
+
+Type: `boolean`.
+
+Gives you the possibility to have functions that are passed to `delay` to be
+executed at runtime rather than at build time.
+
 #### useExamples
 
 Type: `Boolean`.
@@ -1009,6 +1016,13 @@ module.exports = {
   },
 };
 ```
+
+#### delayCalcRuntime
+
+Type: `boolean`.
+
+Gives you the possibility to have functions that are passed to `delay` to be
+executed at runtime rather than at build time.
 
 ##### arrayMin
 

--- a/docs/src/pages/reference/configuration/output.md
+++ b/docs/src/pages/reference/configuration/output.md
@@ -300,7 +300,7 @@ Default Value: `1000`.
 
 Use to specify the delay time for the mock. It can either be a fixed number or a function that returns a number.
 
-#### delayMockFunction
+#### delayFunctionLazyExecute
 
 Type: `boolean`.
 
@@ -1017,7 +1017,7 @@ module.exports = {
 };
 ```
 
-#### delayMockFunction
+#### delayFunctionLazyExecute
 
 Type: `boolean`.
 

--- a/docs/src/pages/reference/configuration/output.md
+++ b/docs/src/pages/reference/configuration/output.md
@@ -300,12 +300,12 @@ Default Value: `1000`.
 
 Use to specify the delay time for the mock. It can either be a fixed number or a function that returns a number.
 
-#### delayCalcRuntime
+#### delayMockFunction
 
 Type: `boolean`.
 
 Gives you the possibility to have functions that are passed to `delay` to be
-executed at runtime rather than at build time.
+executed at runtime rather than when the mocks are generated.
 
 #### useExamples
 
@@ -1017,12 +1017,12 @@ module.exports = {
 };
 ```
 
-#### delayCalcRuntime
+#### delayMockFunction
 
 Type: `boolean`.
 
 Gives you the possibility to have functions that are passed to `delay` to be
-executed at runtime rather than at build time.
+executed at runtime rather than when the mocks are generated.
 
 ##### arrayMin
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -232,7 +232,7 @@ export type GlobalMockOptions = {
   delay?: number | (() => number);
   // This is used to execute functions that are passed to the 'delay' argument
   // at runtime rather than build time.
-  delayMockFunction?: boolean;
+  delayFunctionLazyExecute?: boolean;
   // This is used to set the base url to your own custom value
   baseUrl?: string;
   // This is used to set the locale of the faker library

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -230,6 +230,9 @@ export type GlobalMockOptions = {
   useExamples?: boolean;
   // This is used to set the delay to your own custom value
   delay?: number | (() => number);
+  // This is used to execute functions that are passed to the 'delay' argument
+  // at runtime rather than build time.
+  delayCalcRuntime?: boolean;
   // This is used to set the base url to your own custom value
   baseUrl?: string;
   // This is used to set the locale of the faker library

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -232,7 +232,7 @@ export type GlobalMockOptions = {
   delay?: number | (() => number);
   // This is used to execute functions that are passed to the 'delay' argument
   // at runtime rather than build time.
-  delayCalcRuntime?: boolean;
+  delayMockFunction?: boolean;
   // This is used to set the base url to your own custom value
   baseUrl?: string;
   // This is used to set the locale of the faker library

--- a/packages/mock/src/delay.ts
+++ b/packages/mock/src/delay.ts
@@ -8,11 +8,11 @@ export const getDelay = (
     typeof override?.mock?.delay === 'number'
       ? override?.mock?.delay
       : options?.delay;
-  const delayCalcRuntime =
-    override?.mock?.delayCalcRuntime ?? options?.delayCalcRuntime;
+  const delayMockFunction =
+    override?.mock?.delayMockFunction ?? options?.delayMockFunction;
   switch (typeof overrideDelay) {
     case 'function':
-      return delayCalcRuntime ? overrideDelay : overrideDelay();
+      return delayMockFunction ? overrideDelay : overrideDelay();
     case 'number':
       return overrideDelay;
     default:

--- a/packages/mock/src/delay.ts
+++ b/packages/mock/src/delay.ts
@@ -8,11 +8,12 @@ export const getDelay = (
     typeof override?.mock?.delay === 'number'
       ? override?.mock?.delay
       : options?.delay;
-  const delayMockFunction =
-    override?.mock?.delayMockFunction ?? options?.delayMockFunction;
+  const delayFunctionLazyExecute =
+    override?.mock?.delayFunctionLazyExecute ??
+    options?.delayFunctionLazyExecute;
   switch (typeof overrideDelay) {
     case 'function':
-      return delayMockFunction ? overrideDelay : overrideDelay();
+      return delayFunctionLazyExecute ? overrideDelay : overrideDelay();
     case 'number':
       return overrideDelay;
     default:

--- a/packages/mock/src/delay.ts
+++ b/packages/mock/src/delay.ts
@@ -3,14 +3,16 @@ import { GlobalMockOptions, NormalizedOverrideOutput } from '@orval/core';
 export const getDelay = (
   override?: NormalizedOverrideOutput,
   options?: GlobalMockOptions,
-): number => {
+): GlobalMockOptions['delay'] => {
   const overrideDelay =
     typeof override?.mock?.delay === 'number'
       ? override?.mock?.delay
       : options?.delay;
+  const delayCalcRuntime =
+    override?.mock?.delayCalcRuntime ?? options?.delayCalcRuntime;
   switch (typeof overrideDelay) {
     case 'function':
-      return overrideDelay();
+      return delayCalcRuntime ? overrideDelay : overrideDelay();
     case 'number':
       return overrideDelay;
     default:

--- a/packages/mock/src/msw/index.ts
+++ b/packages/mock/src/msw/index.ts
@@ -84,10 +84,11 @@ export const generateMSW = (
     ? `export const ${getResponseMockFunctionName} = (${isResponseOverridable ? `overrideResponse: any = {}` : ''})${mockData ? '' : `: ${returnType}`} => (${value})\n\n`
     : '';
 
+  const delayTime = getDelay(override, !isFunction(mock) ? mock : undefined);
   const handlerImplementation = `
 export const ${handlerName} = (${isReturnHttpResponse && !isTextPlain ? `overrideResponse?: ${returnType}` : ''}) => {
   return http.${verb}('${route}', async () => {
-    await delay(${getDelay(override, !isFunction(mock) ? mock : undefined)});
+    await delay(${isFunction(delayTime) ? `(${delayTime})()` : delayTime});
     return new HttpResponse(${
       isReturnHttpResponse
         ? isTextPlain

--- a/tests/configs/default.config.ts
+++ b/tests/configs/default.config.ts
@@ -127,7 +127,7 @@ export default defineConfig({
     output: {
       mock: {
         delay: () => 400,
-        delayCalcRuntime: true,
+        delayMockFunction: true,
         type: 'msw',
       },
       schemas: '../generated/default/runtime-mock-delay/model',

--- a/tests/configs/default.config.ts
+++ b/tests/configs/default.config.ts
@@ -122,4 +122,16 @@ export default defineConfig({
       },
     },
   },
+  'runtime-mock-delay': {
+    input: '../specifications/petstore.yaml',
+    output: {
+      mock: {
+        delay: () => 400,
+        delayCalcRuntime: true,
+        type: 'msw',
+      },
+      schemas: '../generated/default/runtime-mock-delay/model',
+      target: '../generated/default/runtime-mock-delay/endpoints.ts',
+    },
+  },
 });

--- a/tests/configs/default.config.ts
+++ b/tests/configs/default.config.ts
@@ -127,7 +127,7 @@ export default defineConfig({
     output: {
       mock: {
         delay: () => 400,
-        delayMockFunction: true,
+        delayFunctionLazyExecute: true,
         type: 'msw',
       },
       schemas: '../generated/default/runtime-mock-delay/model',


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

Add support for generating mock delay times at runtime.

Fixes: #1279

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

1. In root run `yarn build`.
2. cd samples/react-query/basic.
3. Open orval.config.ts and replace `mock: true,` with:
```typescript
      mock: {
        type: 'msw',
        delay: () => (process.env.NODE_ENV === 'test' ? 10 : 1000),
        delayCalcRuntime: true,
      },
```
4. Run `yarn generate-api`.
5. Open `src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts`.
6. See that the delays are now `await delay((() => (process.env.NODE_ENV === 'test' ? 10 : 1e3))());`