### PR TITLE
fix(zod): treat `additionalProperties` keyword 

### DIFF
--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -229,15 +229,15 @@ export const generateZodValidationSchemaDefinition = (
       if (schema.additionalProperties) {
         functions.push([
           'additionalProperties',
-          isBoolean(schema.additionalProperties)
-            ? schema.additionalProperties
-            : generateZodValidationSchemaDefinition(
-                schema.additionalProperties as SchemaObject,
-                context,
-                true,
-                name,
-                strict,
-              ),
+          generateZodValidationSchemaDefinition(
+            isBoolean(schema.additionalProperties)
+              ? {}
+              : (schema.additionalProperties as SchemaObject),
+            context,
+            true,
+            name,
+            strict,
+          ),
         ]);
 
         break;

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -70,7 +70,7 @@ const resolveZodType = (schemaTypeValue: SchemaObject['type']) => {
 let constsUniqueCounter: Record<string, number> = {};
 
 // https://github.com/colinhacks/zod#coercion-for-primitives
-const COERCEABLE_TYPES = ['string', 'number', 'boolean', 'bigint', 'date'];
+const COERCIBLE_TYPES = ['string', 'number', 'boolean', 'bigint', 'date'];
 
 export const generateZodValidationSchemaDefinition = (
   schema: SchemaObject | undefined,
@@ -299,7 +299,7 @@ export type ZodValidationSchemaDefinitionInput = {
 
 export const parseZodValidationSchemaDefinition = (
   input: ZodValidationSchemaDefinitionInput,
-  contex: ContextSpecs,
+  context: ContextSpecs,
   coerceTypes: boolean | ZodCoerceType[] = false,
   preprocessResponse?: GeneratorMutator,
 ): { zod: string; consts: string } => {
@@ -387,11 +387,11 @@ ${Object.entries(args)
       coerceTypes &&
       (Array.isArray(coerceTypes)
         ? coerceTypes.includes(fn as ZodCoerceType)
-        : COERCEABLE_TYPES.includes(fn));
+        : COERCIBLE_TYPES.includes(fn));
 
     if (
       (fn !== 'date' && shouldCoerceType) ||
-      (fn === 'date' && shouldCoerceType && contex.output.override.useDates)
+      (fn === 'date' && shouldCoerceType && context.output.override.useDates)
     ) {
       return `.coerce.${fn}(${args})`;
     }

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, it } from 'vitest';
 import {
-  type ZodValidationSchemaDefinitionInput,
+  type ZodValidationSchemaDefinition,
   parseZodValidationSchemaDefinition,
   generateZodValidationSchemaDefinition,
 } from '.';
 import { SchemaObject } from 'openapi3-ts/oas30';
 import { ContextSpecs } from '@orval/core';
 
-const queryParams: ZodValidationSchemaDefinitionInput = {
+const queryParams: ZodValidationSchemaDefinition = {
   functions: [
     [
       'object',

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -42,6 +42,29 @@ const queryParams: ZodValidationSchemaDefinition = {
   consts: [],
 };
 
+const record: ZodValidationSchemaDefinition = {
+  functions: [
+    [
+      'object',
+      {
+        queryParams: {
+          functions: [
+            [
+              'additionalProperties',
+              {
+                functions: [['any', undefined]],
+                consts: [],
+              },
+            ],
+          ],
+          consts: [],
+        },
+      },
+    ],
+  ],
+  consts: [],
+};
+
 describe('parseZodValidationSchemaDefinition', () => {
   describe('with `override.coerceTypes = false` (default)', () => {
     it('does not emit coerced zod property schemas', () => {
@@ -82,6 +105,24 @@ describe('parseZodValidationSchemaDefinition', () => {
       );
     });
   });
+
+  it('treats additionalProperties properly', () => {
+    const parseResult = parseZodValidationSchemaDefinition(
+      record,
+      {
+        output: {
+          override: {
+            useDates: false,
+          },
+        },
+      } as ContextSpecs,
+      false,
+    );
+
+    expect(parseResult.zod).toBe(
+      'zod.object({\n  "queryParams": zod.record(zod.string(), zod.any())\n})',
+    );
+  });
 });
 
 const objectIntoObjectSchema: SchemaObject = {
@@ -115,6 +156,20 @@ const deepRequiredSchema: SchemaObject = {
           type: 'string',
         },
       },
+    },
+  },
+};
+
+const additionalPropertiesSchema: SchemaObject = {
+  type: 'object',
+  properties: {
+    any: {
+      type: 'object',
+      additionalProperties: {},
+    },
+    true: {
+      type: 'object',
+      additionalProperties: true,
     },
   },
 };
@@ -213,6 +268,60 @@ describe('generateZodValidationSchemaDefinition`', () => {
                   },
                 ],
                 ['strict', undefined],
+                ['optional', undefined],
+              ],
+              consts: [],
+            },
+          },
+        ],
+        ['strict', undefined],
+      ],
+      consts: [],
+    });
+  });
+
+  it('additionalProperties', () => {
+    const result = generateZodValidationSchemaDefinition(
+      additionalPropertiesSchema,
+      {
+        output: {
+          override: {
+            useDates: false,
+          },
+        },
+      } as ContextSpecs,
+      true,
+      'strict',
+      true,
+    );
+
+    expect(result).toEqual({
+      functions: [
+        [
+          'object',
+          {
+            any: {
+              functions: [
+                [
+                  'additionalProperties',
+                  {
+                    functions: [['any', undefined]],
+                    consts: [],
+                  },
+                ],
+                ['optional', undefined],
+              ],
+              consts: [],
+            },
+            true: {
+              functions: [
+                [
+                  'additionalProperties',
+                  {
+                    functions: [['any', undefined]],
+                    consts: [],
+                  },
+                ],
                 ['optional', undefined],
               ],
               consts: [],

--- a/tests/configs/zod.config.ts
+++ b/tests/configs/zod.config.ts
@@ -128,4 +128,13 @@ export default defineConfig({
       target: '../specifications/circular.yaml',
     },
   },
+  additionalProperties: {
+    output: {
+      target: '../generated/zod',
+      client: 'zod',
+    },
+    input: {
+      target: '../specifications/additional-properties.yaml',
+    },
+  },
 });


### PR DESCRIPTION
## Status

**READY**

## Description

`additionalProperties: true` isn't treated the right way during schema parsing, which results in runtime error during generation. Since #972 is stalled, decided to dig into it myself.

## Related PRs

Previous attempt to fix this:

| branch              | PR       |
| ------------------- | -------- |
| [CxGarcia:fix/zod-additional-properties](https://github.com/CxGarcia/orval/tree/fix/zod-additional-properties) | [link](https://github.com/anymaniax/orval/pull/972) |
