### PR TITLE
docs: fix format for `suppressReadonlyModifier`

### DIFF
--- a/docs/src/pages/reference/configuration/output.md
+++ b/docs/src/pages/reference/configuration/output.md
@@ -1732,7 +1732,7 @@ module.exports = {
     output: {
       override: {
         suppressReadonlyModifier: true,
-      }
+      },
     },
   },
 };


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

I encountered format error in docs so, i fixed it.

## Related PRs

https://github.com/anymaniax/orval/pull/1468

## Todos

- [x] Tests
- [x] Documentation
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce

none