### PR TITLE
feat: generate literal types for booleans and numbers

### DIFF
--- a/packages/core/src/getters/object.ts
+++ b/packages/core/src/getters/object.ts
@@ -1,14 +1,15 @@
 import { ReferenceObject, SchemaObject } from 'openapi3-ts/oas30';
 import { resolveExampleRefs, resolveObject, resolveValue } from '../resolvers';
-import { ContextSpecs, ScalarValue, SchemaType } from '../types';
+import {
+  ContextSpecs,
+  ScalarValue,
+  SchemaType,
+  SchemaWithConst,
+} from '../types';
 import { isBoolean, isReference, jsDoc, pascal } from '../utils';
 import { combineSchemas } from './combine';
 import { getKey } from './keys';
 import { getRefInfo } from './ref';
-
-interface SchemaWithConst extends SchemaObject {
-  const: string;
-}
 
 /**
  * Return the output type from an object

--- a/packages/core/src/getters/scalar.ts
+++ b/packages/core/src/getters/scalar.ts
@@ -1,5 +1,10 @@
 import { SchemaObject } from 'openapi3-ts/oas30';
-import { ContextSpecs, ScalarValue, OutputClient } from '../types';
+import {
+  ContextSpecs,
+  ScalarValue,
+  OutputClient,
+  SchemaWithConst,
+} from '../types';
 import { escape, isString } from '../utils';
 import { getArray } from './array';
 import { getObject } from './object';
@@ -46,6 +51,11 @@ export const getScalar = ({
         isEnum = true;
       }
 
+      const itemWithConst = item as SchemaWithConst;
+      if (itemWithConst.const) {
+        value = itemWithConst.const;
+      }
+
       return {
         value: value + nullable,
         isEnum,
@@ -60,8 +70,15 @@ export const getScalar = ({
     }
 
     case 'boolean':
+      let value = 'boolean';
+
+      const itemWithConst = item as SchemaWithConst;
+      if (itemWithConst.const) {
+        value = itemWithConst.const;
+      }
+
       return {
-        value: 'boolean' + nullable,
+        value: value + nullable,
         type: 'boolean',
         isEnum: false,
         schemas: [],
@@ -107,6 +124,11 @@ export const getScalar = ({
         if (item.format === 'date' || item.format === 'date-time') {
           value = 'Date';
         }
+      }
+
+      const itemWithConst = item as SchemaWithConst;
+      if (itemWithConst.const) {
+        value = `'${itemWithConst.const}'`;
       }
 
       return {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1053,3 +1053,7 @@ export type GeneratorApiBuilder = GeneratorApiOperations & {
   importsMock: GenerateMockImports;
   extraFiles: ClientFileBuilder[];
 };
+
+export interface SchemaWithConst extends SchemaObject {
+  const: string;
+}

--- a/tests/configs/default.config.ts
+++ b/tests/configs/default.config.ts
@@ -171,4 +171,12 @@ export default defineConfig({
       mock: true,
     },
   },
+  const: {
+    input: '../specifications/const.yaml',
+    output: {
+      schemas: '../generated/default/const/model',
+      target: '../generated/default/const',
+      mock: true,
+    },
+  },
 });

--- a/tests/specifications/const.yaml
+++ b/tests/specifications/const.yaml
@@ -1,0 +1,52 @@
+openapi: 3.1.0
+info:
+  title: Const
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    StringConst:
+      type: object
+      required:
+        - value
+        - valueWithoutType
+        - valueNullable
+      properties:
+        value:
+          type: string
+          const: string
+        valueWithoutType:
+          const: string
+        valueNullable:
+          type:
+            - string
+            - 'null'
+          const: string
+    BooleanConst:
+      type: object
+      required:
+        - value
+        - valueNullable
+      properties:
+        value:
+          type: boolean
+          const: true
+        valueNullable:
+          type:
+            - boolean
+            - 'null'
+          const: true
+    IntegerConst:
+      type: object
+      required:
+        - value
+        - valueNullable
+      properties:
+        value:
+          type: number
+          const: 1
+        valueNullable:
+          type:
+            - number
+            - 'null'
+          const: 1


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

Allows for the generation of literal types for booleans and numbers. Fixes #1509.

## Todos

- [x] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

Outline the steps to test or reproduce the PR here.

```bash
> git clone https://github.com/RinseV/orval.git
```

1. Install dependencies & build the package
2. Generate the default specification in the `tests` folder: `yarn generate:default`
3. The generated models will have the correct literal types

## Notes

I didn't want to break the current functionality from #1326 where not specifying a `type` will generate it as a string literal. So, having only `const` without a `type` will still generate as a string. The same is true for a `type` of `string`. But if the `type` is either `number`, `integer` or `boolean`, the type will be generated as the literal value of `const`. This can result in invalid code (like specifying a property with `type: number` and `const: value` which will generate as `property: value`).

### Comparison
Schema:
```yaml
components:
  schemas:
    StringConst:
      type: object
      required:
        - value
        - valueWithoutType
        - valueNullable
      properties:
        value:
          type: string
          const: string
        valueWithoutType:
          const: string
        valueNullable:
          type:
            - string
            - 'null'
          const: string
```
#### Before
```typescript
export type StringConst = {
  value: string;
  valueWithoutType: "string";
  valueNullable: "string" | null;
};
```

#### Now
```typescript
export type StringConst = {
  value: "string";
  valueWithoutType: "string";
  valueNullable: "string" | null;
};
```
