### PR TITLE
fix(mocks): use original name of ref schema in ref resolution

### DIFF
--- a/packages/mock/src/faker/resolvers/value.ts
+++ b/packages/mock/src/faker/resolvers/value.ts
@@ -80,7 +80,7 @@ export const resolveMockValue = ({
 }): MockDefinition & { type?: string } => {
   if (isReference(schema)) {
     const {
-      name,
+      originalName,
       specKey = context.specKey,
       refPaths,
     } = getRefInfo(schema.$ref, context);
@@ -89,7 +89,7 @@ export const resolveMockValue = ({
 
     const newSchema = {
       ...schemaRef,
-      name,
+      name: originalName,
       path: schema.path,
       isRef: true,
     };


### PR DESCRIPTION
Use original name of referenced schema in ref resolution

fix #1500

## Status

**READY**

## Description

- Resolves an issue where the maximum call stack is exceed when using circular dependencies in schema. 
- The mock scalar function uses the `existingReferencedProperties` variable to maintain a list of visited schema items.
- The name provided from the `resolveValue` function uses the ref's value as pascalCase instead of the original name.
- This would cause an infinite loop as the visited ref object isn't recognised as being visited.
- Fixed by using the original name in schema ref resolution.

## Steps to Test or Reproduce

1. Generate mocks from a schema that includes a ref to a component with a lower case name.
2. Check it doesn't fail.
