### PR TITLE
feat: added `output.fileExtension` option to possible specifying the extension for the generated file.

### DIFF
--- a/docs/src/pages/reference/configuration/output.md
+++ b/docs/src/pages/reference/configuration/output.md
@@ -63,7 +63,7 @@ Type: `String`.
 
 Default Value: `.ts`.
 
-Specify the file extension of automatically generated files. `tags`, `tags-split`, `split` modes do not affect `schema` files, only `client` files.
+Specify the file extension for files generated automatically. Modes such as `tags`, `tags-split`, and `split` do not alter `schema` files; they only pertain to `client` files.
 
 ```js
 module.exports = {

--- a/docs/src/pages/reference/configuration/output.md
+++ b/docs/src/pages/reference/configuration/output.md
@@ -57,13 +57,13 @@ module.exports = {
 };
 ```
 
-### extension
+### fileExtension
 
 Type: `String`.
 
 Default Value: `.ts`.
 
-Specify the extension of automatically generated files. `tags`, `tags-split`, `split` modes do not affect `schema` files, only `client` files.
+Specify the file extension of automatically generated files. `tags`, `tags-split`, `split` modes do not affect `schema` files, only `client` files.
 
 ```js
 module.exports = {
@@ -72,7 +72,7 @@ module.exports = {
       mode: 'split'
       target: './/gen/endpoints',
       schemas: './gen/model',
-      extension: '.gen.ts'
+      fileExtension: '.gen.ts'
     },
   },
 };

--- a/docs/src/pages/reference/configuration/output.md
+++ b/docs/src/pages/reference/configuration/output.md
@@ -57,6 +57,36 @@ module.exports = {
 };
 ```
 
+### extension
+
+Type: `String`.
+
+Default Value: `.ts`.
+
+Specify the extension of automatically generated files. `tags`, `tags-split`, `split` modes do not affect `schema` files, only `client` files.
+
+```js
+module.exports = {
+  petstore: {
+    output: {
+      mode: 'split'
+      target: './/gen/endpoints',
+      schemas: './gen/model',
+      extension: '.gen.ts'
+    },
+  },
+};
+```
+
+```
+src/gen/
+├── endpoints
+│   └── swaggerPetstore.gen.ts
+└── model
+    ├── listPetsParams.ts
+    └── pets.ts
+```
+
 ### workspace
 
 Type: `String`.
@@ -802,7 +832,6 @@ Type: `number`.
 Default Value: `Detect from package json`.
 
 Use to specify a version for the generated hooks. This is useful if you want to force a version for the hooks.
