### PR TITLE
fix(mocks): handle OpenAPI 3.1 nullability

### DIFF
--- a/packages/mock/src/faker/getters/object.ts
+++ b/packages/mock/src/faker/getters/object.ts
@@ -72,6 +72,23 @@ export const getMockObject = ({
     });
   }
 
+  if (Array.isArray(item.type)) {
+    return combineSchemasMock({
+      item: {
+        anyOf: item.type.map((type) => ({ type })),
+        name: item.name,
+      },
+      separator: 'anyOf',
+      mockOptions,
+      operationId,
+      tags,
+      combine,
+      context,
+      imports,
+      existingReferencedProperties,
+    });
+  }
+
   if (item.properties) {
     let value =
       !combine ||

--- a/packages/mock/src/faker/getters/scalar.ts
+++ b/packages/mock/src/faker/getters/scalar.ts
@@ -248,7 +248,13 @@ export const getMockScalar = ({
       };
     }
 
-    case 'object':
+    case 'null':
+      return {
+        value: 'null',
+        imports: [],
+        name: item.name,
+      };
+
     default: {
       return getMockObject({
         item,

--- a/tests/configs/mock.config.ts
+++ b/tests/configs/mock.config.ts
@@ -104,4 +104,14 @@ export default defineConfig({
       target: '../specifications/petstore.yaml',
     },
   },
+  nullType: {
+    output: {
+      schemas: '../generated/mock/null-type/model',
+      target: '../generated/mock/null-type/endpoints.ts',
+      mock: true,
+    },
+    input: {
+      target: '../specifications/null-type.yaml',
+    },
+  },
 });


### PR DESCRIPTION
## Status

**READY**

## Description

Support for `type: [X, null]` into mocks. This PR is almost identical to the original one: https://github.com/anymaniax/orval/pull/645/files. 

I reused the #645 spec to create this test.

## Todos

- [x] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

It previously generated the following:

```ts
export const getFetchNullableResponseMock = (): FetchNullable200 => ({})
```

Now its working as intended

```ts
export const getFetchNullableResponseMock = (): FetchNullable200 =>
  faker.helpers.arrayElement([faker.word.sample(), null]);
```