### PR TITLE
feat(msw): take string pattern property into account when generating mocks

### DIFF
--- a/packages/mock/src/faker/getters/scalar.ts
+++ b/packages/mock/src/faker/getters/scalar.ts
@@ -7,14 +7,14 @@ import {
   mergeDeep,
   MockOptions,
 } from '@orval/core';
+import { MockDefinition, MockSchemaObject } from '../../types';
+import { DEFAULT_FORMAT_MOCK } from '../constants';
 import {
   getNullable,
   resolveMockOverride,
   resolveMockValue,
 } from '../resolvers';
-import { MockDefinition, MockSchemaObject } from '../../types';
 import { getMockObject } from './object';
-import { DEFAULT_FORMAT_MOCK } from '../constants';
 
 export const getMockScalar = ({
   item,
@@ -241,6 +241,8 @@ export const getMockScalar = ({
         value = item.path?.endsWith('[]')
           ? `faker.helpers.arrayElements(${enumValue})`
           : `faker.helpers.arrayElement(${enumValue})`;
+      } else if (item.pattern) {
+        value = `faker.helpers.fromRegExp('${item.pattern}')`;
       }
 
       return {

--- a/tests/configs/swr.config.ts
+++ b/tests/configs/swr.config.ts
@@ -189,4 +189,18 @@ export default defineConfig({
       target: '../specifications/optional-request-body.yaml',
     },
   },
+  pattern: {
+    output: {
+      target: '../generated/swr/pattern/endpoints.ts',
+      schemas: '../generated/swr/pattern/model',
+      client: 'swr',
+      mock: true,
+    },
+    input: {
+      target: '../specifications/pattern.yaml',
+      override: {
+        transformer: '../transformers/add-version.js',
+      },
+    },
+  },
 });

--- a/tests/specifications/pattern.yaml
+++ b/tests/specifications/pattern.yaml
@@ -1,0 +1,25 @@
+openapi: '3.0.0'
+info:
+  version: 1.0.0
+  title: Pattern
+paths:
+  /example:
+    get:
+      summary: Example
+      responses:
+        '200':
+          description: 'Example'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Node'
+components:
+  schemas:
+    Node:
+      type: object
+      required:
+        - guid
+      properties:
+        guid:
+          type: string
+          pattern: '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'


### PR DESCRIPTION
## Status

**READY**

## Description

Fixes #1396. String properties has an optional field 'pattern', which contains a regex pattern: [OpenAPI Spec](https://swagger.io/docs/specification/data-models/data-types/#string)
Faker has support for generating random strings based on a regex: faker.helpers.fromRegExp

## Todos

- [x] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

yarn generate:swr
check tests/generated/swr/pattern/enpoints.ts -> getGetVversionExampleResponseMock