### PR TITLE
fix(core): correctly generate ref'ed combined enums

### DIFF
--- a/packages/core/src/getters/combine.ts
+++ b/packages/core/src/getters/combine.ts
@@ -173,28 +173,17 @@ export const combineSchemas = ({
   if (isAllEnums && name && items.length > 1) {
     const newEnum = `// eslint-disable-next-line @typescript-eslint/no-redeclare\nexport const ${pascal(
       name,
-    )} = ${getCombineEnumValue(resolvedData)};\n`;
+    )} = ${getCombineEnumValue(resolvedData)}`;
 
     return {
-      value: `typeof ${pascal(name)}[keyof typeof ${pascal(name)}] ${nullable}`,
-      imports: [
-        {
-          name: pascal(name),
-        },
-      ],
-      schemas: [
-        ...resolvedData.schemas,
-        {
-          imports: resolvedData.imports.map<GeneratorImport>((toImport) => ({
-            ...toImport,
-            values: true,
-          })),
-          model: newEnum,
-          name: pascal(name),
-        },
-      ],
+      value: `typeof ${pascal(name)}[keyof typeof ${pascal(name)}] ${nullable};\n\n${newEnum}`,
+      imports: resolvedData.imports.map<GeneratorImport>((toImport) => ({
+        ...toImport,
+        values: true,
+      })),
+      schemas: [...resolvedData.schemas],
       isEnum: false,
-      type: 'object' as SchemaType,
+      type: 'object',
       isRef: false,
       hasReadonlyProps: resolvedData.hasReadonlyProps,
       example: schema.example,


### PR DESCRIPTION
## Status

**READY**

## Description

Fixes #1419 

## Steps to Test or Reproduce

Generate using the definition in the linked issue.
No error should be present and the resulting `colors.ts` file should be
```ts
import { Colors1 } from './colors1';
import { Colors2 } from './colors2';

export type Colors = (typeof Colors)[keyof typeof Colors];

// eslint-disable-next-line @typescript-eslint/no-redeclare
export const Colors = { ...Colors1, ...Colors2 } as const;
```