### PR TITLE
feat: allow override for mock handlers to be a function

### DIFF
--- a/packages/mock/src/msw/index.ts
+++ b/packages/mock/src/msw/index.ts
@@ -95,10 +95,10 @@ const generateDefinition = (
     : '';
 
   const delay = getDelay(override, !isFunction(mock) ? mock : undefined);
-  const handlerHasOverride = isReturnHttpResponse && !isTextPlain;
-  const infoParam = handlerHasOverride ? 'info' : '';
+  const isHandlerOverridden = isReturnHttpResponse && !isTextPlain;
+  const infoParam = isHandlerOverridden ? 'info' : '';
   const handlerImplementation = `
-export const ${handlerName} = (${handlerHasOverride ? `overrideResponse?: ${returnType} | ((${infoParam}: Parameters<Parameters<typeof http.${verb}>[1]>[0]) => ${returnType})` : ''}) => {
+export const ${handlerName} = (${isHandlerOverridden ? `overrideResponse?: ${returnType} | ((${infoParam}: Parameters<Parameters<typeof http.${verb}>[1]>[0]) => ${returnType})` : ''}) => {
   return http.${verb}('${route}', ${
     delay === false
       ? `(${infoParam}) => {`


### PR DESCRIPTION
## Status

**READY**

## Description

Fixes #1329 
Adds the ability to pass a function into mock handlers as override

## Steps to Test or Reproduce

yarn generate with a config that has mock: true
check mock handlers, the override parameter should be able to be a function as well