### PR TITLE
fix(swr): correct second mutator parameter when using custom mutator

### DIFF
--- a/packages/swr/src/index.ts
+++ b/packages/swr/src/index.ts
@@ -552,7 +552,7 @@ const generateSwrHook = (
     summary,
     deprecated,
   }: GeneratorVerbOptions,
-  { route }: GeneratorOptions,
+  { route, context }: GeneratorOptions,
 ) => {
   const isRequestOptions = override?.requestOptions !== false;
   const doc = jsDoc({ summary, deprecated });
@@ -695,8 +695,15 @@ export const ${swrKeyFnName} = (${queryKeyProps}) => [\`${route}\`${
     const swrMutationFetcherType = mutator
       ? `Promise<${response.definition.success || 'unknown'}>`
       : `Promise<AxiosResponse<${response.definition.success || 'unknown'}>>`;
+    const swrMutationFetcherOptionType = !mutator
+      ? 'AxiosRequestConfig'
+      : mutator.hasSecondArg
+        ? `SecondParameter<typeof ${mutator.name}>`
+        : '';
     const swrMutationFetcherOptions =
-      !mutator && isRequestOptions ? 'options?: AxiosRequestConfig' : '';
+      isRequestOptions && swrMutationFetcherOptionType
+        ? `options${context.output.optionsParamRequired ? '' : '?'}: ${swrMutationFetcherOptionType}`
+        : '';
 
     const swrMutationFetcherArg = props.some(
       (prop) => prop.type === GetterPropType.BODY,

--- a/tests/configs/swr.config.ts
+++ b/tests/configs/swr.config.ts
@@ -59,7 +59,7 @@ export default defineConfig({
       mock: true,
       override: {
         mutator: {
-          path: '../mutators/custom-instance.ts',
+          path: '../mutators/multi-arguments.ts',
           name: 'customInstance',
         },
       },
@@ -73,8 +73,8 @@ export default defineConfig({
   },
   customClient: {
     output: {
-      target: '../generated/swr/mutator/endpoints.ts',
-      schemas: '../generated/swr/mutator/model',
+      target: '../generated/swr/custom-client/endpoints.ts',
+      schemas: '../generated/swr/custom-client/model',
       client: 'swr',
       mock: true,
       override: {


### PR DESCRIPTION
## Status

**READY**

## Description

Ran into this issue in my project and noticed there was an issue describing it:
Fixes #1233 

## Todos

- [x] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

1. Use the changed swr config (without the changed code) and run generate:swr
2. Notice mutation fetchers are missing the options parameter
3. Build with changed code
4. Run generate:swr
5. Notice mutation fetchers are now correctly taking an options parameter and passing it on to the api call