### PR TITLE
fix(core): Referencing combined enums results in a duplicate schema name error

### DIFF
--- a/packages/core/src/getters/combine.ts
+++ b/packages/core/src/getters/combine.ts
@@ -173,26 +173,20 @@ export const combineSchemas = ({
   if (isAllEnums && name && items.length > 1) {
     const newEnum = `// eslint-disable-next-line @typescript-eslint/no-redeclare\nexport const ${pascal(
       name,
-    )} = ${getCombineEnumValue(resolvedData)};\n`;
+    )} = ${getCombineEnumValue(resolvedData)}`;
 
     return {
-      value: `typeof ${pascal(name)}[keyof typeof ${pascal(name)}] ${nullable}`,
+      value: `typeof ${pascal(name)}[keyof typeof ${pascal(name)}] ${nullable}\n\n${newEnum}`,
       imports: [
         {
           name: pascal(name),
         },
+        ...resolvedData.imports.map<GeneratorImport>((toImport) => ({
+          ...toImport,
+          values: true,
+        })),
       ],
-      schemas: [
-        ...resolvedData.schemas,
-        {
-          imports: resolvedData.imports.map<GeneratorImport>((toImport) => ({
-            ...toImport,
-            values: true,
-          })),
-          model: newEnum,
-          name: pascal(name),
-        },
-      ],
+      schemas: [...resolvedData.schemas],
       isEnum: false,
       type: 'object' as SchemaType,
       isRef: false,

--- a/tests/configs/default.config.ts
+++ b/tests/configs/default.config.ts
@@ -163,4 +163,12 @@ export default defineConfig({
       target: '../generated/default/http-status-mocks/endpoints.ts',
     },
   },
+  'combined-enum': {
+    input: '../specifications/combined-enum.yaml',
+    output: {
+      schemas: '../generated/default/combine-enum/schemas',
+      target: '../generated/default/combine-enum',
+      mock: true,
+    },
+  },
 });

--- a/tests/specifications/combined-enum.yaml
+++ b/tests/specifications/combined-enum.yaml
@@ -1,0 +1,32 @@
+openapi: 3.0.3
+info:
+  title: Combined enums
+  version: 1.0.0
+paths:
+  /api/colors:
+    get:
+      summary: sample colors
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ColorObject'
+components:
+  schemas:
+    Colors1:
+      type: string
+      enum: [red, blue, yellow]
+    Colors2:
+      type: string
+      enum: [green, purple, orange]
+    Colors:
+      oneOf:
+        - $ref: '#/components/schemas/Colors1'
+        - $ref: '#/components/schemas/Colors2'
+    ColorObject:
+      type: object
+      properties:
+        color:
+          $ref: '#/components/schemas/Colors'


### PR DESCRIPTION
## Status

**READY**

## Description

Fix #1419 

Fixes Referencing combined enums results in a duplicate schema name error #1419

## Todos

- [x] Tests
- [x] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

Outline the steps to test or reproduce the PR here.

```bash
> cd tests
> yarn generate:default
```
You should see 

> 🎉 combined-enum - Your OpenAPI spec has been converted into ready to use orval!

Should generate the following file at `tests/generated/default/combine-enum/schemas/colors.ts`
```typescript
import { Colors1 } from './colors1';
import { Colors2 } from './colors2';

export type Colors = typeof Colors[keyof typeof Colors] 

// eslint-disable-next-line @typescript-eslint/no-redeclare
export const Colors = {...Colors1,...Colors2,} as const;
```
