### PR TITLE
fix: schema type integer

### DIFF
--- a/packages/core/src/getters/res-req-types.ts
+++ b/packages/core/src/getters/res-req-types.ts
@@ -287,7 +287,11 @@ const getSchemaFormDataAndUrlEncoded = ({
     return `${form}${propName}.forEach(value => ${variableName}.append('data', value))\n`;
   }
 
-  if (schema.type === 'number' || schema.type === 'boolean') {
+  if (
+    schema.type === 'number' ||
+    schema.type === 'integer' ||
+    schema.type === 'boolean'
+  ) {
     return `${form}${variableName}.append('data', ${propName}.toString())\n`;
   }
 


### PR DESCRIPTION
## Status

READY

## Description

Added support for schema type `integer` to have the same behavior as `number` when generating form data code. 

[Source](https://swagger.io/docs/specification/data-models/data-types/#numbers)

## Related PRs

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce
