### PR TITLE
fix: use unknown instead of any for additional properties

### DIFF
--- a/packages/core/src/getters/object.ts
+++ b/packages/core/src/getters/object.ts
@@ -130,7 +130,7 @@ export const getObject = ({
           if (arr.length - 1 === index) {
             if (item.additionalProperties) {
               if (isBoolean(item.additionalProperties)) {
-                acc.value += `\n  [key: string]: any;\n }`;
+                acc.value += `\n  [key: string]: unknown;\n }`;
               } else {
                 const resolvedValue = resolveValue({
                   schema: item.additionalProperties,
@@ -166,7 +166,7 @@ export const getObject = ({
   if (item.additionalProperties) {
     if (isBoolean(item.additionalProperties)) {
       return {
-        value: `{ [key: string]: any }` + nullable,
+        value: `{ [key: string]: unknown }` + nullable,
         imports: [],
         schemas: [],
         isEnum: false,
@@ -206,7 +206,7 @@ export const getObject = ({
 
   return {
     value:
-      (item.type === 'object' ? '{ [key: string]: any }' : 'unknown') +
+      (item.type === 'object' ? '{ [key: string]: unknown }' : 'unknown') +
       nullable,
     imports: [],
     schemas: [],


### PR DESCRIPTION
## Status

READY

## Description

Fixes https://github.com/anymaniax/orval/issues/1464

The generated type for objects with `additionalProperties: true` becomes `[key: string]: unknown` instead of `[key: string]: any` for better type safety.

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

Outline the steps to test or reproduce the PR here.

```bash
> git pull --prune
> git checkout <branch>
> grunt jasmine
```

1.
