### PR TITLE
chore(swr): extract http client in `swr`

### DIFF
--- a/packages/swr/src/client.ts
+++ b/packages/swr/src/client.ts
@@ -9,6 +9,7 @@ import {
   isSyntheticDefaultImportsAllow,
   toObjectString,
   VERBS_WITH_BODY,
+  GeneratorMutator,
 } from '@orval/core';
 
 export const AXIOS_DEPENDENCIES: GeneratorDependency[] = [
@@ -134,4 +135,14 @@ export const generateSwrRequestFunction = (
     }.${verb}(${options});
   }
 `;
+};
+
+export const getSwrRequestOptions = (mutator?: GeneratorMutator) => {
+  if (!mutator) {
+    return `axios?: AxiosRequestConfig`;
+  } else if (mutator?.hasSecondArg) {
+    return `request?: SecondParameter<typeof ${mutator.name}>`;
+  } else {
+    return '';
+  }
 };

--- a/packages/swr/src/client.ts
+++ b/packages/swr/src/client.ts
@@ -170,3 +170,22 @@ export const getSwrRequestSecondArg = (mutator?: GeneratorMutator) => {
     return '';
   }
 };
+
+export const getSwrMutationFetcherOptionType = (mutator?: GeneratorMutator) => {
+  if (!mutator) {
+    return 'AxiosRequestConfig';
+  } else if (mutator.hasSecondArg) {
+    return `SecondParameter<typeof ${mutator.name}>`;
+  } else {
+    return '';
+  }
+};
+
+export const getSwrMutationFetcherType = (
+  response: GetterResponse,
+  mutator?: GeneratorMutator,
+) => {
+  return mutator
+    ? `Promise<${response.definition.success || 'unknown'}>`
+    : `Promise<AxiosResponse<${response.definition.success || 'unknown'}>>`;
+};

--- a/packages/swr/src/client.ts
+++ b/packages/swr/src/client.ts
@@ -160,3 +160,13 @@ export const getSwrErrorType = (
     return `AxiosError<${response.definition.errors || 'unknown'}>`;
   }
 };
+
+export const getSwrRequestSecondArg = (mutator?: GeneratorMutator) => {
+  if (!mutator) {
+    return `, axios: axiosOptions`;
+  } else if (mutator?.hasSecondArg) {
+    return ', request: requestOptions';
+  } else {
+    return '';
+  }
+};

--- a/packages/swr/src/client.ts
+++ b/packages/swr/src/client.ts
@@ -163,9 +163,19 @@ export const getSwrErrorType = (
 
 export const getSwrRequestSecondArg = (mutator?: GeneratorMutator) => {
   if (!mutator) {
-    return `, axios: axiosOptions`;
+    return `axios: axiosOptions`;
   } else if (mutator?.hasSecondArg) {
-    return ', request: requestOptions';
+    return 'request: requestOptions';
+  } else {
+    return '';
+  }
+};
+
+export const getHttpRequestSecondArg = (mutator?: GeneratorMutator) => {
+  if (!mutator) {
+    return `axiosOptions`;
+  } else if (mutator?.hasSecondArg) {
+    return 'requestOptions';
   } else {
     return '';
   }

--- a/packages/swr/src/client.ts
+++ b/packages/swr/src/client.ts
@@ -10,6 +10,7 @@ import {
   toObjectString,
   VERBS_WITH_BODY,
   GeneratorMutator,
+  GetterResponse,
 } from '@orval/core';
 
 export const AXIOS_DEPENDENCIES: GeneratorDependency[] = [
@@ -144,5 +145,18 @@ export const getSwrRequestOptions = (mutator?: GeneratorMutator) => {
     return `request?: SecondParameter<typeof ${mutator.name}>`;
   } else {
     return '';
+  }
+};
+
+export const getSwrErrorType = (
+  response: GetterResponse,
+  mutator?: GeneratorMutator,
+) => {
+  if (mutator) {
+    return mutator.hasErrorType
+      ? `ErrorType<${response.definition.errors || 'unknown'}>`
+      : response.definition.errors || 'unknown';
+  } else {
+    return `AxiosError<${response.definition.errors || 'unknown'}>`;
   }
 };

--- a/packages/swr/src/client.ts
+++ b/packages/swr/src/client.ts
@@ -1,0 +1,137 @@
+import {
+  generateFormDataAndUrlEncodedFunction,
+  generateMutatorConfig,
+  generateMutatorRequestOptions,
+  generateOptions,
+  GeneratorDependency,
+  GeneratorOptions,
+  GeneratorVerbOptions,
+  isSyntheticDefaultImportsAllow,
+  toObjectString,
+  VERBS_WITH_BODY,
+} from '@orval/core';
+
+export const AXIOS_DEPENDENCIES: GeneratorDependency[] = [
+  {
+    exports: [
+      {
+        name: 'axios',
+        default: true,
+        values: true,
+        syntheticDefaultImport: true,
+      },
+      { name: 'AxiosRequestConfig' },
+      { name: 'AxiosResponse' },
+      { name: 'AxiosError' },
+    ],
+    dependency: 'axios',
+  },
+];
+
+export const generateSwrRequestFunction = (
+  {
+    headers,
+    queryParams,
+    operationName,
+    response,
+    mutator,
+    body,
+    props,
+    verb,
+    formData,
+    formUrlEncoded,
+    override,
+    paramsSerializer,
+  }: GeneratorVerbOptions,
+  { route, context }: GeneratorOptions,
+) => {
+  const isRequestOptions = override?.requestOptions !== false;
+  const isFormData = override?.formData !== false;
+  const isFormUrlEncoded = override?.formUrlEncoded !== false;
+  const isExactOptionalPropertyTypes =
+    !!context.output.tsconfig?.compilerOptions?.exactOptionalPropertyTypes;
+  const isBodyVerb = VERBS_WITH_BODY.includes(verb);
+  const isSyntheticDefaultImportsAllowed = isSyntheticDefaultImportsAllow(
+    context.output.tsconfig,
+  );
+
+  const bodyForm = generateFormDataAndUrlEncodedFunction({
+    formData,
+    formUrlEncoded,
+    body,
+    isFormData,
+    isFormUrlEncoded,
+  });
+
+  if (mutator) {
+    const mutatorConfig = generateMutatorConfig({
+      route,
+      body,
+      headers,
+      queryParams,
+      response,
+      verb,
+      isFormData,
+      isFormUrlEncoded,
+      hasSignal: false,
+      isBodyVerb,
+      isExactOptionalPropertyTypes,
+    });
+
+    const propsImplementation =
+      mutator?.bodyTypeName && body.definition
+        ? toObjectString(props, 'implementation').replace(
+            new RegExp(`(\\w*):\\s?${body.definition}`),
+            `$1: ${mutator.bodyTypeName}<${body.definition}>`,
+          )
+        : toObjectString(props, 'implementation');
+
+    const requestOptions = isRequestOptions
+      ? generateMutatorRequestOptions(
+          override?.requestOptions,
+          mutator.hasSecondArg,
+        )
+      : '';
+
+    return `export const ${operationName} = (\n    ${propsImplementation}\n ${
+      isRequestOptions && mutator.hasSecondArg
+        ? `options${context.output.optionsParamRequired ? '' : '?'}: SecondParameter<typeof ${mutator.name}>`
+        : ''
+    }) => {${bodyForm}
+      return ${mutator.name}<${response.definition.success || 'unknown'}>(
+      ${mutatorConfig},
+      ${requestOptions});
+    }
+  `;
+  }
+
+  const options = generateOptions({
+    route,
+    body,
+    headers,
+    queryParams,
+    response,
+    verb,
+    requestOptions: override?.requestOptions,
+    isFormData,
+    isFormUrlEncoded,
+    paramsSerializer,
+    paramsSerializerOptions: override?.paramsSerializerOptions,
+    isExactOptionalPropertyTypes,
+    hasSignal: false,
+  });
+
+  return `export const ${operationName} = (\n    ${toObjectString(
+    props,
+    'implementation',
+  )} ${
+    isRequestOptions ? `options?: AxiosRequestConfig\n` : ''
+  } ): Promise<AxiosResponse<${
+    response.definition.success || 'unknown'
+  }>> => {${bodyForm}
+    return axios${
+      !isSyntheticDefaultImportsAllowed ? '.default' : ''
+    }.${verb}(${options});
+  }
+`;
+};

--- a/packages/swr/src/index.ts
+++ b/packages/swr/src/index.ts
@@ -27,6 +27,8 @@ import {
   getSwrRequestOptions,
   getSwrErrorType,
   getSwrRequestSecondArg,
+  getSwrMutationFetcherOptionType,
+  getSwrMutationFetcherType,
 } from './client';
 
 const PARAMS_SERIALIZER_DEPENDENCIES: GeneratorDependency[] = [
@@ -500,14 +502,11 @@ export const ${swrKeyFnName} = (${queryKeyProps}) => [\`${route}\`${
     const swrMutationFetcherName = camel(
       `get-${operationName}-mutation-fetcher`,
     );
-    const swrMutationFetcherType = mutator
-      ? `Promise<${response.definition.success || 'unknown'}>`
-      : `Promise<AxiosResponse<${response.definition.success || 'unknown'}>>`;
-    const swrMutationFetcherOptionType = !mutator
-      ? 'AxiosRequestConfig'
-      : mutator.hasSecondArg
-        ? `SecondParameter<typeof ${mutator.name}>`
-        : '';
+
+    const swrMutationFetcherType = getSwrMutationFetcherType(response, mutator);
+    const swrMutationFetcherOptionType =
+      getSwrMutationFetcherOptionType(mutator);
+
     const swrMutationFetcherOptions =
       isRequestOptions && swrMutationFetcherOptionType
         ? `options${context.output.optionsParamRequired ? '' : '?'}: ${swrMutationFetcherOptionType}`

--- a/packages/swr/src/index.ts
+++ b/packages/swr/src/index.ts
@@ -21,7 +21,11 @@ import {
   jsDoc,
   SwrOptions,
 } from '@orval/core';
-import { AXIOS_DEPENDENCIES, generateSwrRequestFunction } from './client';
+import {
+  AXIOS_DEPENDENCIES,
+  generateSwrRequestFunction,
+  getSwrRequestOptions,
+} from './client';
 
 const PARAMS_SERIALIZER_DEPENDENCIES: GeneratorDependency[] = [
   {
@@ -105,13 +109,7 @@ const generateSwrArguments = ({
     return `swrOptions?: ${definition}`;
   }
 
-  return `options?: { swr?:${definition}, ${
-    !mutator
-      ? `axios?: AxiosRequestConfig`
-      : mutator?.hasSecondArg
-        ? `request?: SecondParameter<typeof ${mutator.name}>`
-        : ''
-  } }\n`;
+  return `options?: { swr?:${definition}, ${getSwrRequestOptions(mutator)} }\n`;
 };
 
 const generateSwrMutationArguments = ({
@@ -131,13 +129,7 @@ const generateSwrMutationArguments = ({
     return `swrOptions?: ${definition}`;
   }
 
-  return `options?: { swr?:${definition}, ${
-    !mutator
-      ? `axios?: AxiosRequestConfig`
-      : mutator?.hasSecondArg
-        ? `request?: SecondParameter<typeof ${mutator.name}>`
-        : ''
-  } }\n`;
+  return `options?: { swr?:${definition}, ${getSwrRequestOptions(mutator)}}\n`;
 };
 
 const generateSwrImplementation = ({

--- a/packages/swr/src/index.ts
+++ b/packages/swr/src/index.ts
@@ -27,6 +27,7 @@ import {
   getSwrRequestOptions,
   getSwrErrorType,
   getSwrRequestSecondArg,
+  getHttpRequestSecondArg,
   getSwrMutationFetcherOptionType,
   getSwrMutationFetcherType,
 } from './client';
@@ -182,6 +183,7 @@ const generateSwrImplementation = ({
 
   const errorType = getSwrErrorType(response, mutator);
   const swrRequestSecondArg = getSwrRequestSecondArg(mutator);
+  const httpRequestSecondArg = getHttpRequestSecondArg(mutator);
 
   const useSWRInfiniteImplementation = swrOptions.useInfinite
     ? `
