### PR TITLE
fix(override): add deep merge with operations and tag options

### DIFF
--- a/packages/core/src/generators/verbs-options.ts
+++ b/packages/core/src/generators/verbs-options.ts
@@ -74,11 +74,10 @@ const generateVerbOptions = async ({
     {} as NormalizedOperationOptions,
   );
 
-  const override: NormalizedOverrideOutput = {
-    ...output.override,
-    ...overrideTag,
-    ...overrideOperation,
-  };
+  const override: NormalizedOverrideOutput = mergeDeep(
+    mergeDeep(output.override, overrideTag),
+    overrideOperation,
+  );
 
   const overrideOperationName =
     overrideOperation?.operationName || output.override?.operationName;

--- a/packages/core/src/utils/merge-deep.ts
+++ b/packages/core/src/utils/merge-deep.ts
@@ -1,11 +1,11 @@
 const isObject = (obj: unknown) => obj && typeof obj === 'object';
 
-export function mergeDeep<T extends Record<string, any>>(
-  source: T,
-  target: T,
-): T {
+export function mergeDeep<
+  T extends Record<string, any>,
+  U extends Record<string, any>,
+>(source: T, target: U): T & U {
   if (!isObject(target) || !isObject(source)) {
-    return source;
+    return source as T & U;
   }
 
   return Object.entries(target).reduce(
@@ -23,5 +23,5 @@ export function mergeDeep<T extends Record<string, any>>(
       return acc;
     },
     Object.assign({}, source),
-  );
+  ) as T & U;
 }

--- a/samples/react-query/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/react-query/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -46,15 +46,23 @@ type Awaited<O> = O extends AwaitedInput<infer T> ? T : never;
 /**
  * @summary List all pets
  */
-const listPets = (params?: ListPetsParams, version: number = 1) => {
+export const listPets = (
+  params?: ListPetsParams,
+  version: number = 1,
+  signal?: AbortSignal,
+) => {
   return customInstance<PetsArray>({
     url: `/v${version}/pets`,
     method: 'GET',
     params,
+    signal,
   });
 };
 
-const getListPetsQueryKey = (params?: ListPetsParams, version: number = 1) => {
+export const getListPetsQueryKey = (
+  params?: ListPetsParams,
+  version: number = 1,
+) => {
   return [`/v${version}/pets`, ...(params ? [params] : [])] as const;
 };
 
@@ -89,8 +97,12 @@ export const getListPetsInfiniteQueryOptions = <
     Awaited<ReturnType<typeof listPets>>,
     QueryKey,
     ListPetsParams['limit']
-  > = ({ pageParam }) =>
-    listPets({ ...params, limit: pageParam || params?.['limit'] }, version);
+  > = ({ signal, pageParam }) =>
+    listPets(
+      { ...params, limit: pageParam || params?.['limit'] },
+      version,
+      signal,
+    );
 
   return {
     queryKey,
@@ -170,8 +182,9 @@ export const getListPetsQueryOptions = <
   const queryKey =
     queryOptions?.queryKey ?? getListPetsQueryKey(params, version);
 
-  const queryFn: QueryFunction<Awaited<ReturnType<typeof listPets>>> = () =>
-    listPets(params, version);
+  const queryFn: QueryFunction<Awaited<ReturnType<typeof listPets>>> = ({
+    signal,
+  }) => listPets(params, version, signal);
 
   return {
     queryKey,
@@ -235,8 +248,9 @@ export const getListPetsSuspenseQueryOptions = <
   const queryKey =
     queryOptions?.queryKey ?? getListPetsQueryKey(params, version);
 
-  const queryFn: QueryFunction<Awaited<ReturnType<typeof listPets>>> = () =>
-    listPets(params, version);
+  const queryFn: QueryFunction<Awaited<ReturnType<typeof listPets>>> = ({
+    signal,
+  }) => listPets(params, version, signal);
 
   return {
     queryKey,
@@ -321,8 +335,12 @@ export const getListPetsSuspenseInfiniteQueryOptions = <
     Awaited<ReturnType<typeof listPets>>,
     QueryKey,
     ListPetsParams['limit']
-  > = ({ pageParam }) =>
-    listPets({ ...params, limit: pageParam || params?.['limit'] }, version);
+  > = ({ signal, pageParam }) =>
+    listPets(
+      { ...params, limit: pageParam || params?.['limit'] },
+      version,
+      signal,
+    );
 
   return {
     queryKey,


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

Currently when you provide operation or tag options it completely override the global one. This will solve the problem with a deep merge