### PR TITLE
feat: use string literals for const properties

### DIFF
--- a/packages/core/src/getters/object.ts
+++ b/packages/core/src/getters/object.ts
@@ -1,14 +1,15 @@
 import { ReferenceObject, SchemaObject } from 'openapi3-ts/oas30';
 import { resolveExampleRefs, resolveObject, resolveValue } from '../resolvers';
-import { ContextSpecs, ScalarValue, SchemaType } from '../types';
+import {
+  ContextSpecs,
+  ScalarValue,
+  SchemaType,
+  SchemaWithConst,
+} from '../types';
 import { isBoolean, isReference, jsDoc, pascal } from '../utils';
 import { combineSchemas } from './combine';
 import { getKey } from './keys';
 import { getRefInfo } from './ref';
-
-interface SchemaWithConst extends SchemaObject {
-  const: string;
-}
 
 /**
  * Return the output type from an object

--- a/packages/core/src/getters/scalar.ts
+++ b/packages/core/src/getters/scalar.ts
@@ -1,5 +1,10 @@
 import { SchemaObject } from 'openapi3-ts/oas30';
-import { ContextSpecs, ScalarValue, OutputClient } from '../types';
+import {
+  ContextSpecs,
+  ScalarValue,
+  OutputClient,
+  SchemaWithConst,
+} from '../types';
 import { escape, isString } from '../utils';
 import { getArray } from './array';
 import { getObject } from './object';
@@ -25,6 +30,9 @@ export const getScalar = ({
   const nullable = item.nullable && !isAngularClient ? ' | null' : '';
 
   const enumItems = item.enum?.filter((enumItem) => enumItem !== null);
+
+  const itemWithConst = item as SchemaWithConst;
+  const isConst = itemWithConst.const !== undefined;
 
   if (!item.type && item.items) {
     item.type = 'array';
@@ -101,6 +109,10 @@ export const getScalar = ({
 
       if (item.format === 'binary') {
         value = 'Blob';
+      }
+
+      if (isConst) {
+        value = `'${itemWithConst.const}'`;
       }
 
       if (context.output.override.useDates) {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1037,3 +1037,7 @@ export type GeneratorApiBuilder = GeneratorApiOperations & {
   importsMock: GenerateMockImports;
   extraFiles: ClientFileBuilder[];
 };
+
+export interface SchemaWithConst extends SchemaObject {
+  const: string;
+}

--- a/tests/configs/swr.config.ts
+++ b/tests/configs/swr.config.ts
@@ -189,4 +189,15 @@ export default defineConfig({
       target: '../specifications/optional-request-body.yaml',
     },
   },
+  constants: {
+    output: {
+      target: '../generated/swr/constants/endpoints.ts',
+      schemas: '../generated/swr/constants/model',
+      client: 'swr',
+      mock: true,
+    },
+    input: {
+      target: '../specifications/constants.yaml',
+    },
+  },
 });

--- a/tests/specifications/constants.yaml
+++ b/tests/specifications/constants.yaml
@@ -1,0 +1,60 @@
+openapi: 3.1.0
+info:
+  title: Constants
+  version: 1.0.0
+paths:
+  /api/cat:
+    get:
+      summary: sample cat
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Cat'
+  /api/nullable-cat:
+    get:
+      summary: sample nullable cat
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NullableCat'
+  /api/dog:
+    get:
+      summary: sample dog
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Dog'
+components:
+  schemas:
+    Cat:
+      type: object
+      required: ['type']
+      properties:
+        type:
+          type: string
+          const: cat
+    NullableCat:
+      type: object
+      required: ['type']
+      properties:
+        type:
+          type:
+            - string
+            - 'null'
+          const: cat
+    Dog:
+      type: object
+      required: ['type']
+      properties:
+        type:
+          type: string
+          const: dog


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**WIP**

## Description

Fix #1326 to use [string literal types](https://www.typescriptlang.org/docs/handbook/literal-types.html#string-literal-types) for `const` properties defined in an OAS 3.1 schema. OAS 3.1 [introduced the `const` property](https://www.apimatic.io/blog/2021/09/migrating-to-and-from-openapi-3-1) as an alternative to single-valued enums. Previously, Orval did not generate string literal types for constant strings but instead typed them as just `string`. With this change, properties with `type: string` and a `const` keyword are transformed to their literal values as their type.

I've included a new specification that has different values and nullable versions of `const` properties. However, the `example-v3-1.yaml` specification also has a `const` property which is now also generated correctly. I'll be happy to remove the new spec if it's not needed.

## Related PRs

[A previous PR](https://github.com/anymaniax/orval/pull/1180) fixed a problem with the `const` keyword where the type was being interpreted as `unknown`. However, this fix does not make it so string constants have their value as their type.

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

Outline the steps to test or reproduce the PR here.

```bash
> git pull --prune
> git checkout <branch>
> grunt jasmine
```

1. Generate the test specifications using `yarn generate` from the `tests` folder
2. Observe the generated types in `tests/generated/default/example-v3-1/model/test.ts` and `tests/generated/swr/constants/model/*.ts`
3. The properties marked with `const` should have a string literal type instead of just `string`
