### PR TITLE
feat(swr): support for using `fetch` for http clients with `swr`

### DIFF
--- a/docs/src/pages/reference/configuration/output.md
+++ b/docs/src/pages/reference/configuration/output.md
@@ -39,6 +39,28 @@ module.exports = {
 
 if you want you can provide a function to extend or create you custom client generator and this function receive a [[GeneratorClients](https://github.com/anymaniax/orval/blob/master/packages/core/src/types.ts#L156)](https://github.com/anymaniax/orval/blob/master/packages/core/src/types.ts#L156) in argument and should return a [ClientGeneratorsBuilder](https://github.com/anymaniax/orval/blob/master/packages/core/src/types.ts#L652).
 
+### client
+
+Type: `String`.
+
+Valid values: `fetch`, `axios`.
+
+Default Value: `axios`.
+
+```js
+module.exports = {
+  petstore: {
+    output: {
+      client: 'swr',
+      httpClient: 'fetch',
+    },
+  },
+};
+```
+
+if you want you can use the `fetch` API as an http client with `Hooks` of `swr`, specify `fetch` in the `httpClient` option.
+Note that `httpClient` is currently only available when `swr` is specified as the `client` option.
+
 ### schemas
 
 Type: `String`.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -791,6 +791,7 @@ export type ClientDependenciesBuilder = (
   hasGlobalMutator: boolean,
   hasParamsSerializerOptions: boolean,
   packageJson?: PackageJson,
+  httpClient?: OutputHttpClient,
 ) => GeneratorDependency[];
 
 export type ClientMockGeneratorImplementation = {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -48,6 +48,7 @@ export type NormalizedOutputOptions = {
   mock?: GlobalMockOptions | ClientMockBuilder;
   override: NormalizedOverrideOutput;
   client: OutputClient | OutputClientFunc;
+  httpClient: OutputHttpClient;
   clean: boolean | string[];
   prettier: boolean;
   tslint: boolean;
@@ -169,6 +170,7 @@ export type OutputOptions = {
   mock?: boolean | GlobalMockOptions | ClientMockBuilder;
   override?: OverrideOutput;
   client?: OutputClient | OutputClientFunc;
+  httpClient?: OutputHttpClient;
   clean?: boolean | string[];
   prettier?: boolean;
   tslint?: boolean;
@@ -216,6 +218,14 @@ export const OutputClient = {
 } as const;
 
 export type OutputClient = (typeof OutputClient)[keyof typeof OutputClient];
+
+export const OutputHttpClient = {
+  AXIOS: 'axios',
+  FETCH: 'fetch',
+} as const;
+
+export type OutputHttpClient =
+  (typeof OutputHttpClient)[keyof typeof OutputHttpClient];
 
 export const OutputMode = {
   SINGLE: 'single',
@@ -562,6 +572,7 @@ export interface GlobalOptions {
   biome?: boolean;
   mock?: boolean | GlobalMockOptions;
   client?: OutputClient;
+  httpClient?: OutputHttpClient;
   mode?: OutputMode;
   tsconfig?: string | Tsconfig;
   packageJson?: string;

--- a/packages/fetch/src/index.ts
+++ b/packages/fetch/src/index.ts
@@ -13,7 +13,7 @@ import {
   isObject,
 } from '@orval/core';
 
-const generateRequestFunction = (
+export const generateRequestFunction = (
   {
     queryParams,
     operationName,

--- a/packages/fetch/src/index.ts
+++ b/packages/fetch/src/index.ts
@@ -1,11 +1,9 @@
 import {
   camel,
   ClientBuilder,
-  ClientDependenciesBuilder,
   ClientGeneratorsBuilder,
   generateFormDataAndUrlEncodedFunction,
   generateVerbImports,
-  GeneratorDependency,
   GeneratorOptions,
   GeneratorVerbOptions,
   GetterPropType,

--- a/packages/fetch/src/index.ts
+++ b/packages/fetch/src/index.ts
@@ -61,8 +61,8 @@ ${
   return \`${route}${queryParams ? '?${normalizedParams.toString()}' : ''}\`
 }\n`;
 
-  const responseTypeName = `${operationName}Response`;
-  const responseTypeImplementation = `export type ${operationName}Response = {
+  const responseTypeName = fetchResponseTypeName(operationName);
+  const responseTypeImplementation = `export type ${responseTypeName} = {
   data: ${response.definition.success || 'unknown'};
   status: number;
 }`;
@@ -136,6 +136,9 @@ ${
 
   return implementation;
 };
+
+export const fetchResponseTypeName = (operationName: string) =>
+  `${operationName}Response`;
 
 export const generateClient: ClientBuilder = (verbOptions, options) => {
   const imports = generateVerbImports(verbOptions);

--- a/packages/orval/src/client.ts
+++ b/packages/orval/src/client.ts
@@ -78,6 +78,7 @@ export const generateClientImports: GeneratorClientImports = ({
             hasGlobalMutator,
             hasParamsSerializerOptions,
             packageJson,
+            output.httpClient,
           ),
           ...imports,
         ]

--- a/packages/orval/src/utils/options.ts
+++ b/packages/orval/src/utils/options.ts
@@ -25,6 +25,7 @@ import {
   OperationOptions,
   OptionsExport,
   OutputClient,
+  OutputHttpClient,
   OutputMode,
   QueryOptions,
   RefComponentSuffix,
@@ -80,7 +81,8 @@ export const normalizeOptions = async (
     workspace,
   );
 
-  const { clean, prettier, client, mode, tslint, biome } = globalOptions;
+  const { clean, prettier, client, httpClient, mode, tslint, biome } =
+    globalOptions;
 
   const tsconfig = await loadTsconfig(
     outputOptions.tsconfig || globalOptions.tsconfig,
@@ -144,6 +146,8 @@ export const normalizeOptions = async (
       fileExtension: outputOptions.fileExtension || defaultFileExtension,
       workspace: outputOptions.workspace ? outputWorkspace : undefined,
       client: outputOptions.client ?? client ?? OutputClient.AXIOS_FUNCTIONS,
+      httpClient:
+        outputOptions.httpClient ?? httpClient ?? OutputHttpClient.AXIOS,
       mode: normalizeOutputMode(outputOptions.mode ?? mode),
       mock,
       clean: outputOptions.clean ?? clean ?? false,

--- a/packages/swr/package.json
+++ b/packages/swr/package.json
@@ -13,6 +13,7 @@
     "lint": "eslint src/**/*.ts"
   },
   "dependencies": {
-    "@orval/core": "6.31.0"
+    "@orval/core": "6.31.0",
+    "@orval/fetch": "6.31.0"
   }
 }

--- a/packages/swr/src/client.ts
+++ b/packages/swr/src/client.ts
@@ -154,9 +154,30 @@ const generateAxiosRequestFunction = (
 `;
 };
 
-export const getSwrRequestOptions = (mutator?: GeneratorMutator) => {
+export const getSwrRequestOptions = (
+  httpClient: OutputHttpClient,
+  mutator?: GeneratorMutator,
+) => {
+  if (httpClient === OutputHttpClient.AXIOS) {
+    return getSwrAxiosRequestOptions(mutator);
+  } else {
+    return getSwrFetchRequestOptions(mutator);
+  }
+};
+
+const getSwrAxiosRequestOptions = (mutator?: GeneratorMutator) => {
   if (!mutator) {
     return `axios?: AxiosRequestConfig`;
+  } else if (mutator?.hasSecondArg) {
+    return `request?: SecondParameter<typeof ${mutator.name}>`;
+  } else {
+    return '';
+  }
+};
+
+const getSwrFetchRequestOptions = (mutator?: GeneratorMutator) => {
+  if (!mutator) {
+    return `fetch?: RequestInit`;
   } else if (mutator?.hasSecondArg) {
     return `request?: SecondParameter<typeof ${mutator.name}>`;
   } else {

--- a/packages/swr/src/client.ts
+++ b/packages/swr/src/client.ts
@@ -223,9 +223,14 @@ const getSwrFetchErrorType = (
   }
 };
 
-export const getSwrRequestSecondArg = (mutator?: GeneratorMutator) => {
+export const getSwrRequestSecondArg = (
+  httpClient: OutputHttpClient,
+  mutator?: GeneratorMutator,
+) => {
   if (!mutator) {
-    return `axios: axiosOptions`;
+    return httpClient === OutputHttpClient.AXIOS
+      ? 'axios: axiosOptions'
+      : 'fetch: fetchOptions';
   } else if (mutator?.hasSecondArg) {
     return 'request: requestOptions';
   } else {
@@ -233,9 +238,14 @@ export const getSwrRequestSecondArg = (mutator?: GeneratorMutator) => {
   }
 };
 
-export const getHttpRequestSecondArg = (mutator?: GeneratorMutator) => {
+export const getHttpRequestSecondArg = (
+  httpClient: OutputHttpClient,
+  mutator?: GeneratorMutator,
+) => {
   if (!mutator) {
-    return `axiosOptions`;
+    return httpClient === OutputHttpClient.AXIOS
+      ? `axiosOptions`
+      : `fetchOptions`;
   } else if (mutator?.hasSecondArg) {
     return 'requestOptions';
   } else {

--- a/packages/swr/src/client.ts
+++ b/packages/swr/src/client.ts
@@ -11,7 +11,10 @@ import {
   VERBS_WITH_BODY,
   GeneratorMutator,
   GetterResponse,
+  OutputHttpClient,
 } from '@orval/core';
+
+import { generateRequestFunction as generateFetchRequestFunction } from '@orval/fetch';
 
 export const AXIOS_DEPENDENCIES: GeneratorDependency[] = [
   {
@@ -31,6 +34,17 @@ export const AXIOS_DEPENDENCIES: GeneratorDependency[] = [
 ];
 
 export const generateSwrRequestFunction = (
+  verbOptions: GeneratorVerbOptions,
+  options: GeneratorOptions,
+) => {
+  if (options.context.output.httpClient === OutputHttpClient.AXIOS) {
+    return generateAxiosRequestFunction(verbOptions, options);
+  } else {
+    return generateFetchRequestFunction(verbOptions, options);
+  }
+};
+
+const generateAxiosRequestFunction = (
   {
     headers,
     queryParams,

--- a/packages/swr/src/client.ts
+++ b/packages/swr/src/client.ts
@@ -166,6 +166,18 @@ export const getSwrRequestOptions = (mutator?: GeneratorMutator) => {
 
 export const getSwrErrorType = (
   response: GetterResponse,
+  httpClient: OutputHttpClient,
+  mutator?: GeneratorMutator,
+) => {
+  if (httpClient === OutputHttpClient.AXIOS) {
+    return getSwrAxiosErrorType(response, mutator);
+  } else {
+    return getSwrFetchErrorType(response, mutator);
+  }
+};
+
+const getSwrAxiosErrorType = (
+  response: GetterResponse,
   mutator?: GeneratorMutator,
 ) => {
   if (mutator) {
@@ -174,6 +186,19 @@ export const getSwrErrorType = (
       : response.definition.errors || 'unknown';
   } else {
     return `AxiosError<${response.definition.errors || 'unknown'}>`;
+  }
+};
+
+const getSwrFetchErrorType = (
+  response: GetterResponse,
+  mutator?: GeneratorMutator,
+) => {
+  if (mutator) {
+    return mutator.hasErrorType
+      ? `ErrorType<${response.definition.errors || 'unknown'}>`
+      : response.definition.errors || 'unknown';
+  } else {
+    return `Promise<${response.definition.errors || 'unknown'}>`;
   }
 };
 

--- a/packages/swr/src/client.ts
+++ b/packages/swr/src/client.ts
@@ -241,12 +241,13 @@ export const getSwrMutationFetcherType = (
   operationName: string,
   mutator?: GeneratorMutator,
 ) => {
-  if (mutator) {
-    return `Promise<${response.definition.success || 'unknown'}>`;
-  } else if (httpClient === OutputHttpClient.AXIOS) {
-    return `Promise<AxiosResponse<${response.definition.success || 'unknown'}>>`;
-  } else {
+  if (httpClient === OutputHttpClient.FETCH) {
     const responseType = fetchResponseTypeName(operationName);
+
     return `Promise<${responseType}>`;
+  } else if (mutator) {
+    return `Promise<${response.definition.success || 'unknown'}>`;
+  } else {
+    return `Promise<AxiosResponse<${response.definition.success || 'unknown'}>>`;
   }
 };

--- a/packages/swr/src/client.ts
+++ b/packages/swr/src/client.ts
@@ -1,3 +1,4 @@
+import { el } from '@faker-js/faker';
 import {
   generateFormDataAndUrlEncodedFunction,
   generateMutatorConfig,
@@ -14,7 +15,10 @@ import {
   OutputHttpClient,
 } from '@orval/core';
 
-import { generateRequestFunction as generateFetchRequestFunction } from '@orval/fetch';
+import {
+  generateRequestFunction as generateFetchRequestFunction,
+  fetchResponseTypeName,
+} from '@orval/fetch';
 
 export const AXIOS_DEPENDENCIES: GeneratorDependency[] = [
   {
@@ -234,11 +238,15 @@ export const getSwrMutationFetcherOptionType = (
 export const getSwrMutationFetcherType = (
   response: GetterResponse,
   httpClient: OutputHttpClient,
+  operationName: string,
   mutator?: GeneratorMutator,
 ) => {
-  return mutator
-    ? `Promise<${response.definition.success || 'unknown'}>`
-    : httpClient === OutputHttpClient.AXIOS
-      ? `Promise<AxiosResponse<${response.definition.success || 'unknown'}>>`
-      : `Promise<${response.definition.success || 'unknown'}>`;
+  if (mutator) {
+    return `Promise<${response.definition.success || 'unknown'}>`;
+  } else if (httpClient === OutputHttpClient.AXIOS) {
+    return `Promise<AxiosResponse<${response.definition.success || 'unknown'}>>`;
+  } else {
+    const responseType = fetchResponseTypeName(operationName);
+    return `Promise<${responseType}>`;
+  }
 };

--- a/packages/swr/src/client.ts
+++ b/packages/swr/src/client.ts
@@ -109,16 +109,18 @@ const generateAxiosRequestFunction = (
         )
       : '';
 
-    return `export const ${operationName} = (\n    ${propsImplementation}\n ${
+    const requestImplementation = `export const ${operationName} = (\n    ${propsImplementation}\n ${
       isRequestOptions && mutator.hasSecondArg
         ? `options${context.output.optionsParamRequired ? '' : '?'}: SecondParameter<typeof ${mutator.name}>`
         : ''
     }) => {${bodyForm}
-      return ${mutator.name}<${response.definition.success || 'unknown'}>(
-      ${mutatorConfig},
-      ${requestOptions});
-    }
-  `;
+    return ${mutator.name}<${response.definition.success || 'unknown'}>(
+    ${mutatorConfig},
+    ${requestOptions});
+  }
+`;
+
+    return requestImplementation;
   }
 
   const options = generateOptions({

--- a/packages/swr/src/client.ts
+++ b/packages/swr/src/client.ts
@@ -158,26 +158,10 @@ export const getSwrRequestOptions = (
   httpClient: OutputHttpClient,
   mutator?: GeneratorMutator,
 ) => {
-  if (httpClient === OutputHttpClient.AXIOS) {
-    return getSwrAxiosRequestOptions(mutator);
-  } else {
-    return getSwrFetchRequestOptions(mutator);
-  }
-};
-
-const getSwrAxiosRequestOptions = (mutator?: GeneratorMutator) => {
   if (!mutator) {
-    return `axios?: AxiosRequestConfig`;
-  } else if (mutator?.hasSecondArg) {
-    return `request?: SecondParameter<typeof ${mutator.name}>`;
-  } else {
-    return '';
-  }
-};
-
-const getSwrFetchRequestOptions = (mutator?: GeneratorMutator) => {
-  if (!mutator) {
-    return `fetch?: RequestInit`;
+    return httpClient === OutputHttpClient.AXIOS
+      ? 'axios?: AxiosRequestConfig'
+      : 'fetch?: RequestInit';
   } else if (mutator?.hasSecondArg) {
     return `request?: SecondParameter<typeof ${mutator.name}>`;
   } else {
@@ -190,36 +174,15 @@ export const getSwrErrorType = (
   httpClient: OutputHttpClient,
   mutator?: GeneratorMutator,
 ) => {
-  if (httpClient === OutputHttpClient.AXIOS) {
-    return getSwrAxiosErrorType(response, mutator);
-  } else {
-    return getSwrFetchErrorType(response, mutator);
-  }
-};
-
-const getSwrAxiosErrorType = (
-  response: GetterResponse,
-  mutator?: GeneratorMutator,
-) => {
   if (mutator) {
     return mutator.hasErrorType
       ? `ErrorType<${response.definition.errors || 'unknown'}>`
       : response.definition.errors || 'unknown';
   } else {
-    return `AxiosError<${response.definition.errors || 'unknown'}>`;
-  }
-};
+    const errorType =
+      httpClient === OutputHttpClient.AXIOS ? 'AxiosError' : 'Promise';
 
-const getSwrFetchErrorType = (
-  response: GetterResponse,
-  mutator?: GeneratorMutator,
-) => {
-  if (mutator) {
-    return mutator.hasErrorType
-      ? `ErrorType<${response.definition.errors || 'unknown'}>`
-      : response.definition.errors || 'unknown';
-  } else {
-    return `Promise<${response.definition.errors || 'unknown'}>`;
+    return `${errorType}<${response.definition.errors || 'unknown'}>`;
   }
 };
 

--- a/packages/swr/src/client.ts
+++ b/packages/swr/src/client.ts
@@ -216,9 +216,14 @@ export const getHttpRequestSecondArg = (
   }
 };
 
-export const getSwrMutationFetcherOptionType = (mutator?: GeneratorMutator) => {
+export const getSwrMutationFetcherOptionType = (
+  httpClient: OutputHttpClient,
+  mutator?: GeneratorMutator,
+) => {
   if (!mutator) {
-    return 'AxiosRequestConfig';
+    return httpClient === OutputHttpClient.AXIOS
+      ? 'AxiosRequestConfig'
+      : 'RequestInit';
   } else if (mutator.hasSecondArg) {
     return `SecondParameter<typeof ${mutator.name}>`;
   } else {
@@ -228,9 +233,12 @@ export const getSwrMutationFetcherOptionType = (mutator?: GeneratorMutator) => {
 
 export const getSwrMutationFetcherType = (
   response: GetterResponse,
+  httpClient: OutputHttpClient,
   mutator?: GeneratorMutator,
 ) => {
   return mutator
     ? `Promise<${response.definition.success || 'unknown'}>`
-    : `Promise<AxiosResponse<${response.definition.success || 'unknown'}>>`;
+    : httpClient === OutputHttpClient.AXIOS
+      ? `Promise<AxiosResponse<${response.definition.success || 'unknown'}>>`
+      : `Promise<${response.definition.success || 'unknown'}>`;
 };

--- a/packages/swr/src/index.ts
+++ b/packages/swr/src/index.ts
@@ -527,6 +527,7 @@ export const ${swrKeyFnName} = (${queryKeyProps}) => [\`${route}\`${
     const swrMutationFetcherType = getSwrMutationFetcherType(
       response,
       httpClient,
+      operationName,
       mutator,
     );
     const swrMutationFetcherOptionType = getSwrMutationFetcherOptionType(

--- a/packages/swr/src/index.ts
+++ b/packages/swr/src/index.ts
@@ -20,6 +20,7 @@ import {
   Verbs,
   jsDoc,
   SwrOptions,
+  OutputHttpClient,
 } from '@orval/core';
 import {
   AXIOS_DEPENDENCIES,
@@ -83,8 +84,12 @@ const SWR_MUTATION_DEPENDENCIES: GeneratorDependency[] = [
 export const getSwrDependencies: ClientDependenciesBuilder = (
   hasGlobalMutator: boolean,
   hasParamsSerializerOptions: boolean,
+  _packageJson,
+  httpClient?: OutputHttpClient,
 ) => [
-  ...(!hasGlobalMutator ? AXIOS_DEPENDENCIES : []),
+  ...(!hasGlobalMutator && httpClient === OutputHttpClient.AXIOS
+    ? AXIOS_DEPENDENCIES
+    : []),
   ...(hasParamsSerializerOptions ? PARAMS_SERIALIZER_DEPENDENCIES : []),
   ...SWR_DEPENDENCIES,
   ...SWR_INFINITE_DEPENDENCIES,

--- a/packages/swr/src/index.ts
+++ b/packages/swr/src/index.ts
@@ -155,6 +155,7 @@ const generateSwrImplementation = ({
   swrOptions,
   props,
   doc,
+  httpClient,
 }: {
   isRequestOptions: boolean;
   operationName: string;
@@ -168,6 +169,7 @@ const generateSwrImplementation = ({
   mutator?: GeneratorMutator;
   swrOptions: SwrOptions;
   doc?: string;
+  httpClient: OutputHttpClient;
 }) => {
   const swrProps = toObjectString(props, 'implementation');
 
@@ -186,7 +188,7 @@ const generateSwrImplementation = ({
   const swrKeyImplementation = `const swrKey = swrOptions?.swrKey ?? (() => isEnabled ? ${swrKeyFnName}(${swrKeyProperties}) : null);`;
   const swrKeyLoaderImplementation = `const swrKeyLoader = swrOptions?.swrKeyLoader ?? (() => isEnabled ? ${swrKeyLoaderFnName}(${swrKeyProperties}) : null);`;
 
-  const errorType = getSwrErrorType(response, mutator);
+  const errorType = getSwrErrorType(response, httpClient, mutator);
   const swrRequestSecondArg = getSwrRequestSecondArg(mutator);
   const httpRequestSecondArg = getHttpRequestSecondArg(mutator);
 
@@ -291,6 +293,7 @@ const generateSwrMutationImplementation = ({
   swrOptions,
   doc,
   swrBodyType,
+  httpClient,
 }: {
   isRequestOptions: boolean;
   operationName: string;
@@ -305,6 +308,7 @@ const generateSwrMutationImplementation = ({
   swrOptions: SwrOptions;
   doc?: string;
   swrBodyType: string;
+  httpClient: OutputHttpClient;
 }) => {
   const hasParamReservedWord = props.some(
     (prop: GetterProp) => prop.name === 'query',
@@ -313,7 +317,7 @@ const generateSwrMutationImplementation = ({
 
   const swrKeyImplementation = `const swrKey = swrOptions?.swrKey ?? ${swrKeyFnName}(${swrKeyProperties});`;
 
-  const errorType = getSwrErrorType(response, mutator);
+  const errorType = getSwrErrorType(response, httpClient, mutator);
   const swrRequestSecondArg = getSwrRequestSecondArg(mutator);
   const httpRequestSecondArg = getHttpRequestSecondArg(mutator);
 
@@ -437,6 +441,7 @@ export const ${swrKeyFnName} = (${queryKeyProps}) => [\`${route}\`${
       response,
       swrOptions: override.swr,
       doc,
+      httpClient: context.output.httpClient,
     });
 
     return swrKeyFn + swrKeyLoader + swrImplementation;
@@ -556,6 +561,7 @@ export const ${swrMutationFetcherName} = (${swrProps} ${swrMutationFetcherOption
       swrOptions: override.swr,
       doc,
       swrBodyType,
+      httpClient: context.output.httpClient,
     });
 
     return swrMutationFetcherFn + swrMutationKeyFn + swrImplementation;

--- a/packages/swr/src/index.ts
+++ b/packages/swr/src/index.ts
@@ -193,8 +193,8 @@ const generateSwrImplementation = ({
   const swrKeyLoaderImplementation = `const swrKeyLoader = swrOptions?.swrKeyLoader ?? (() => isEnabled ? ${swrKeyLoaderFnName}(${swrKeyProperties}) : null);`;
 
   const errorType = getSwrErrorType(response, httpClient, mutator);
-  const swrRequestSecondArg = getSwrRequestSecondArg(mutator);
-  const httpRequestSecondArg = getHttpRequestSecondArg(mutator);
+  const swrRequestSecondArg = getSwrRequestSecondArg(httpClient, mutator);
+  const httpRequestSecondArg = getHttpRequestSecondArg(httpClient, mutator);
 
   const useSWRInfiniteImplementation = swrOptions.useInfinite
     ? `
@@ -324,8 +324,8 @@ const generateSwrMutationImplementation = ({
   const swrKeyImplementation = `const swrKey = swrOptions?.swrKey ?? ${swrKeyFnName}(${swrKeyProperties});`;
 
   const errorType = getSwrErrorType(response, httpClient, mutator);
-  const swrRequestSecondArg = getSwrRequestSecondArg(mutator);
-  const httpRequestSecondArg = getHttpRequestSecondArg(mutator);
+  const swrRequestSecondArg = getSwrRequestSecondArg(httpClient, mutator);
+  const httpRequestSecondArg = getHttpRequestSecondArg(httpClient, mutator);
 
   const useSwrImplementation = `
 export type ${pascal(

--- a/packages/swr/src/index.ts
+++ b/packages/swr/src/index.ts
@@ -101,11 +101,13 @@ const generateSwrArguments = ({
   mutator,
   isRequestOptions,
   isInfinite,
+  httpClient,
 }: {
   operationName: string;
   mutator?: GeneratorMutator;
   isRequestOptions: boolean;
   isInfinite: boolean;
+  httpClient: OutputHttpClient;
 }) => {
   const configType = isInfinite
     ? 'SWRInfiniteConfiguration'
@@ -119,7 +121,7 @@ const generateSwrArguments = ({
     return `swrOptions?: ${definition}`;
   }
 
-  return `options?: { swr?:${definition}, ${getSwrRequestOptions(mutator)} }\n`;
+  return `options?: { swr?:${definition}, ${getSwrRequestOptions(httpClient, mutator)} }\n`;
 };
 
 const generateSwrMutationArguments = ({
@@ -127,11 +129,13 @@ const generateSwrMutationArguments = ({
   isRequestOptions,
   mutator,
   swrBodyType,
+  httpClient,
 }: {
   operationName: string;
   isRequestOptions: boolean;
   mutator?: GeneratorMutator;
   swrBodyType: string;
+  httpClient: OutputHttpClient;
 }) => {
   const definition = `SWRMutationConfiguration<Awaited<ReturnType<typeof ${operationName}>>, TError, string, ${swrBodyType}, Awaited<ReturnType<typeof ${operationName}>>> & { swrKey?: string }`;
 
@@ -139,7 +143,7 @@ const generateSwrMutationArguments = ({
     return `swrOptions?: ${definition}`;
   }
 
-  return `options?: { swr?:${definition}, ${getSwrRequestOptions(mutator)}}\n`;
+  return `options?: { swr?:${definition}, ${getSwrRequestOptions(httpClient, mutator)}}\n`;
 };
 
 const generateSwrImplementation = ({
@@ -207,6 +211,7 @@ ${doc}export const ${camel(
     mutator,
     isRequestOptions,
     isInfinite: true,
+    httpClient,
   })}) => {
   ${
     isRequestOptions
@@ -248,6 +253,7 @@ ${doc}export const ${camel(`use-${operationName}`)} = <TError = ${errorType}>(
     mutator,
     isRequestOptions,
     isInfinite: false,
+    httpClient,
   })}) => {
   ${
     isRequestOptions
@@ -333,6 +339,7 @@ ${doc}export const ${camel(`use-${operationName}`)} = <TError = ${errorType}>(
     isRequestOptions,
     mutator,
     swrBodyType,
+    httpClient,
   })}) => {
 
   ${isRequestOptions ? `const {swr: swrOptions${swrRequestSecondArg ? `, ${swrRequestSecondArg}` : ''}} = options ?? {}` : ''}

--- a/packages/swr/src/index.ts
+++ b/packages/swr/src/index.ts
@@ -384,6 +384,7 @@ const generateSwrHook = (
   { route, context }: GeneratorOptions,
 ) => {
   const isRequestOptions = override?.requestOptions !== false;
+  const httpClient = context.output.httpClient;
   const doc = jsDoc({ summary, deprecated });
 
   if (verb === Verbs.GET) {
@@ -448,7 +449,7 @@ export const ${swrKeyFnName} = (${queryKeyProps}) => [\`${route}\`${
       response,
       swrOptions: override.swr,
       doc,
-      httpClient: context.output.httpClient,
+      httpClient,
     });
 
     return swrKeyFn + swrKeyLoader + swrImplementation;
@@ -523,9 +524,15 @@ export const ${swrKeyFnName} = (${queryKeyProps}) => [\`${route}\`${
       `get-${operationName}-mutation-fetcher`,
     );
 
-    const swrMutationFetcherType = getSwrMutationFetcherType(response, mutator);
-    const swrMutationFetcherOptionType =
-      getSwrMutationFetcherOptionType(mutator);
+    const swrMutationFetcherType = getSwrMutationFetcherType(
+      response,
+      httpClient,
+      mutator,
+    );
+    const swrMutationFetcherOptionType = getSwrMutationFetcherOptionType(
+      httpClient,
+      mutator,
+    );
 
     const swrMutationFetcherOptions =
       isRequestOptions && swrMutationFetcherOptionType

--- a/tests/configs/swr.config.ts
+++ b/tests/configs/swr.config.ts
@@ -51,6 +51,18 @@ export default defineConfig({
       target: '../specifications/petstore.yaml',
     },
   },
+  httpClientFetch: {
+    output: {
+      target: '../generated/swr/http-client-fetch/endpoints.ts',
+      schemas: '../generated/swr/http-client-fetch/model',
+      mode: 'tags-split',
+      client: 'swr',
+      httpClient: 'fetch',
+    },
+    input: {
+      target: '../specifications/petstore.yaml',
+    },
+  },
   mutator: {
     output: {
       target: '../generated/swr/mutator/endpoints.ts',
@@ -89,6 +101,25 @@ export default defineConfig({
       override: {
         transformer: '../transformers/add-version.js',
       },
+    },
+  },
+  httpClientFetchWithCustomFetch: {
+    output: {
+      target:
+        '../generated/swr/http-client-fetch-with-custom-fetch/endpoints.ts',
+      schemas: '../generated/swr/http-client-fetch-with-custom-fetch/model',
+      client: 'swr',
+      httpClient: 'fetch',
+      mock: true,
+      override: {
+        mutator: {
+          path: '../mutators/custom-fetch.ts',
+          name: 'customFetch',
+        },
+      },
+    },
+    input: {
+      target: '../specifications/petstore.yaml',
     },
   },
   namedParameters: {

--- a/tests/mutators/custom-fetch.ts
+++ b/tests/mutators/custom-fetch.ts
@@ -53,5 +53,5 @@ export const customFetch = async <T>(
   const response = await fetch(request);
   const data = await getBody<T>(response);
 
-  return data;
+  return { status: response.status, data } as T;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -980,6 +980,7 @@ __metadata:
   resolution: "@orval/swr@workspace:packages/swr"
   dependencies:
     "@orval/core": "npm:6.31.0"
+    "@orval/fetch": "npm:6.31.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

follow up #1387 
I added `output.httpClient` option.
And able to using `fetch` API with `swr` client. custom mutators also available.
Since `@orval/fetch` doesn't have a any deps, i specified `@orval/fetch` as a dependency of `@orval/swr`. This allows the automatically generated functions of the http client to be shared, improving maintainability.

## Related PRs

none

## Todos

- [x] Tests
- [x] Documentation
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce

You can check generated code in the test

```bash
cd tests
yarn generate
```

I added test case is bellow:

- `generated/swr/http-client-fetch`
- `generated/swr/http-client-fetch`
