### PR TITLE
chore(msw): add `msw` guide route

### DIFF
--- a/docs/src/manifests/manifest.json
+++ b/docs/src/manifests/manifest.json
@@ -69,6 +69,11 @@
           "title": "SWR",
           "path": "/guides/swr",
           "editUrl": "/guides/swr.md"
+        },
+        {
+          "title": "MSW",
+          "path": "/guides/msw",
+          "editUrl": "/guides/msw.md"
         }
       ]
     },


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

I added the `msw` guide route. Because I created a guide on how to use `msw` in [this PR](https://github.com/anymaniax/orval/pull/1250), but I forgot to add the route. so, the guide was not showing up on the documentation site.

## Related PRs

#1250

## Todos

- [ ] Tests
- [x] Documentation
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce

1. this PR merge
2. I'll check to document site
