### PR TITLE
fix(msw): correctly generate ref'd examples

### DIFF
--- a/packages/mock/src/msw/mocks.ts
+++ b/packages/mock/src/msw/mocks.ts
@@ -145,11 +145,12 @@ export const getResponsesMockDefinition = ({
         context.output.override?.mock?.useExamples ||
         mockOptions?.useExamples
       ) {
-        const exampleValue =
+        let exampleValue =
           example ||
           originalSchema?.example ||
-          Object.values(examples || {})[0]?.value ||
+          Object.values(examples || {})[0] ||
           originalSchema?.examples?.[0];
+        exampleValue = exampleValue?.value ?? exampleValue;
         if (exampleValue) {
           acc.definitions.push(
             transformer

--- a/tests/configs/swr.config.ts
+++ b/tests/configs/swr.config.ts
@@ -217,4 +217,22 @@ export default defineConfig({
       },
     },
   },
+  examples: {
+    output: {
+      target: '../generated/swr/examples/endpoints.ts',
+      schemas: '../generated/swr/examples/model',
+      client: 'swr',
+      mock: {
+        generateEachHttpStatus: true,
+        type: 'msw',
+        useExamples: true,
+      },
+    },
+    input: {
+      target: '../specifications/examples.yaml',
+      override: {
+        transformer: '../transformers/add-version.js',
+      },
+    },
+  },
 });

--- a/tests/specifications/examples.yaml
+++ b/tests/specifications/examples.yaml
@@ -1,0 +1,50 @@
+openapi: 3.0.0
+info:
+  title: Sample API
+  version: 0.0.0
+  license:
+    name: MIT
+    url: https://opensource.org/licenses/MIT
+
+paths:
+  /users:
+    get:
+      operationId: 'get-users'
+      responses:
+        '200':
+          description: A JSON array of user names
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+              examples:
+                default:
+                  $ref: '#/components/examples/GetUsersResponseExample'
+  /users2:
+    get:
+      operationId: 'get-users-2'
+      responses:
+        '200':
+          description: A JSON array of user names
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+              examples:
+                default:
+                  value:
+                    - userA
+                    - userB
+                    - userC
+
+components:
+  examples:
+    GetUsersResponseExample:
+      value:
+        - userD
+        - userE
+        - userF


### PR DESCRIPTION
## Status

**READY**

## Description

Fixes #1458.

## Steps to Test or Reproduce
yarn build
yarn generate:swr
check generated/examples/endpoints -> `getGetUsersResponseMock` and `getGetUsers2ResponseMock` should be `["userD","userE","userF"]` and `["userA","userB","userC"]`
