### PR TITLE
feat: add override function to empty response mocks

### DIFF
--- a/packages/mock/src/msw/index.ts
+++ b/packages/mock/src/msw/index.ts
@@ -113,13 +113,9 @@ const generateDefinition = (
 
   const delay = getDelay(override, !isFunction(mock) ? mock : undefined);
   const isHandlerOverridden = isReturnHttpResponse && !isTextPlain;
-  const infoParam = isHandlerOverridden ? 'info' : '';
+  const infoParam = 'info';
   const handlerImplementation = `
-export const ${handlerName} = (${
-    isHandlerOverridden
-      ? `overrideResponse?: ${returnType} | ((${infoParam}: Parameters<Parameters<typeof http.${verb}>[1]>[0]) => Promise<${returnType}> | ${returnType})`
-      : ''
-  }) => {
+export const ${handlerName} = (overrideResponse?: ${returnType} | ((${infoParam}: Parameters<Parameters<typeof http.${verb}>[1]>[0]) => Promise<${returnType}> | ${returnType})) => {
   return http.${verb}('${route}', ${
     (isReturnHttpResponse && !isTextPlain) || delay !== false ? 'async' : ''
   } (${infoParam}) => {${
@@ -127,6 +123,7 @@ export const ${handlerName} = (${
       ? `await delay(${isFunction(delay) ? `(${delay})()` : delay});`
       : ''
   }
+  ${isReturnHttpResponse ? '' : `if (typeof overrideResponse === 'function') {await overrideResponse(info); }`}
     return new HttpResponse(${
       isReturnHttpResponse
         ? isTextPlain

--- a/samples/angular-app/src/api/endpoints/pets/pets.msw.ts
+++ b/samples/angular-app/src/api/endpoints/pets/pets.msw.ts
@@ -34,6 +34,7 @@ export const getListPetsMockHandler = (
 ) => {
   return http.get('*/v:version/pets', async (info) => {
     await delay(1000);
+
     return new HttpResponse(
       JSON.stringify(
         overrideResponse !== undefined
@@ -47,9 +48,18 @@ export const getListPetsMockHandler = (
   });
 };
 
-export const getCreatePetsMockHandler = () => {
-  return http.post('*/v:version/pets', async () => {
+export const getCreatePetsMockHandler = (
+  overrideResponse?:
+    | void
+    | ((
+        info: Parameters<Parameters<typeof http.post>[1]>[0],
+      ) => Promise<void> | void),
+) => {
+  return http.post('*/v:version/pets', async (info) => {
     await delay(1000);
+    if (typeof overrideResponse === 'function') {
+      await overrideResponse(info);
+    }
     return new HttpResponse(null, { status: 201 });
   });
 };
@@ -63,6 +73,7 @@ export const getShowPetByIdMockHandler = (
 ) => {
   return http.get('*/v:version/pets/:petId', async (info) => {
     await delay(1000);
+
     return new HttpResponse(
       JSON.stringify(
         overrideResponse !== undefined

--- a/samples/basic/api/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/basic/api/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -147,6 +147,7 @@ export const getListPetsMockHandler = (
 ) => {
   return http.get('*/v:version/pets', async (info) => {
     await delay(1000);
+
     return new HttpResponse(
       JSON.stringify(
         overrideResponse !== undefined
@@ -160,9 +161,18 @@ export const getListPetsMockHandler = (
   });
 };
 
-export const getCreatePetsMockHandler = () => {
-  return http.post('*/v:version/pets', async () => {
+export const getCreatePetsMockHandler = (
+  overrideResponse?:
+    | void
+    | ((
+        info: Parameters<Parameters<typeof http.post>[1]>[0],
+      ) => Promise<void> | void),
+) => {
+  return http.post('*/v:version/pets', async (info) => {
     await delay(1000);
+    if (typeof overrideResponse === 'function') {
+      await overrideResponse(info);
+    }
     return new HttpResponse(null, { status: 201 });
   });
 };
@@ -176,6 +186,7 @@ export const getListPetsNestedArrayMockHandler = (
 ) => {
   return http.get('*/v:version/pets-nested-array', async (info) => {
     await delay(1000);
+
     return new HttpResponse(
       JSON.stringify(
         overrideResponse !== undefined
@@ -198,6 +209,7 @@ export const getShowPetByIdMockHandler = (
 ) => {
   return http.get('*/v:version/pets/:petId', async (info) => {
     await delay(1000);
+
     return new HttpResponse(
       JSON.stringify(
         overrideResponse !== undefined

--- a/samples/next-app-with-fetch/app/gen/pets/pets.msw.ts
+++ b/samples/next-app-with-fetch/app/gen/pets/pets.msw.ts
@@ -418,6 +418,7 @@ export const getListPetsMockHandler = (
 ) => {
   return http.get('*/pets', async (info) => {
     await delay(1000);
+
     return new HttpResponse(
       JSON.stringify(
         overrideResponse !== undefined
@@ -440,6 +441,7 @@ export const getCreatePetsMockHandler = (
 ) => {
   return http.post('*/pets', async (info) => {
     await delay(1000);
+
     return new HttpResponse(
       JSON.stringify(
         overrideResponse !== undefined
@@ -462,6 +464,7 @@ export const getUpdatePetsMockHandler = (
 ) => {
   return http.put('*/pets', async (info) => {
     await delay(1000);
+
     return new HttpResponse(
       JSON.stringify(
         overrideResponse !== undefined
@@ -484,6 +487,7 @@ export const getShowPetByIdMockHandler = (
 ) => {
   return http.get('*/pets/:petId', async (info) => {
     await delay(1000);
+
     return new HttpResponse(
       JSON.stringify(
         overrideResponse !== undefined

--- a/samples/react-app-with-swr/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
+++ b/samples/react-app-with-swr/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
@@ -47,6 +47,7 @@ export const getListPetsMockHandler = (
 ) => {
   return http.get('*/v:version/pets', async (info) => {
     await delay(1000);
+
     return new HttpResponse(
       JSON.stringify(
         overrideResponse !== undefined
@@ -69,6 +70,7 @@ export const getCreatePetsMockHandler = (
 ) => {
   return http.post('*/v:version/pets', async (info) => {
     await delay(1000);
+
     return new HttpResponse(
       JSON.stringify(
         overrideResponse !== undefined
@@ -91,6 +93,7 @@ export const getShowPetByIdMockHandler = (
 ) => {
   return http.get('*/v:version/pets/:petId', async (info) => {
     await delay(1000);
+
     return new HttpResponse(
       JSON.stringify(
         overrideResponse !== undefined

--- a/samples/react-app/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
+++ b/samples/react-app/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
@@ -34,6 +34,7 @@ export const getListPetsMockHandler = (
 ) => {
   return http.get('*/v:version/pets', async (info) => {
     await delay(1000);
+
     return new HttpResponse(
       JSON.stringify(
         overrideResponse !== undefined
@@ -47,9 +48,18 @@ export const getListPetsMockHandler = (
   });
 };
 
-export const getCreatePetsMockHandler = () => {
-  return http.post('*/v:version/pets', async () => {
+export const getCreatePetsMockHandler = (
+  overrideResponse?:
+    | void
+    | ((
+        info: Parameters<Parameters<typeof http.post>[1]>[0],
+      ) => Promise<void> | void),
+) => {
+  return http.post('*/v:version/pets', async (info) => {
     await delay(1000);
+    if (typeof overrideResponse === 'function') {
+      await overrideResponse(info);
+    }
     return new HttpResponse(null, { status: 201 });
   });
 };
@@ -63,6 +73,7 @@ export const getShowPetByIdMockHandler = (
 ) => {
   return http.get('*/v:version/pets/:petId', async (info) => {
     await delay(1000);
+
     return new HttpResponse(
       JSON.stringify(
         overrideResponse !== undefined

--- a/samples/react-query/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
+++ b/samples/react-query/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
@@ -86,6 +86,7 @@ export const getListPetsMockHandler = (
 ) => {
   return http.get('*/v:version/pets', async (info) => {
     await delay(1000);
+
     return new HttpResponse(
       JSON.stringify(
         overrideResponse !== undefined
@@ -99,9 +100,18 @@ export const getListPetsMockHandler = (
   });
 };
 
-export const getCreatePetsMockHandler = () => {
-  return http.post('*/v:version/pets', async () => {
+export const getCreatePetsMockHandler = (
+  overrideResponse?:
+    | void
+    | ((
+        info: Parameters<Parameters<typeof http.post>[1]>[0],
+      ) => Promise<void> | void),
+) => {
+  return http.post('*/v:version/pets', async (info) => {
     await delay(1000);
+    if (typeof overrideResponse === 'function') {
+      await overrideResponse(info);
+    }
     return new HttpResponse(null, { status: 201 });
   });
 };
@@ -115,6 +125,7 @@ export const getListPetsNestedArrayMockHandler = (
 ) => {
   return http.get('*/v:version/pets-nested-array', async (info) => {
     await delay(1000);
+
     return new HttpResponse(
       JSON.stringify(
         overrideResponse !== undefined
@@ -137,6 +148,7 @@ export const getShowPetByIdMockHandler = (
 ) => {
   return http.get('*/v:version/pets/:petId', async (info) => {
     await delay(1000);
+
     return new HttpResponse(
       JSON.stringify(
         overrideResponse !== undefined

--- a/samples/react-query/custom-client/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
+++ b/samples/react-query/custom-client/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
@@ -86,6 +86,7 @@ export const getListPetsMockHandler = (
 ) => {
   return http.get('*/v:version/pets', async (info) => {
     await delay(1000);
+
     return new HttpResponse(
       JSON.stringify(
         overrideResponse !== undefined
@@ -99,9 +100,18 @@ export const getListPetsMockHandler = (
   });
 };
 
-export const getCreatePetsMockHandler = () => {
-  return http.post('*/v:version/pets', async () => {
+export const getCreatePetsMockHandler = (
+  overrideResponse?:
+    | void
+    | ((
+        info: Parameters<Parameters<typeof http.post>[1]>[0],
+      ) => Promise<void> | void),
+) => {
+  return http.post('*/v:version/pets', async (info) => {
     await delay(1000);
+    if (typeof overrideResponse === 'function') {
+      await overrideResponse(info);
+    }
     return new HttpResponse(null, { status: 201 });
   });
 };
@@ -115,6 +125,7 @@ export const getListPetsNestedArrayMockHandler = (
 ) => {
   return http.get('*/v:version/pets-nested-array', async (info) => {
     await delay(1000);
+
     return new HttpResponse(
       JSON.stringify(
         overrideResponse !== undefined
@@ -137,6 +148,7 @@ export const getShowPetByIdMockHandler = (
 ) => {
   return http.get('*/v:version/pets/:petId', async (info) => {
     await delay(1000);
+
     return new HttpResponse(
       JSON.stringify(
         overrideResponse !== undefined

--- a/samples/svelte-query/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
+++ b/samples/svelte-query/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
@@ -34,6 +34,7 @@ export const getListPetsMockHandler = (
 ) => {
   return http.get('*/v:version/pets', async (info) => {
     await delay(1000);
+
     return new HttpResponse(
       JSON.stringify(
         overrideResponse !== undefined
@@ -47,9 +48,18 @@ export const getListPetsMockHandler = (
   });
 };
 
-export const getCreatePetsMockHandler = () => {
-  return http.post('*/v:version/pets', async () => {
+export const getCreatePetsMockHandler = (
+  overrideResponse?:
+    | void
+    | ((
+        info: Parameters<Parameters<typeof http.post>[1]>[0],
+      ) => Promise<void> | void),
+) => {
+  return http.post('*/v:version/pets', async (info) => {
     await delay(1000);
+    if (typeof overrideResponse === 'function') {
+      await overrideResponse(info);
+    }
     return new HttpResponse(null, { status: 201 });
   });
 };
@@ -63,6 +73,7 @@ export const getShowPetByIdMockHandler = (
 ) => {
   return http.get('*/v:version/pets/:petId', async (info) => {
     await delay(1000);
+
     return new HttpResponse(
       JSON.stringify(
         overrideResponse !== undefined

--- a/samples/vue-query/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
+++ b/samples/vue-query/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
@@ -45,6 +45,7 @@ export const getListPetsMockHandler = (
 ) => {
   return http.get('*/v:version/pets', async (info) => {
     await delay(1000);
+
     return new HttpResponse(
       JSON.stringify(
         overrideResponse !== undefined
@@ -67,6 +68,7 @@ export const getCreatePetsMockHandler = (
 ) => {
   return http.post('*/v:version/pets', async (info) => {
     await delay(1000);
+
     return new HttpResponse(
       JSON.stringify(
         overrideResponse !== undefined
@@ -89,6 +91,7 @@ export const getShowPetByIdMockHandler = (
 ) => {
   return http.get('*/v:version/pets/:petId', async (info) => {
     await delay(1000);
+
     return new HttpResponse(
       JSON.stringify(
         overrideResponse !== undefined
@@ -102,9 +105,18 @@ export const getShowPetByIdMockHandler = (
   });
 };
 
-export const getPostApiV1UserLogoutMockHandler = () => {
-  return http.post('*/api/v1/user/logout', async () => {
+export const getPostApiV1UserLogoutMockHandler = (
+  overrideResponse?:
+    | void
+    | ((
+        info: Parameters<Parameters<typeof http.post>[1]>[0],
+      ) => Promise<void> | void),
+) => {
+  return http.post('*/api/v1/user/logout', async (info) => {
     await delay(1000);
+    if (typeof overrideResponse === 'function') {
+      await overrideResponse(info);
+    }
     return new HttpResponse(null, { status: 200 });
   });
 };

--- a/tests/specifications/any-of.yaml
+++ b/tests/specifications/any-of.yaml
@@ -19,6 +19,9 @@ paths:
                 enum: ['B']
               - type: string
                 enum: ['C']
+      responses:
+        '204':
+          description: Ok
 components:
   schemas:
     A:


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

In some cases we do want to assert received request even for empty response mock
for that UI tests can add assertions in MSW mock override function

this PR allows us to do such assertion even for empty response mock:
```ts
      server.use(
        getPetsControllerBulkUpdateMockHandler(
          async ({ request, params }) => {
            const body = await request.json();

            expect(params.id).toBe('2');

            expect(body).toEqual({
              cats: [],
            });
          },
        ),
      );
```