### PR TITLE
fix(msw): make sure to early out when detecting loop in additionalproperties

### DIFF
--- a/packages/mock/src/faker/getters/object.ts
+++ b/packages/mock/src/faker/getters/object.ts
@@ -149,6 +149,14 @@ export const getMockObject = ({
     if (isBoolean(item.additionalProperties)) {
       return { value: `{}`, imports: [], name: item.name };
     }
+    if (
+      isReference(item.additionalProperties) &&
+      existingReferencedProperties.includes(
+        item.additionalProperties.$ref.split('/').pop()!,
+      )
+    ) {
+      return { value: `{}`, imports: [], name: item.name };
+    }
 
     const resolvedValue = resolveMockValue({
       schema: {

--- a/packages/mock/src/msw/mocks.ts
+++ b/packages/mock/src/msw/mocks.ts
@@ -100,7 +100,7 @@ const getMockScalarJsTypes = (
             `min: ${mockOptionsWithoutFunc.arrayMin}, ` +
             `max: ${mockOptionsWithoutFunc.arrayMax}}` +
             `)}, () => faker.number.int())`
-        : 'faker.number.int().toString()';
+        : 'faker.number.int()';
     case 'string':
       return isArray
         ? `Array.from({length: faker.number.int({` +


### PR DESCRIPTION
## Status

**READY**

## Description

Fixes #1347 
Running generate on the attached api definition resulted in an error, where `getGetNextResponseMock = (): number` returned a string. Also fixed this, unsure why it hasn't been an issue before?

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

Follow the steps in the issue
