### PR TITLE
fix(msw): fix response http status code in handler function

### DIFF
--- a/packages/mock/src/msw/index.ts
+++ b/packages/mock/src/msw/index.ts
@@ -184,7 +184,7 @@ export const generateMSW = (
     generatorVerbOptions,
     generatorOptions,
     response.definition.success,
-    '200',
+    response.types.success[0].key,
     response.imports,
     response.types.success,
     response.contentTypes,


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

Currently, the http status code of the response in the `handler` function is fixed to `200`. So I fixed it to use the first success response.

When using the following `OpenaAPI`

```yaml
paths:
  /pets:
    post:
      summary: Create a pet
      operationId: createPets
      tags:
        - pets
      requestBody:
        description: post body
        required: true
        content:
          application/json:
            schema:
              $ref: '#/components/schemas/Pet'
      responses:
        '201':
          description: Null response
```

### Before

`status` fixed `200` in `msw` definition.

```
export const getCreatePetsMockHandler = () => {
  return http.post('*/pets', async () => {
    await delay(1000);
    return new HttpResponse(null,
      {
        status: 200,
        headers: {
          'Content-Type': 'application/json',
        }
      }
    )
  })
}
```

### After

use `201` from `OpenAPI` definition.

```
export const getCreatePetsMockHandler = () => {
  return http.post('*/pets', async () => {
    await delay(1000);
    return new HttpResponse(null,
      {
        status: 201,
        headers: {
          'Content-Type': 'application/json',
        }
      }
    )
  })
}
```

## Related PRs

## Todos

- [x] Tests
- [x] Documentation
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce

You can check it by automatically generating it using the `yaml` prepared in the "Description".
