### PR TITLE
orval/query - override shouldExportHttpClient / shouldExportQueryKey flags introduced

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -410,6 +410,8 @@ export type NormalizedQueryOptions = {
   queryOptions?: NormalizedMutator;
   mutationOptions?: NormalizedMutator;
   shouldExportMutatorHooks?: boolean;
+  shouldExportHttpClient?: boolean;
+  shouldExportQueryKey?: boolean;
   signal?: boolean;
   version?: 3 | 4 | 5;
 };
@@ -427,6 +429,8 @@ export type QueryOptions = {
   queryOptions?: Mutator;
   mutationOptions?: Mutator;
   shouldExportMutatorHooks?: boolean;
+  shouldExportHttpClient?: boolean;
+  shouldExportQueryKey?: boolean;
   signal?: boolean;
   version?: 3 | 4 | 5;
 };

--- a/packages/orval/src/utils/options.ts
+++ b/packages/orval/src/utils/options.ts
@@ -211,10 +211,15 @@ export const normalizeOptions = async (
         },
         hono: normalizeHonoOptions(outputOptions.override?.hono, workspace),
         query: {
-          useQuery: true,
-          useMutation: true,
-          signal: true,
-          shouldExportMutatorHooks: true,
+          useQuery: outputOptions.override?.query?.useQuery ?? true,
+          useMutation: outputOptions.override?.query?.useMutation ?? true,
+          signal: outputOptions.override?.query?.signal ?? true,
+          shouldExportMutatorHooks:
+              outputOptions.override?.query?.shouldExportMutatorHooks ?? true,
+          shouldExportHttpClient:
+              outputOptions.override?.query?.shouldExportHttpClient ?? true,
+          shouldExportQueryKey:
+              outputOptions.override?.query?.shouldExportQueryKey ?? true,
           ...normalizeQueryOptions(outputOptions.override?.query, workspace),
         },
         zod: {
@@ -509,6 +514,12 @@ const normalizeQueryOptions = (
       : {}),
     ...(!isUndefined(queryOptions.shouldExportMutatorHooks)
       ? { shouldExportMutatorHooks: queryOptions.shouldExportMutatorHooks }
+      : {}),
+    ...(!isUndefined(queryOptions.shouldExportQueryKey)
+      ? { shouldExportQueryKey: queryOptions.shouldExportQueryKey }
+      : {}),
+    ...(!isUndefined(queryOptions.shouldExportHttpClient)
+      ? { shouldExportHttpClient: queryOptions.shouldExportHttpClient }
       : {}),
     ...(!isUndefined(queryOptions.signal)
       ? { signal: queryOptions.signal }

--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -466,7 +466,7 @@ const generateQueryRequestFunction = (
     `;
     }
 
-    return `export const ${operationName} = (\n    ${propsImplementation}\n ${
+    return `${override.query.shouldExportHttpClient ? 'export ' : ''}const ${operationName} = (\n    ${propsImplementation}\n ${
       isRequestOptions && mutator.hasSecondArg
         ? `options?: SecondParameter<typeof ${mutator.name}>,`
         : ''
@@ -1302,7 +1302,7 @@ const generateQueryHook = async (
       : `\`${route}\``;
 
     // Note: do not unref() params in Vue - this will make key lose reactivity
-    const queryKeyFn = `export const ${queryKeyFnName} = (${queryKeyProps}) => {
+    const queryKeyFn = `${override.query.shouldExportQueryKey ? 'export ' : ''}const ${queryKeyFnName} = (${queryKeyProps}) => {
     return [${routeString}${queryParams ? ', ...(params ? [params]: [])' : ''}${
       body.implementation ? `, ${body.implementation}` : ''
     }] as const;

--- a/packages/query/src/utils.ts
+++ b/packages/query/src/utils.ts
@@ -47,10 +47,16 @@ export const normalizeQueryOptions = (
           ),
         }
       : {}),
+    ...(queryOptions.signal ? { signal: true } : {}),
     ...(queryOptions.shouldExportMutatorHooks
       ? { shouldExportMutatorHooks: true }
       : {}),
-    ...(queryOptions.signal ? { signal: true } : {}),
+    ...(queryOptions.shouldExportQueryKey
+      ? { shouldExportQueryKey: true }
+      : {}),
+    ...(queryOptions.shouldExportHttpClient
+      ? { shouldExportHttpClient: true }
+      : {}),
   };
 };
 


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

**Feature**
New overrides for react-query:
- shouldExportQueryKey - flag enabling/disabling QueryKey export
- shouldExportHttpClient - flag enabling/disabling "raw" Axios client export

**Bugfix**
seems like react-query/overrides did not work - they were defaulting to "true" :)

## Todos

- [ ] Tests
- [x] Documentation
- [X] Changelog Entry (unreleased)
