### PR TITLE
feat: add `input.filters.schemas` option

### DIFF
--- a/docs/src/pages/reference/configuration/input.md
+++ b/docs/src/pages/reference/configuration/input.md
@@ -92,6 +92,25 @@ module.exports = {
 };
 ```
 
+#### schemas
+
+Type: Array of `string` or `RegExp`.
+
+Only schemas names match the specified `string` or `RegExp` will be automatically generated.
+For instance the example below only generates the `schema` object that matches string `Error` or regular expression `/Cat/`.
+
+```js
+module.exports = {
+  petstore: {
+    input: {
+      filters: {
+        schemas: ['Error', /Cat/],
+      },
+    },
+  },
+};
+```
+
 ### converterOptions
 
 Type: `Object`.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -152,10 +152,7 @@ export type NormalizedInputOptions = {
   override: OverrideInput;
   converterOptions: swagger2openapi.Options;
   parserOptions: SwaggerParserOptions;
-  filters?: {
-    tags?: (string | RegExp)[];
-    schemas?: (string | RegExp)[];
-  };
+  filters?: InputFiltersOption;
 };
 
 export type OutputClientFunc = (
@@ -191,16 +188,18 @@ export type SwaggerParserOptions = Omit<SwaggerParser.Options, 'validate'> & {
   validate?: boolean;
 };
 
+export type InputFiltersOption = {
+  tags?: (string | RegExp)[];
+  schemas?: (string | RegExp)[];
+};
+
 export type InputOptions = {
   target: string | Record<string, unknown> | OpenAPIObject;
   validation?: boolean;
   override?: OverrideInput;
   converterOptions?: swagger2openapi.Options;
   parserOptions?: SwaggerParserOptions;
-  filters?: {
-    tags?: (string | RegExp)[];
-    schemas?: (string | RegExp)[];
-  };
+  filters?: InputFiltersOption;
 };
 
 export const OutputClient = {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -154,6 +154,7 @@ export type NormalizedInputOptions = {
   parserOptions: SwaggerParserOptions;
   filters?: {
     tags?: (string | RegExp)[];
+    schemas?: (string | RegExp)[];
   };
 };
 
@@ -198,6 +199,7 @@ export type InputOptions = {
   parserOptions?: SwaggerParserOptions;
   filters?: {
     tags?: (string | RegExp)[];
+    schemas?: (string | RegExp)[];
   };
 };
 

--- a/packages/orval/src/import-open-api.ts
+++ b/packages/orval/src/import-open-api.ts
@@ -30,7 +30,7 @@ export const importOpenApi = async ({
 }: ImportOpenApi): Promise<WriteSpecsBuilder> => {
   const specs = await generateInputSpecs({ specs: data, input, workspace });
 
-  const schemas = getApiSchemas({ output, target, workspace, specs });
+  const schemas = getApiSchemas({ input, output, target, workspace, specs });
 
   const api = await getApiBuilder({
     // @ts-expect-error // FIXME
@@ -93,11 +93,13 @@ const generateInputSpecs = async ({
 };
 
 const getApiSchemas = ({
+  input,
   output,
   target,
   workspace,
   specs,
 }: {
+  input: InputOptions;
   output: NormalizedOutputOptions;
   workspace: string;
   target: string;
@@ -121,6 +123,7 @@ const getApiSchemas = ({
         parsedSchemas,
         context,
         output.override.components.schemas.suffix,
+        input.filters?.schemas,
       );
 
       const responseDefinition = generateComponentDefinition(

--- a/packages/orval/src/import-open-api.ts
+++ b/packages/orval/src/import-open-api.ts
@@ -113,10 +113,12 @@ const getApiSchemas = ({
         output,
       };
 
+      const parsedSchemas = spec.openapi
+        ? (spec.components?.schemas as SchemasObject)
+        : getAllSchemas(spec, specKey);
+
       const schemaDefinition = generateSchemasDefinition(
-        !spec.openapi
-          ? getAllSchemas(spec, specKey)
-          : (spec.components?.schemas as SchemasObject),
+        parsedSchemas,
         context,
         output.override.components.schemas.suffix,
       );

--- a/tests/configs/default.config.ts
+++ b/tests/configs/default.config.ts
@@ -6,6 +6,16 @@ export default defineConfig({
     input: '../specifications/petstore.yaml',
     output: '../generated/default/petstore/endpoints.ts',
   },
+  'petstore-filter': {
+    input: {
+      target: '../specifications/petstore.yaml',
+      filters: {
+        tags: ['health'],
+        schemas: ['Error', /Cat/],
+      },
+    },
+    output: '../generated/default/petstore-filter/endpoints.ts',
+  },
   'petstore-transfomer': {
     output: {
       target: '../generated/default/petstore-transformer/endpoints.ts',


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

i added `input.fliters.schemas` option. Because even if i use `input.fliters.tags` to filter endpoint generation, schema objects are not filtered, resulting in unnecessary files being generated. I can avoid that by using `input.fliters.schemas` together.

## Related PRs

none

## Todos

- [x] Tests
- [x] Documentation
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce

Using the test case I added, we can check.