### PR TITLE
fix: allow async overrideResponse to be passed to msw handler (issue 1389)

### DIFF
--- a/packages/mock/src/msw/index.ts
+++ b/packages/mock/src/msw/index.ts
@@ -109,7 +109,7 @@ const generateDefinition = (
   const isHandlerOverridden = isReturnHttpResponse && !isTextPlain;
   const infoParam = isHandlerOverridden ? 'info' : '';
   const handlerImplementation = `
-export const ${handlerName} = (${isHandlerOverridden ? `overrideResponse?: ${returnType} | ((${infoParam}: Parameters<Parameters<typeof http.${verb}>[1]>[0]) => ${returnType})` : ''}) => {
+export const ${handlerName} = (${isHandlerOverridden ? `overrideResponse?: ${returnType} | ((${infoParam}: Parameters<Parameters<typeof http.${verb}>[1]>[0]) => Promise<${returnType}> | ${returnType})` : ''}) => {
   return http.${verb}('${route}', ${
     delay === false
       ? `(${infoParam}) => {`
@@ -121,7 +121,7 @@ export const ${handlerName} = (${isHandlerOverridden ? `overrideResponse?: ${ret
         ? isTextPlain
           ? `${getResponseMockFunctionName}()`
           : `JSON.stringify(overrideResponse !== undefined 
-            ? (typeof overrideResponse === "function" ? overrideResponse(${infoParam}) : overrideResponse) 
+            ? (typeof overrideResponse === "function" ? await overrideResponse(${infoParam}) : overrideResponse)
             : ${getResponseMockFunctionName}())`
         : null
     },


### PR DESCRIPTION
## Status

**WIP**

## Description

This fixes issue 1389.

In MSW, a mock handler can access the response resolver info. For example, it can access the request body to change the response based on the request. Access to that request body is only possible through an `async` function call to `json()`.

```typescript
http.post("/some/path", async ({ request }) => {
  const requestJson = await request.json();
  // Do something with the request, such as producing a response based on it.
  return ...
});
```

In Orval, PR #1375 made it possible for the override in a MSW mock handler to be a function, and Orval passes the response resolver info to that function. However, Orval requires a synchronous method that returns a response object. It does not allow `async` functions.

Before this PR, it was not possible to migrate the above mock handler to Orval.

```typescript
getSomePathMockHandler(async ({ request }) => {  // This does not type-check. Orval does not allow a Promise<SomeResponse> return type.
  const requestJson = await request.json();
  // Do something with the request, such as producing a response based on it.
  return ...
});
```

This PR changes the code generation such that both `Promise<ResponseType> | ResponseType` is allowed as a return type for the override, analogous to what MSW does.

## Related PRs

#1375

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

_I'm not sure what's expected of me in this section._