### PR TITLE
feat(fetch): include status code in `fetch` client response

### DIFF
--- a/samples/next-app-with-fetch/app/gen/pets/pets.ts
+++ b/samples/next-app-with-fetch/app/gen/pets/pets.ts
@@ -43,6 +43,11 @@ type NonReadonly<T> = [T] extends [UnionToIntersection<T>]
 /**
  * @summary List all pets
  */
+export type listPetsResponse = {
+  data: Pets;
+  status: number;
+};
+
 export const getListPetsUrl = (params?: ListPetsParams) => {
   const normalizedParams = new URLSearchParams();
 
@@ -60,8 +65,8 @@ export const getListPetsUrl = (params?: ListPetsParams) => {
 export const listPets = async (
   params?: ListPetsParams,
   options?: RequestInit,
-): Promise<Pets> => {
-  return customFetch<Promise<Pets>>(getListPetsUrl(params), {
+): Promise<listPetsResponse> => {
+  return customFetch<Promise<listPetsResponse>>(getListPetsUrl(params), {
     ...options,
     method: 'GET',
   });
@@ -70,6 +75,11 @@ export const listPets = async (
 /**
  * @summary Create a pet
  */
+export type createPetsResponse = {
+  data: Pet;
+  status: number;
+};
+
 export const getCreatePetsUrl = () => {
   return `http://localhost:3000/pets`;
 };
@@ -77,8 +87,8 @@ export const getCreatePetsUrl = () => {
 export const createPets = async (
   createPetsBodyItem: CreatePetsBodyItem[],
   options?: RequestInit,
-): Promise<Pet> => {
-  return customFetch<Promise<Pet>>(getCreatePetsUrl(), {
+): Promise<createPetsResponse> => {
+  return customFetch<Promise<createPetsResponse>>(getCreatePetsUrl(), {
     ...options,
     method: 'POST',
     body: JSON.stringify(createPetsBodyItem),
@@ -88,6 +98,11 @@ export const createPets = async (
 /**
  * @summary Update a pet
  */
+export type updatePetsResponse = {
+  data: Pet;
+  status: number;
+};
+
 export const getUpdatePetsUrl = () => {
   return `http://localhost:3000/pets`;
 };
@@ -95,8 +110,8 @@ export const getUpdatePetsUrl = () => {
 export const updatePets = async (
   pet: NonReadonly<Pet>,
   options?: RequestInit,
-): Promise<Pet> => {
-  return customFetch<Promise<Pet>>(getUpdatePetsUrl(), {
+): Promise<updatePetsResponse> => {
+  return customFetch<Promise<updatePetsResponse>>(getUpdatePetsUrl(), {
     ...options,
     method: 'PUT',
     body: JSON.stringify(pet),
@@ -106,6 +121,11 @@ export const updatePets = async (
 /**
  * @summary Info for a specific pet
  */
+export type showPetByIdResponse = {
+  data: Pet;
+  status: number;
+};
+
 export const getShowPetByIdUrl = (petId: string) => {
   return `http://localhost:3000/pets/${petId}`;
 };
@@ -113,8 +133,8 @@ export const getShowPetByIdUrl = (petId: string) => {
 export const showPetById = async (
   petId: string,
   options?: RequestInit,
-): Promise<Pet> => {
-  return customFetch<Promise<Pet>>(getShowPetByIdUrl(petId), {
+): Promise<showPetByIdResponse> => {
+  return customFetch<Promise<showPetByIdResponse>>(getShowPetByIdUrl(petId), {
     ...options,
     method: 'GET',
   });

--- a/samples/next-app-with-fetch/app/pets.tsx
+++ b/samples/next-app-with-fetch/app/pets.tsx
@@ -1,16 +1,19 @@
 import { listPets } from './gen/pets/pets';
 
 export default async function Pets() {
-  const pets = await listPets();
+  const { data: pets, status } = await listPets();
 
   return (
     <div>
       <h1 className="text-4xl">Pets by server actions</h1>
+
       <ul>
         {pets.map((pet) => (
           <li key={pet.id}>{pet.name}</li>
         ))}
       </ul>
+
+      <h2 className="text-xl">Status: {status}</h2>
     </div>
   );
 }

--- a/samples/next-app-with-fetch/custom-fetch.ts
+++ b/samples/next-app-with-fetch/custom-fetch.ts
@@ -53,5 +53,5 @@ export const customFetch = async <T>(
   const response = await fetch(request);
   const data = await getBody<T>(response);
 
-  return data;
+  return { status: response.status, data } as T;
 };


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

fix #1465

I updated the 'fetch' client to include the status code in the response, as below:

```typescript
export type listPetsResponse = {
  status: number;
  data: Pets;
};

export const listPets = async (
  params?: ListPetsParams,
  options?: RequestInit,
): Promise<listPetsResponse> => {
  const res = await fetch(getListPetsUrl(params), {
    ...options,
    method: 'GET',
  });
  const data = await res.json();

  return { status: res.status, data: data };
};
```

## Related PRs

none

## Todos

- [x] Tests
- [x] Documentation
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce

none