### PR TITLE
fix: allParamsOptional implemented in params and props

### DIFF
--- a/packages/core/src/generators/verbs-options.ts
+++ b/packages/core/src/generators/verbs-options.ts
@@ -136,6 +136,7 @@ const generateVerbOptions = async ({
     headers,
     operationName,
     context,
+    output,
   });
 
   const mutator = await generateMutator({

--- a/packages/core/src/getters/params.ts
+++ b/packages/core/src/getters/params.ts
@@ -91,16 +91,20 @@ export const getParams = ({
     });
 
     let paramType = resolvedValue.value;
-    if (output.allParamsOptional) {
-      paramType = `${paramType} | undefined | null`; // TODO: maybe check that `paramType` isn't already undefined or null
-    }
 
     const definition = `${name}${
-      !required || resolvedValue.originalSchema!.default ? '?' : ''
+      !required ||
+      resolvedValue.originalSchema!.default ||
+      output.allParamsOptional
+        ? '?'
+        : ''
     }: ${resolvedValue.value}`;
 
     const implementation = `${name}${
-      !required && !resolvedValue.originalSchema!.default ? '?' : ''
+      (!required && !resolvedValue.originalSchema!.default) ||
+      output.allParamsOptional
+        ? '?'
+        : ''
     }${
       !resolvedValue.originalSchema!.default
         ? `: ${paramType}`

--- a/packages/core/src/getters/props.ts
+++ b/packages/core/src/getters/props.ts
@@ -5,6 +5,7 @@ import {
   GetterProps,
   GetterPropType,
   GetterQueryParam,
+  NormalizedOutputOptions,
 } from '../types';
 import { isUndefined, pascal, sortByPriority } from '../utils';
 
@@ -15,6 +16,7 @@ export const getProps = ({
   operationName,
   headers,
   context,
+  output,
 }: {
   body: GetterBody;
   queryParams?: GetterQueryParam;
@@ -22,41 +24,48 @@ export const getProps = ({
   operationName: string;
   headers?: GetterQueryParam;
   context: ContextSpecs;
+  output: NormalizedOutputOptions;
 }): GetterProps => {
   const bodyProp = {
     name: body.implementation,
-    definition: `${body.implementation}${body.isOptional ? '?' : ''}: ${body.definition}`,
-    implementation: `${body.implementation}${body.isOptional ? '?' : ''}: ${body.definition}`,
+    definition: `${body.implementation}${body.isOptional || output.allParamsOptional ? '?' : ''}: ${body.definition}`,
+    implementation: `${body.implementation}${body.isOptional || output.allParamsOptional ? '?' : ''}: ${body.definition}`,
     default: false,
-    required: !body.isOptional,
+    required: output.allParamsOptional ? false : !body.isOptional,
     type: GetterPropType.BODY,
   };
 
   const queryParamsProp = {
     name: 'params',
-    definition: `params${queryParams?.isOptional ? '?' : ''}: ${
+    definition: `params${queryParams?.isOptional || output.allParamsOptional ? '?' : ''}: ${
       queryParams?.schema.name
     }`,
-    implementation: `params${queryParams?.isOptional ? '?' : ''}: ${
+    implementation: `params${queryParams?.isOptional || output.allParamsOptional ? '?' : ''}: ${
       queryParams?.schema.name
     }`,
     default: false,
-    required: !isUndefined(queryParams?.isOptional)
-      ? !queryParams?.isOptional
-      : false,
+    required: output.allParamsOptional
+      ? false
+      : !isUndefined(queryParams?.isOptional)
+        ? !queryParams?.isOptional
+        : false,
     type: GetterPropType.QUERY_PARAM,
   };
 
   const headersProp = {
     name: 'headers',
-    definition: `headers${headers?.isOptional ? '?' : ''}: ${
+    definition: `headers${headers?.isOptional || output.allParamsOptional ? '?' : ''}: ${
       headers?.schema.name
     }`,
-    implementation: `headers${headers?.isOptional ? '?' : ''}: ${
+    implementation: `headers${headers?.isOptional || output.allParamsOptional ? '?' : ''}: ${
       headers?.schema.name
     }`,
     default: false,
-    required: !isUndefined(headers?.isOptional) ? !headers?.isOptional : false,
+    required: output.allParamsOptional
+      ? false
+      : !isUndefined(headers?.isOptional)
+        ? !headers?.isOptional
+        : false,
     type: GetterPropType.HEADER,
   };
 


### PR DESCRIPTION
## Status

Ready

Fix #1322 

## Description

- Enhanced the current build setting allParamsOptional (refer to https://github.com/anymaniax/orval/issues/1322).
- Fixed/removed the TODO comment (`Maybe ensure that 'paramType' isn't already undefined or null`). In my view, optional signifies a property marked with a ?, rather than extending the type with `| undefined | null`.

I experimented with these adjustments locally in a playground project using Orval clients: default (axios), vue-query, and Angular. 
I have created a draft PR to ensure that my changes pass all the pipeline tests. 
These adjustments are to the core, so I hope that by testing them with all the mentioned setups, I have thoroughly validated my changes. 

Please feel free to double-check before approving my PR

## Related PRs

n/a

## Todos

n/a

## Steps to Test or Reproduce

n/a
