### PR TITLE
fix: generate each http status is now zod specific

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -388,6 +388,7 @@ export type ZodOptions = {
     body?: Mutator;
     response?: Mutator;
   };
+  generateEachHttpStatus?: boolean;
 };
 
 export type ZodCoerceType = 'string' | 'number' | 'boolean' | 'bigint' | 'date';
@@ -414,6 +415,7 @@ export type NormalizedZodOptions = {
     body?: NormalizedMutator;
     response?: NormalizedMutator;
   };
+  generateEachHttpStatus: boolean;
 };
 
 export type HonoOptions = {

--- a/packages/orval/src/utils/options.ts
+++ b/packages/orval/src/utils/options.ts
@@ -286,6 +286,7 @@ export const normalizeOptions = async (
                 }
               : {}),
           },
+          generateEachHttpStatus: outputOptions.override?.zod?.generateEachHttpStatus ?? false,
         },
         swr: {
           ...(outputOptions.override?.swr ?? {}),
@@ -463,6 +464,7 @@ const normalizeOperationsAndTags = (
                           }
                         : {}),
                     },
+                    generateEachHttpStatus: zod?.generateEachHttpStatus ?? false,
                   },
                 }
               : {}),

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -25,7 +25,6 @@ import {
   ZodCoerceType,
   generateMutator,
   GeneratorMutator,
-  GlobalMockOptions,
 } from '@orval/core';
 import uniq from 'lodash.uniq';
 
@@ -680,7 +679,7 @@ const generateZodRoute = async (
   });
 
   const responses = (
-    (context.output.mock as GlobalMockOptions)?.generateEachHttpStatus
+    context.output.override.zod.generateEachHttpStatus
       ? Object.entries(spec?.[verb]?.responses ?? {})
       : [['', spec?.[verb]?.responses[200]]]
   ) as [string, ResponseObject | ReferenceObject][];


### PR DESCRIPTION
## Status

<!--- **READY** --->

**READY**

## Description

This PR fixes an issues introduced in #1380 that used the mock `generateEachHttpStatus` option to determine whether to generate more reposopnes than just `200` this resolves this by adding that option to zod. 