### PR TITLE
feat: use better regex for route parameters

### DIFF
--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -28,3 +28,5 @@ export const VERBS_WITH_BODY = [
 
 export const URL_REGEX =
   /^(?:http(s)?:\/\/)?[\w.-]+(?:\.[\w\.-]+)+[\w\-\._~:/?#[\]@!\$&'\(\)\*\+,;=.]+$/;
+
+export const TEMPLATE_TAG_REGEX = /\${(.+?)}/g; // For replace of 'thing' ${thing}

--- a/packages/core/src/getters/route.ts
+++ b/packages/core/src/getters/route.ts
@@ -1,6 +1,6 @@
 import { camel, sanitize } from '../utils';
+import { TEMPLATE_TAG_REGEX } from '../constants';
 
-const TEMPLATE_TAG_REGEX = /\${(\w+)}/g; // For replace of 'thing' ${thing}
 const TEMPLATE_TAG_IN_PATH_REGEX = /\/([\w]+)(?:\$\{)/g; // all dynamic parts of path
 
 const hasParam = (path: string): boolean => /[^{]*{[\w*_-]*}.*/.test(path);

--- a/packages/query/src/utils.ts
+++ b/packages/query/src/utils.ts
@@ -11,6 +11,7 @@ import {
   upath,
   GetterProps,
   GetterPropType,
+  TEMPLATE_TAG_REGEX,
 } from '@orval/core';
 import chalk from 'chalk';
 
@@ -122,7 +123,7 @@ export const wrapRouteParameters = (
   route: string,
   prepend: string,
   append: string,
-): string => route.replaceAll(/\${(.+?)}/g, `\${${prepend}$1${append}}`);
+): string => route.replaceAll(TEMPLATE_TAG_REGEX, `\${${prepend}$1${append}}`);
 
 export const makeRouteSafe = (route: string): string =>
   wrapRouteParameters(route, 'encodeURIComponent(String(', '))');


### PR DESCRIPTION
## Status

<!--- **READY** --->

**READY**

## Description

Fixes #1084

This PR moves `TEMPLATE_TAG_REGEX` into core constants and updates it to be `/\${(.+?)}/g` as described in #1084.
It also imports this variable in `wrapRouteParameters` to reduce code duplication.

## Related PRs

#895