-
 
 #### angular
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -43,6 +43,7 @@ export type NormalizedOutputOptions = {
   workspace?: string;
   target?: string;
   schemas?: string;
+  extension: string;
   mode: OutputMode;
   mock?: GlobalMockOptions | ClientMockBuilder;
   override: NormalizedOverrideOutput;
@@ -161,6 +162,7 @@ export type OutputOptions = {
   workspace?: string;
   target?: string;
   schemas?: string;
+  extension?: string;
   mode?: OutputMode;
   // If mock is a boolean, it will use the default mock options (type: msw)
   mock?: boolean | GlobalMockOptions | ClientMockBuilder;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -43,7 +43,7 @@ export type NormalizedOutputOptions = {
   workspace?: string;
   target?: string;
   schemas?: string;
-  extension: string;
+  fileExtension: string;
   mode: OutputMode;
   mock?: GlobalMockOptions | ClientMockBuilder;
   override: NormalizedOverrideOutput;
@@ -162,7 +162,7 @@ export type OutputOptions = {
   workspace?: string;
   target?: string;
   schemas?: string;
-  extension?: string;
+  fileExtension?: string;
   mode?: OutputMode;
   // If mock is a boolean, it will use the default mock options (type: msw)
   mock?: boolean | GlobalMockOptions | ClientMockBuilder;

--- a/packages/core/src/writers/single-mode.ts
+++ b/packages/core/src/writers/single-mode.ts
@@ -21,7 +21,7 @@ export const writeSingleMode = async ({
   try {
     const { path, dirname } = getFileInfo(output.target, {
       backupFilename: camel(builder.info.title),
-      extension: output.extension,
+      extension: output.fileExtension,
     });
 
     const {
@@ -41,7 +41,8 @@ export const writeSingleMode = async ({
     const schemasPath = output.schemas
       ? upath.relativeSafe(
           dirname,
-          getFileInfo(output.schemas, { extension: output.extension }).dirname,
+          getFileInfo(output.schemas, { extension: output.fileExtension })
+            .dirname,
         )
       : undefined;
 

--- a/packages/core/src/writers/single-mode.ts
+++ b/packages/core/src/writers/single-mode.ts
@@ -21,6 +21,7 @@ export const writeSingleMode = async ({
   try {
     const { path, dirname } = getFileInfo(output.target, {
       backupFilename: camel(builder.info.title),
+      extension: output.extension,
     });
 
     const {
@@ -38,7 +39,10 @@ export const writeSingleMode = async ({
     let data = header;
 
     const schemasPath = output.schemas
-      ? upath.relativeSafe(dirname, getFileInfo(output.schemas).dirname)
+      ? upath.relativeSafe(
+          dirname,
+          getFileInfo(output.schemas, { extension: output.extension }).dirname,
+        )
       : undefined;
 
     const isAllowSyntheticDefaultImports = isSyntheticDefaultImportsAllow(

--- a/packages/core/src/writers/split-mode.ts
+++ b/packages/core/src/writers/split-mode.ts
@@ -22,6 +22,7 @@ export const writeSplitMode = async ({
   try {
     const { filename, dirname, extension } = getFileInfo(output.target, {
       backupFilename: camel(builder.info.title),
+      extension: output.extension,
     });
 
     const {
@@ -40,7 +41,10 @@ export const writeSplitMode = async ({
     let mockData = header;
 
     const relativeSchemasPath = output.schemas
-      ? upath.relativeSafe(dirname, getFileInfo(output.schemas).dirname)
+      ? upath.relativeSafe(
+          dirname,
+          getFileInfo(output.schemas, { extension: output.extension }).dirname,
+        )
       : './' + filename + '.schemas';
 
     const isAllowSyntheticDefaultImports = isSyntheticDefaultImportsAllow(

--- a/packages/core/src/writers/split-mode.ts
+++ b/packages/core/src/writers/split-mode.ts
@@ -22,7 +22,7 @@ export const writeSplitMode = async ({
   try {
     const { filename, dirname, extension } = getFileInfo(output.target, {
       backupFilename: camel(builder.info.title),
-      extension: output.extension,
+      extension: output.fileExtension,
     });
 
     const {
@@ -43,7 +43,8 @@ export const writeSplitMode = async ({
     const relativeSchemasPath = output.schemas
       ? upath.relativeSafe(
           dirname,
-          getFileInfo(output.schemas, { extension: output.extension }).dirname,
+          getFileInfo(output.schemas, { extension: output.fileExtension })
+            .dirname,
         )
       : './' + filename + '.schemas';
 

--- a/packages/core/src/writers/split-tags-mode.ts
+++ b/packages/core/src/writers/split-tags-mode.ts
@@ -22,6 +22,7 @@ export const writeSplitTagsMode = async ({
 }: WriteModeProps): Promise<string[]> => {
   const { filename, dirname, extension } = getFileInfo(output.target, {
     backupFilename: camel(builder.info.title),
+    extension: output.extension,
   });
 
   const target = generateTargetForTags(builder, output);
@@ -50,7 +51,11 @@ export const writeSplitTagsMode = async ({
 
         const relativeSchemasPath = output.schemas
           ? '../' +
-            upath.relativeSafe(dirname, getFileInfo(output.schemas).dirname)
+            upath.relativeSafe(
+              dirname,
+              getFileInfo(output.schemas, { extension: output.extension })
+                .dirname,
+            )
           : '../' + filename + '.schemas';
 
         const importsForBuilder =

--- a/packages/core/src/writers/split-tags-mode.ts
+++ b/packages/core/src/writers/split-tags-mode.ts
@@ -22,7 +22,7 @@ export const writeSplitTagsMode = async ({
 }: WriteModeProps): Promise<string[]> => {
   const { filename, dirname, extension } = getFileInfo(output.target, {
     backupFilename: camel(builder.info.title),
-    extension: output.extension,
+    extension: output.fileExtension,
   });
 
   const target = generateTargetForTags(builder, output);
@@ -53,7 +53,7 @@ export const writeSplitTagsMode = async ({
           ? '../' +
             upath.relativeSafe(
               dirname,
-              getFileInfo(output.schemas, { extension: output.extension })
+              getFileInfo(output.schemas, { extension: output.fileExtension })
                 .dirname,
             )
           : '../' + filename + '.schemas';

--- a/packages/core/src/writers/tags-mode.ts
+++ b/packages/core/src/writers/tags-mode.ts
@@ -21,7 +21,7 @@ export const writeTagsMode = async ({
 }: WriteModeProps): Promise<string[]> => {
   const { filename, dirname, extension } = getFileInfo(output.target, {
     backupFilename: camel(builder.info.title),
-    extension: output.extension,
+    extension: output.fileExtension,
   });
 
   const target = generateTargetForTags(builder, output);
@@ -50,7 +50,7 @@ export const writeTagsMode = async ({
         const schemasPathRelative = output.schemas
           ? upath.relativeSafe(
               dirname,
-              getFileInfo(output.schemas, { extension: output.extension })
+              getFileInfo(output.schemas, { extension: output.fileExtension })
                 .dirname,
             )
           : './' + filename + '.schemas';

--- a/packages/core/src/writers/tags-mode.ts
+++ b/packages/core/src/writers/tags-mode.ts
@@ -21,6 +21,7 @@ export const writeTagsMode = async ({
 }: WriteModeProps): Promise<string[]> => {
   const { filename, dirname, extension } = getFileInfo(output.target, {
     backupFilename: camel(builder.info.title),
+    extension: output.extension,
   });
 
   const target = generateTargetForTags(builder, output);
@@ -47,7 +48,11 @@ export const writeTagsMode = async ({
         let data = header;
 
         const schemasPathRelative = output.schemas
-          ? upath.relativeSafe(dirname, getFileInfo(output.schemas).dirname)
+          ? upath.relativeSafe(
+              dirname,
+              getFileInfo(output.schemas, { extension: output.extension })
+                .dirname,
+            )
           : './' + filename + '.schemas';
 
         const importsForBuilder = [

--- a/packages/orval/src/utils/options.ts
+++ b/packages/orval/src/utils/options.ts
@@ -102,6 +102,8 @@ export const normalizeOptions = async (
     };
   }
 
+  const defaultExtension = '.ts';
+
   const normalizedOptions: NormalizedOptions = {
     input: {
       target: globalOptions.input
@@ -126,6 +128,7 @@ export const normalizeOptions = async (
         ? normalizePath(globalOptions.output, process.cwd())
         : normalizePath(outputOptions.target, outputWorkspace),
       schemas: normalizePath(outputOptions.schemas, outputWorkspace),
+      extension: outputOptions.extension || defaultExtension,
       workspace: outputOptions.workspace ? outputWorkspace : undefined,
       client: outputOptions.client ?? client ?? OutputClient.AXIOS_FUNCTIONS,
       mode: normalizeOutputMode(outputOptions.mode ?? mode),

--- a/packages/orval/src/utils/options.ts
+++ b/packages/orval/src/utils/options.ts
@@ -102,7 +102,7 @@ export const normalizeOptions = async (
     };
   }
 
-  const defaultExtension = '.ts';
+  const defaultFileExtension = '.ts';
 
   const normalizedOptions: NormalizedOptions = {
     input: {
@@ -128,7 +128,7 @@ export const normalizeOptions = async (
         ? normalizePath(globalOptions.output, process.cwd())
         : normalizePath(outputOptions.target, outputWorkspace),
       schemas: normalizePath(outputOptions.schemas, outputWorkspace),
-      extension: outputOptions.extension || defaultExtension,
+      fileExtension: outputOptions.fileExtension || defaultFileExtension,
       workspace: outputOptions.workspace ? outputWorkspace : undefined,
       client: outputOptions.client ?? client ?? OutputClient.AXIOS_FUNCTIONS,
       mode: normalizeOutputMode(outputOptions.mode ?? mode),


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

I added `output.fileExtension` option to possible specifying the extension of the generated file. So, are able to change the automatically generated client code extension to like a `pets.gen.ts`. The default is still `.ts`.
Furthermore, by configuring the following settings, you will be able to generate code with both `client` and `zod`.

`orval.config.js`:

```
import { defineConfig } from "orval";

export default defineConfig({
  petstore: {
    input: {
      target: './petstore.yaml',
    },
    output: {
      client: 'swr',
      mode: 'tags-split',
      target: 'src/gen/endpoints',
      schemas: 'src/gen/model',
      mock: true
    },
  },
  petstoreZod: {
    input: {
      target: './petstore.yaml',
    },
    output: {
      client: 'zod',
      mode: 'tags-split',
      target: 'src/gen/endpoints',
      schemas: 'src/gen/model',
      fileExtension: '.zod.ts',
    },
  },
});
```

generated files:

```
src/gen/
├── endpoints
│   └── pets
│       ├── pets.msw.ts
│       ├── pets.ts
│       └── pets.zod.ts
└── model
    ├── error.ts
    ├── index.ts
    ├── listPetsParams.ts
    ├── pet.ts
    ├── pets.ts
    └── showPetByIdParams.ts
```

This further expands the convenience of orval for me.

## Related PRs

none

## Todos

- [ ] Tests
- [x] Documentation
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce

Configure the following settings and check whether the automatically generated source code is broken.

```
import { defineConfig } from "orval";

export default defineConfig({
  petstore: {
    input: {
      target: './petstore.yaml',
    },
    output: {
      client: 'swr',
      mode: 'tags-split',
      target: 'src/gen/endpoints',
      schemas: 'src/gen/model',
      mock: true
    },
  },
  petstoreZod: {
    input: {
      target: './petstore.yaml',
    },
    output: {
      client: 'zod',
      mode: 'tags-split',
      target: 'src/gen/endpoints',
      schemas: 'src/gen/model',
      fileExtension: '.zod.ts',
    },
  },
});
```