@@ -208,8 +210,8 @@ ${doc}export const ${camel(
   ${enabledImplementation}
   ${swrKeyLoaderImplementation}
   const swrFn = () => ${operationName}(${httpFunctionProps}${
-    httpFunctionProps ? ', ' : ''
-  }${isRequestOptions ? swrRequestSecondArg : ''});
+    httpFunctionProps && httpRequestSecondArg ? ', ' : ''
+  }${httpRequestSecondArg})
 
   const ${queryResultVarName} = useSWRInfinite<Awaited<ReturnType<typeof swrFn>>, TError>(swrKeyLoader, swrFn, ${
     swrOptions.swrInfiniteOptions
@@ -242,15 +244,15 @@ ${doc}export const ${camel(`use-${operationName}`)} = <TError = ${errorType}>(
   })}) => {
   ${
     isRequestOptions
-      ? `const {swr: swrOptions${swrRequestSecondArg}} = options ?? {}`
+      ? `const {swr: swrOptions${swrRequestSecondArg ? `, ${swrRequestSecondArg}` : ''}} = options ?? {}`
       : ''
   }
 
   ${enabledImplementation}
   ${swrKeyImplementation}
   const swrFn = () => ${operationName}(${httpFunctionProps}${
-    httpFunctionProps ? ', ' : ''
-  }${isRequestOptions ? swrRequestSecondArg : ''});
+    httpFunctionProps && httpRequestSecondArg ? ', ' : ''
+  }${httpRequestSecondArg})
 
   const ${queryResultVarName} = useSwr<Awaited<ReturnType<typeof swrFn>>, TError>(swrKey, swrFn, ${
     swrOptions.swrOptions
@@ -308,6 +310,7 @@ const generateSwrMutationImplementation = ({
 
   const errorType = getSwrErrorType(response, mutator);
   const swrRequestSecondArg = getSwrRequestSecondArg(mutator);
+  const httpRequestSecondArg = getHttpRequestSecondArg(mutator);
 
   const useSwrImplementation = `
 export type ${pascal(
@@ -323,12 +326,12 @@ ${doc}export const ${camel(`use-${operationName}`)} = <TError = ${errorType}>(
     swrBodyType,
   })}) => {
 
-  ${isRequestOptions ? `const {swr: swrOptions${swrRequestSecondArg}} = options ?? {}` : ''}
+  ${isRequestOptions ? `const {swr: swrOptions${swrRequestSecondArg ? `, ${swrRequestSecondArg}` : ''}} = options ?? {}` : ''}
 
   ${swrKeyImplementation}
   const swrFn = ${swrMutationFetcherName}(${swrMutationFetcherProperties}${
-    swrMutationFetcherProperties && isRequestOptions ? ',' : ''
-  }${isRequestOptions ? swrRequestSecondArg : ''});
+    swrMutationFetcherProperties && httpRequestSecondArg ? ', ' : ''
+  }${httpRequestSecondArg});
 
   const ${queryResultVarName} = useSWRMutation(swrKey, swrFn, ${
     swrOptions.swrMutationOptions

--- a/packages/swr/src/index.ts
+++ b/packages/swr/src/index.ts
@@ -26,6 +26,7 @@ import {
   generateSwrRequestFunction,
   getSwrRequestOptions,
   getSwrErrorType,
+  getSwrRequestSecondArg,
 } from './client';
 
 const PARAMS_SERIALIZER_DEPENDENCIES: GeneratorDependency[] = [
@@ -178,6 +179,7 @@ const generateSwrImplementation = ({
   const swrKeyLoaderImplementation = `const swrKeyLoader = swrOptions?.swrKeyLoader ?? (() => isEnabled ? ${swrKeyLoaderFnName}(${swrKeyProperties}) : null);`;
 
   const errorType = getSwrErrorType(response, mutator);
+  const swrRequestSecondArg = getSwrRequestSecondArg(mutator);
 
   const useSWRInfiniteImplementation = swrOptions.useInfinite
     ? `
@@ -197,13 +199,7 @@ ${doc}export const ${camel(
   })}) => {
   ${
     isRequestOptions
-      ? `const {swr: swrOptions${
-          !mutator
-            ? `, axios: axiosOptions`
-            : mutator?.hasSecondArg
-              ? ', request: requestOptions'
-              : ''
-        }} = options ?? {}`
+      ? `const {swr: swrOptions${swrRequestSecondArg ? `, ${swrRequestSecondArg}` : ''}} = options ?? {}`
       : ''
   }
 
@@ -211,15 +207,7 @@ ${doc}export const ${camel(
   ${swrKeyLoaderImplementation}
   const swrFn = () => ${operationName}(${httpFunctionProps}${
     httpFunctionProps ? ', ' : ''
-  }${
-    isRequestOptions
-      ? !mutator
-        ? `axiosOptions`
-        : mutator?.hasSecondArg
-          ? 'requestOptions'
-          : ''
-      : ''
-  });
+  }${isRequestOptions ? swrRequestSecondArg : ''});
 
   const ${queryResultVarName} = useSWRInfinite<Awaited<ReturnType<typeof swrFn>>, TError>(swrKeyLoader, swrFn, ${
     swrOptions.swrInfiniteOptions
@@ -252,13 +240,7 @@ ${doc}export const ${camel(`use-${operationName}`)} = <TError = ${errorType}>(
   })}) => {
   ${
     isRequestOptions
-      ? `const {swr: swrOptions${
-          !mutator
-            ? `, axios: axiosOptions`
-            : mutator?.hasSecondArg
-              ? ', request: requestOptions'
-              : ''
-        }} = options ?? {}`
+      ? `const {swr: swrOptions${swrRequestSecondArg}} = options ?? {}`
       : ''
   }
 
@@ -266,15 +248,7 @@ ${doc}export const ${camel(`use-${operationName}`)} = <TError = ${errorType}>(
   ${swrKeyImplementation}
   const swrFn = () => ${operationName}(${httpFunctionProps}${
     httpFunctionProps ? ', ' : ''
-  }${
-    isRequestOptions
-      ? !mutator
-        ? `axiosOptions`
-        : mutator?.hasSecondArg
-          ? 'requestOptions'
-          : ''
-      : ''
-  });
+  }${isRequestOptions ? swrRequestSecondArg : ''});
 
   const ${queryResultVarName} = useSwr<Awaited<ReturnType<typeof swrFn>>, TError>(swrKey, swrFn, ${
     swrOptions.swrOptions

--- a/packages/swr/src/index.ts
+++ b/packages/swr/src/index.ts
@@ -25,6 +25,7 @@ import {
   AXIOS_DEPENDENCIES,
   generateSwrRequestFunction,
   getSwrRequestOptions,
+  getSwrErrorType,
 } from './client';
 
 const PARAMS_SERIALIZER_DEPENDENCIES: GeneratorDependency[] = [
@@ -176,13 +177,7 @@ const generateSwrImplementation = ({
   const swrKeyImplementation = `const swrKey = swrOptions?.swrKey ?? (() => isEnabled ? ${swrKeyFnName}(${swrKeyProperties}) : null);`;
   const swrKeyLoaderImplementation = `const swrKeyLoader = swrOptions?.swrKeyLoader ?? (() => isEnabled ? ${swrKeyLoaderFnName}(${swrKeyProperties}) : null);`;
 
-  let errorType = `AxiosError<${response.definition.errors || 'unknown'}>`;
-
-  if (mutator) {
-    errorType = mutator.hasErrorType
-      ? `ErrorType<${response.definition.errors || 'unknown'}>`
-      : response.definition.errors || 'unknown';
-  }
+  const errorType = getSwrErrorType(response, mutator);
 
   const useSWRInfiniteImplementation = swrOptions.useInfinite
     ? `


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

follow up #1387 
I plan to allow the `swr` client to select an `http fetcher`.
Therefore, I extracted the http request processing to a file to be able to branch flexibly.

## Related PRs

none

## Todos

- [x] Tests
- [x] Documentation
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce

none