### PR TITLE
chore(fetch): add mutator test for `fetch` client

### DIFF
--- a/samples/next-app-with-fetch/orval.config.ts
+++ b/samples/next-app-with-fetch/orval.config.ts
@@ -7,7 +7,6 @@ export default defineConfig({
       target: 'app/gen/petstore.ts',
       schemas: 'app/gen/models',
       client: 'fetch',
-      // client: 'axios',
       baseUrl: 'http://localhost:3000',
       mock: true,
       prettier: true,

--- a/samples/next-app-with-fetch/orval.config.ts
+++ b/samples/next-app-with-fetch/orval.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
       target: 'app/gen/petstore.ts',
       schemas: 'app/gen/models',
       client: 'fetch',
+      // client: 'axios',
       baseUrl: 'http://localhost:3000',
       mock: true,
       prettier: true,

--- a/tests/configs/fetch.config.ts
+++ b/tests/configs/fetch.config.ts
@@ -12,6 +12,23 @@ export default defineConfig({
       target: '../specifications/petstore.yaml',
     },
   },
+  mutator: {
+    output: {
+      target: '../generated/fetch/mutator/endpoints.ts',
+      schemas: '../generated/fetch/mutator/model',
+      mock: true,
+      client: 'fetch',
+      override: {
+        mutator: {
+          path: '../mutators/custom-fetch.ts',
+          name: 'customFetch',
+        },
+      },
+    },
+    input: {
+      target: '../specifications/petstore.yaml',
+    },
+  },
   multiArguments: {
     output: {
       target: '../generated/fetch/multi-arguments/endpoints.ts',

--- a/tests/mutators/custom-fetch.ts
+++ b/tests/mutators/custom-fetch.ts
@@ -1,0 +1,57 @@
+// NOTE: Supports cases where `content-type` is other than `json`
+const getBody = <T>(c: Response | Request): Promise<T> => {
+  const contentType = c.headers.get('content-type');
+
+  if (contentType && contentType.includes('application/json')) {
+    return c.json();
+  }
+
+  if (contentType && contentType.includes('application/pdf')) {
+    return c.blob() as Promise<T>;
+  }
+
+  return c.text() as Promise<T>;
+};
+
+// NOTE: Update just base url
+const getUrl = (contextUrl: string): string => {
+  const url = new URL(contextUrl);
+  const pathname = url.pathname;
+  const search = url.search;
+  const baseUrl =
+    process.env.NODE_ENV === 'production'
+      ? 'productionBaseUrl'
+      : 'http://localhost:3000';
+
+  const requestUrl = new URL(`${baseUrl}${pathname}${search}`);
+
+  return requestUrl.toString();
+};
+
+// NOTE: Add headers
+const getHeaders = (headers?: HeadersInit): HeadersInit => {
+  return {
+    ...headers,
+    Authorization: 'token',
+    'Content-Type': 'multipart/form-data',
+  };
+};
+
+export const customFetch = async <T>(
+  url: string,
+  options: RequestInit,
+): Promise<T> => {
+  const requestUrl = getUrl(url);
+  const requestHeaders = getHeaders(options.headers);
+
+  const requestInit: RequestInit = {
+    ...options,
+    headers: requestHeaders,
+  };
+
+  const request = new Request(requestUrl, requestInit);
+  const response = await fetch(request);
+  const data = await getBody<T>(response);
+
+  return data;
+};


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

follow up #1457
I have prepared basic tests for the `fetch` client.
I added one, because I needed to add only tests that use custom mutators.

## Related PRs

none

## Todos

- [x] Tests
- [x] Documentation
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce

none