### PR TITLE
fix(MSW): fixed so that `Function` can be accepted with `mock` option

### DIFF
--- a/packages/orval/src/utils/options.ts
+++ b/packages/orval/src/utils/options.ts
@@ -93,6 +93,7 @@ export const normalizeOptions = async (
   let mock = outputOptions.mock ?? globalOptions.mock;
   if (typeof mock === 'boolean' && mock) {
     mock = DEFAULT_MOCK_OPTIONS;
+  } else if (isFunction(mock)) {
   } else if (!mock) {
     mock = undefined;
   } else {


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

fix https://github.com/anymaniax/orval/issues/1293

This has been fixed because when `Function` is specified in the `mock` option, the value is lost when nomilize is executed.

## Related PRs

none

## Todos

- [x] Tests
- [x] Documentation
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce

Specify the `Function` that implements `ClientMockBuilder` as the `mock` option and run `orval`. auto generated source code is generated using the specified builder function.

```javascript
import { defineConfig } from 'orval';

export default defineConfig({
  petstoreFile: {
    input: {
      target: './petstore.yaml',
    },
    output: {
      mode: 'tags-split',
      client: 'swr',
      target: 'src/gen/endpoints',
      schemas: 'src/gen/model',
      mock: (verbOptions, generatorOptions) => {
        const imports = '';
        const handlerName = `${verbOptions.operationId}MockHandler`;

        return { 
          imports: imports,
          implementation: {
          function: '',
          handlerName: handlerName,
          handler: `const ${handlerName} = () => { return { data: { id: 1, name: "myName" } } }\n`,
        } };
      },
    },
  },
});
```