### PR TITLE
chore: mock generator builer type to strict

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -760,13 +760,21 @@ export type ClientDependenciesBuilder = (
   packageJson?: PackageJson,
 ) => GeneratorDependency[];
 
+export type ClientMockGeneratorImplementation = {
+  function: string;
+  handlerName: string;
+  handler: string;
+};
+
+export type ClientMockGeneratorBuilder = {
+  imports: GeneratorImport[];
+  implementation: ClientMockGeneratorImplementation;
+};
+
 export type ClientMockBuilder = (
   verbOptions: GeneratorVerbOptions,
   generatorOptions: GeneratorOptions,
-) => {
-  imports: string[];
-  implementation: string;
-};
+) => ClientMockGeneratorBuilder;
 
 export interface ClientGeneratorsBuilder {
   client: ClientBuilder;

--- a/packages/mock/src/msw/index.ts
+++ b/packages/mock/src/msw/index.ts
@@ -9,6 +9,7 @@ import {
   isObject,
   pascal,
   ResReqTypesValue,
+  ClientMockGeneratorBuilder,
 } from '@orval/core';
 import { getRouteMSW, overrideVarName } from '../faker/getters';
 import { getMockDefinition, getMockOptionsDataOverride } from './mocks';
@@ -142,7 +143,7 @@ export const ${handlerName} = (${isReturnHttpResponse && !isTextPlain ? `overrid
 export const generateMSW = (
   generatorVerbOptions: GeneratorVerbOptions,
   generatorOptions: GeneratorOptions,
-) => {
+): ClientMockGeneratorBuilder => {
   const { pathRoute, override, mock } = generatorOptions;
   const { operationId, response } = generatorVerbOptions;
 

--- a/packages/orval/src/client.ts
+++ b/packages/orval/src/client.ts
@@ -249,7 +249,6 @@ export const generateOperations = (
         imports: client.imports,
         // @ts-expect-error // FIXME
         implementationMock: generatedMock.implementation,
-        // @ts-expect-error // FIXME
         importsMock: generatedMock.imports,
         tags: verbOption.tags,
         mutator: verbOption.mutator,


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY/WIP/HOLD**

## Description

`ClientMockBuilder` is old and not working, so i fixed it. And i sepalated types. And I removed the unnecessary `@ts-expect-error` comment

## Related PRs

none

## Todos

- [x] Tests
- [x] Documentation
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce

That all tests pass
