### PR TITLE
feat(core): add option to apply `biome` to generated files

### DIFF
--- a/docs/src/pages/reference/configuration/output.md
+++ b/docs/src/pages/reference/configuration/output.md
@@ -389,6 +389,16 @@ Default Value: `false`.
 
 Can be used to specify `tslint` ([TSLint is deprecated in favour of eslint + plugins](https://github.com/palantir/tslint#tslint)) as typescript linter instead of `eslint`. You need to have tslint in your dependencies.
 
+### biome
+
+Type: `Boolean`.
+
+Default Value: `false`.
+
+You can apply `lint` and `format` of [`biome`](https://biomejs.dev/) to the generated file. You need to have `@biomejs/biome` in your dependencies.
+
+The automatically generated source code does not comply with some lint rules included in the default ruleset for `biome`, so please control them in the your `biome` configuration file.
+
 ### headers
 
 Type: `Boolean`.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -51,6 +51,7 @@ export type NormalizedOutputOptions = {
   clean: boolean | string[];
   prettier: boolean;
   tslint: boolean;
+  biome: boolean;
   tsconfig?: Tsconfig;
   packageJson?: PackageJson;
   headers: boolean;
@@ -171,6 +172,7 @@ export type OutputOptions = {
   clean?: boolean | string[];
   prettier?: boolean;
   tslint?: boolean;
+  biome?: boolean;
   tsconfig?: string | Tsconfig;
   packageJson?: string;
   headers?: boolean;
@@ -527,6 +529,7 @@ export interface GlobalOptions {
   clean?: boolean | string[];
   prettier?: boolean;
   tslint?: boolean;
+  biome?: boolean;
   mock?: boolean | GlobalMockOptions;
   client?: OutputClient;
   mode?: OutputMode;

--- a/packages/orval/src/bin/orval.ts
+++ b/packages/orval/src/bin/orval.ts
@@ -38,6 +38,7 @@ cli
   .option('--clean [path]', 'Clean output directory')
   .option('--prettier [path]', 'Prettier generated files')
   .option('--tslint [path]', 'tslint generated files')
+  .option('--biome [path]', 'biome generated files')
   .option('--tsconfig [path]', 'path to your tsconfig file')
   .action(async (paths, cmd) => {
     if (!cmd.config && isString(cmd.input) && isString(cmd.output)) {
@@ -48,6 +49,7 @@ cli
           clean: cmd.clean,
           prettier: cmd.prettier,
           tslint: cmd.tslint,
+          biome: cmd.biome,
           mock: cmd.mock,
           client: cmd.client,
           mode: cmd.mode,
@@ -81,6 +83,7 @@ cli
         clean: cmd.clean,
         prettier: cmd.prettier,
         tslint: cmd.tslint,
+        biome: cmd.biome,
         mock: cmd.mock,
         client: cmd.client,
         mode: cmd.mode,

--- a/packages/orval/src/utils/options.ts
+++ b/packages/orval/src/utils/options.ts
@@ -78,7 +78,7 @@ export const normalizeOptions = async (
     workspace,
   );
 
-  const { clean, prettier, client, mode, tslint } = globalOptions;
+  const { clean, prettier, client, mode, tslint, biome } = globalOptions;
 
   const tsconfig = await loadTsconfig(
     outputOptions.tsconfig || globalOptions.tsconfig,
@@ -136,6 +136,7 @@ export const normalizeOptions = async (
       clean: outputOptions.clean ?? clean ?? false,
       prettier: outputOptions.prettier ?? prettier ?? false,
       tslint: outputOptions.tslint ?? tslint ?? false,
+      biome: outputOptions.biome ?? biome ?? false,
       tsconfig,
       packageJson,
       headers: outputOptions.headers ?? false,

--- a/packages/orval/src/write-specs.ts
+++ b/packages/orval/src/write-specs.ts
@@ -180,6 +180,19 @@ export const writeSpecs = async (
     }
   }
 
+  if (output.biome) {
+    try {
+      await execa('biome', ['check', '--apply', ...paths]);
+    } catch (e: any) {
+      const message =
+        e.exitCode === 1
+          ? e.stderr
+          : `⚠️  ${projectTitle ? `${projectTitle} - ` : ''}biome not found`;
+
+      log(chalk.yellow(message));
+    }
+  }
+
   createSuccessMessage(projectTitle);
 };
 

--- a/packages/orval/src/write-specs.ts
+++ b/packages/orval/src/write-specs.ts
@@ -186,7 +186,7 @@ export const writeSpecs = async (
     } catch (e: any) {
       const message =
         e.exitCode === 1
-          ? e.stderr
+          ? e.stdout + e.stderr
           : `⚠️  ${projectTitle ? `${projectTitle} - ` : ''}biome not found`;
 
       log(chalk.yellow(message));


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

fix https://github.com/anymaniax/orval/issues/1298

I Added option to apply `Biome` to automatically generated files.
`Biome` also has a command that runs only `format`, but will be `orval` supports the `check --apply` command that runs both `format` and `lint`. Because, if you only want to apply either `format` or `lint`, you can control it with the `Biome` configuration file.

## Related PRs

none

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

1. execute `orval` cli command with `--biome` option and make sure `biome` executes together.

```bash
orval --biome
```

1. you define `biome` to `true` in `orval.config.js` like a bellow, then execute `orval` and make sure `biome` executes together.

```javascript
import { defineConfig } from 'orval';

export default defineConfig({
  petstoreFile: {
    input: {
      target: './petstore.yaml',
    },
    output: {
      client: 'swr',
      target: 'src/gen/endpoints',
      schemas: 'src/gen/model',
      biome: true,
    },
  },
});
```
