### PR TITLE
Feature/react query initial data

### DIFF
--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -1099,6 +1099,9 @@ ${hookOptions}
   const operationPrefix = hasSvelteQueryV4 ? 'create' : 'use';
 
   const queryHookName = camel(`${operationPrefix}-${name}`);
+  const overrideTypes = `export function ${queryHookName}<TData = ${TData}, TError = ${errorType}>(\n ${queryPropDefinitions} ${definedInitialDataQueryArguments}\n  ): ${definedInitialDataReturnType}
+export function ${queryHookName}<TData = ${TData}, TError = ${errorType}>(\n ${queryPropDefinitions} ${undefinedInitialDataQueryArguments}\n  ): ${returnType}
+export function ${queryHookName}<TData = ${TData}, TError = ${errorType}>(\n ${queryPropDefinitions} ${queryArguments}\n  ): ${returnType}`;
   return `
 ${queryOptionsFn}
 
@@ -1107,10 +1110,7 @@ export type ${pascal(
   )}QueryResult = NonNullable<Awaited<ReturnType<${dataType}>>>
 export type ${pascal(name)}QueryError = ${errorType}
 
-
-export function ${queryHookName}<TData = ${TData}, TError = ${errorType}>(\n ${queryPropDefinitions} ${definedInitialDataQueryArguments}\n  ): ${definedInitialDataReturnType}
-export function ${queryHookName}<TData = ${TData}, TError = ${errorType}>(\n ${queryPropDefinitions} ${undefinedInitialDataQueryArguments}\n  ): ${returnType}
-export function ${queryHookName}<TData = ${TData}, TError = ${errorType}>(\n ${queryPropDefinitions} ${queryArguments}\n  ): ${returnType}
+${hasQueryV5 ? overrideTypes : ''}
 ${doc}
 export function ${queryHookName}<TData = ${TData}, TError = ${errorType}>(\n ${queryProps} ${queryArguments}\n  ): ${returnType} {
 

--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -1095,7 +1095,9 @@ ${hookOptions}
   const operationPrefix = hasSvelteQueryV4 ? 'create' : 'use';
 
   const queryHookName = camel(`${operationPrefix}-${name}`);
-  const overrideTypes = `export function ${queryHookName}<TData = ${TData}, TError = ${errorType}>(\n ${queryPropDefinitions} ${definedInitialDataQueryArguments}\n  ): ${definedInitialDataReturnType}
+
+  const overrideTypes = `
+export function ${queryHookName}<TData = ${TData}, TError = ${errorType}>(\n ${queryPropDefinitions} ${definedInitialDataQueryArguments}\n  ): ${definedInitialDataReturnType}
 export function ${queryHookName}<TData = ${TData}, TError = ${errorType}>(\n ${queryPropDefinitions} ${undefinedInitialDataQueryArguments}\n  ): ${returnType}
 export function ${queryHookName}<TData = ${TData}, TError = ${errorType}>(\n ${queryPropDefinitions} ${queryArguments}\n  ): ${returnType}`;
   return `
@@ -1106,7 +1108,7 @@ export type ${pascal(
   )}QueryResult = NonNullable<Awaited<ReturnType<${dataType}>>>
 export type ${pascal(name)}QueryError = ${errorType}
 
-${hasQueryV5 ? overrideTypes : ''}
+${hasQueryV5 && OutputClient.REACT_QUERY === outputClient ? overrideTypes : ''}
 ${doc}
 export function ${queryHookName}<TData = ${TData}, TError = ${errorType}>(\n ${queryProps} ${queryArguments}\n  ): ${returnType} {
 

--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -528,17 +528,13 @@ const generateQueryRequestFunction = (
 `;
 };
 
-type QueryType =
-  | 'infiniteQuery'
-  | 'query'
-  | 'suspenseQuery'
-  | 'suspenseInfiniteQuery';
+type QueryType = 'infiniteQuery' | 'query';
 
 const QueryType = {
-  INFINITE: 'infiniteQuery',
-  QUERY: 'query',
-  SUSPENSE_QUERY: 'suspenseQuery',
-  SUSPENSE_INFINITE: 'suspenseInfiniteQuery',
+  INFINITE: 'infiniteQuery' as QueryType,
+  QUERY: 'query' as QueryType,
+  SUSPENSE_QUERY: 'suspenseQuery' as QueryType,
+  SUSPENSE_INFINITE: 'suspenseInfiniteQuery' as QueryType,
 };
 
 const INFINITE_QUERY_PROPERTIES = ['getNextPageParam', 'getPreviousPageParam'];


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

After generating react-query hooks, When using `useQuery` or `useInfiniteQuery` custom hook generated be Orval, if you profide initial data in the `query` option then the type of `data` property doesn't change it remains `nullable`

```ts
const { data: pets, refetch } = useListPets({}, undefined, {
    query: {
      initialData: [],
    },
  });
```
in this code the type of `pets` variable is `Pet[] | undefined`

where it should be `Pets[]`, because we have provided the initial data, this is the expected behaviour when using `useQuery` directly.

```ts
  const { data: pets } = useQuery({...getListPetsQueryOptions(), initialData: []})
```

in this case the type of `pets` is correct as `Pet[]`

This pr fixes this type issue

## Todos

- [x] Tests
- [x] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

Outline the steps to test or reproduce the PR here.

```bash
> yard dev
```

1.  Open file `samples/react-query/basic/src/App.tsx`
2. replace line no 9: `  const { data: pets, refetch } = useListPets();` with the following code
```ts
const { data: pets, refetch } = useListPets({}, undefined, {
    query: {
      initialData: [],
    },
  });
```
3. Hover over `pets` variable to check it's type
4. The type should be `PetsArray`