### PR TITLE
feat(mock): infer type from enum values for string and number

### DIFF
--- a/packages/mock/src/faker/getters/scalar.ts
+++ b/packages/mock/src/faker/getters/scalar.ts
@@ -4,7 +4,6 @@ import {
   GeneratorImport,
   isReference,
   isRootKey,
-  isString,
   mergeDeep,
   MockOptions,
 } from '@orval/core';

--- a/packages/mock/src/faker/getters/scalar.ts
+++ b/packages/mock/src/faker/getters/scalar.ts
@@ -4,6 +4,7 @@ import {
   GeneratorImport,
   isReference,
   isRootKey,
+  isString,
   mergeDeep,
   MockOptions,
 } from '@orval/core';
@@ -108,7 +109,9 @@ export const getMockScalar = ({
     };
   }
 
-  switch (item.type) {
+  const type = getItemType(item);
+
+  switch (type) {
     case 'number':
     case 'integer': {
       let value = getNullable(
@@ -303,3 +306,15 @@ export const getMockScalar = ({
     }
   }
 };
+
+function getItemType(item: MockSchemaObject) {
+  if (item.type) return item.type;
+  if (!item.enum) return;
+
+  const uniqTypes = new Set(item.enum.map((value) => typeof value));
+  if (uniqTypes.size > 1) return;
+
+  const type = Array.from(uniqTypes.values()).at(0);
+  if (!type) return;
+  return ['string', 'number'].includes(type) ? type : undefined;
+}

--- a/tests/configs/mock.config.ts
+++ b/tests/configs/mock.config.ts
@@ -126,4 +126,12 @@ export default defineConfig({
       target: '../specifications/enum-refs.yaml',
     },
   },
+  typelessEnum: {
+    input: '../specifications/typelessEnum.yaml',
+    output: {
+      schemas: '../generated/mock/typelessEnum/schemas',
+      target: '../generated/mock/typelessEnum',
+      mock: true,
+    },
+  },
 });

--- a/tests/specifications/typelessEnum.yaml
+++ b/tests/specifications/typelessEnum.yaml
@@ -1,0 +1,29 @@
+openapi: 3.0.3
+info:
+  title: Typeless enums
+  version: 1.0.0
+paths:
+  /api/colors:
+    get:
+      summary: sample colors
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ColorObject'
+components:
+  schemas:
+    Colors1:
+      type: string
+      enum: [red, blue, yellow]
+    Colors2:
+      enum: [green, purple, orange]
+    ColorObject:
+      type: object
+      properties:
+        color:
+          oneOf:
+            - $ref: '#/components/schemas/Colors1'
+            - $ref: '#/components/schemas/Colors2'


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

Fixes #1490 by infering type of enum if all enum values have same type and they are string or number


## Todos

- [x] Tests
- [x] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce


```bash
> cd tests
> yarn generate:mock
```

1. Should generate a file at `tests/generated/mock/typelessEnum/typelessEnums.ts` with the following variable 
```ts
export const getGetApiColorsResponseMock = (overrideResponse: Partial< ColorObject > = {}): ColorObject => ({color: faker.helpers.arrayElement([faker.helpers.arrayElement([faker.helpers.arrayElement(Object.values(Colors1)),faker.helpers.arrayElement(Object.values(Colors2))]), undefined]), ...overrideResponse})
```
formatted
```ts
export const getGetApiColorsResponseMock = (
  overrideResponse: Partial<ColorObject> = {},
): ColorObject => ({
  color: faker.helpers.arrayElement([
    faker.helpers.arrayElement([
      faker.helpers.arrayElement(Object.values(Colors1)),
      faker.helpers.arrayElement(Object.values(Colors2)),
    ]),
    undefined,
  ]),
  ...overrideResponse,
});
```
2. The said variable should correctly have faker value for `Colors2` for the `color` property