### PR TITLE
fix(mock/msw): override response if it's false as well

### DIFF
--- a/packages/mock/src/msw/index.ts
+++ b/packages/mock/src/msw/index.ts
@@ -102,7 +102,7 @@ export const ${handlerName} = (${isReturnHttpResponse && !isTextPlain ? `overrid
       isReturnHttpResponse
         ? isTextPlain
           ? `${getResponseMockFunctionName}()`
-          : `JSON.stringify(overrideResponse ? overrideResponse : ${getResponseMockFunctionName}())`
+          : `JSON.stringify(overrideResponse !== undefined ? overrideResponse : ${getResponseMockFunctionName}())`
         : null
     },
       {


### PR DESCRIPTION
## Status

READY

## Description

If you pass the value `false` to a mock handler to override response with that value, it would fallback to the default response. This PR should fix this, and it will now accept any value that isn't `undefined`.

## Todos

- [ ] Tests
- [ ] Documentation (N/A)
- [ ] Changelog Entry (unreleased) 
