### PR TITLE
feat(query): query clients can use `fetch` as an http client

### DIFF
--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@orval/core": "6.31.0",
+    "@orval/fetch": "6.31.0",
     "lodash.omitby": "^4.6.0"
   },
   "devDependencies": {

--- a/packages/query/src/client.ts
+++ b/packages/query/src/client.ts
@@ -262,12 +262,18 @@ export const getQueryErrorType = (
 
 export const getHooksOptionImplementation = (
   isRequestOptions: boolean,
+  httpClient: OutputHttpClient,
   mutator?: GeneratorMutator,
 ) => {
+  const options =
+    httpClient === OutputHttpClient.AXIOS
+      ? ', axios: axiosOptions'
+      : ', fetch: fetchOptions';
+
   return isRequestOptions
     ? `const {mutation: mutationOptions${
         !mutator
-          ? `, axios: axiosOptions`
+          ? options
           : mutator?.hasSecondArg
             ? ', request: requestOptions'
             : ''
@@ -277,11 +283,15 @@ export const getHooksOptionImplementation = (
 
 export const getMutationRequestArgs = (
   isRequestOptions: boolean,
+  httpClient: OutputHttpClient,
   mutator?: GeneratorMutator,
 ) => {
+  const options =
+    httpClient === OutputHttpClient.AXIOS ? 'axiosOptions' : 'fetchOptions';
+
   return isRequestOptions
     ? !mutator
-      ? `axiosOptions`
+      ? options
       : mutator?.hasSecondArg
         ? 'requestOptions'
         : ''

--- a/packages/query/src/client.ts
+++ b/packages/query/src/client.ts
@@ -9,7 +9,14 @@ import {
   GetterProps,
   ContextSpecs,
   GeneratorDependency,
+  GeneratorOptions,
+  OutputHttpClient,
 } from '@orval/core';
+
+import {
+  generateRequestFunction as generateFetchRequestFunction,
+  fetchResponseTypeName,
+} from '@orval/fetch';
 
 import { vueUnRefParams } from './utils';
 
@@ -45,6 +52,39 @@ export const generateRequestOptionsArguments = ({
 };
 
 export const generateQueryHttpRequestFunction = (
+  verbOptions: GeneratorVerbOptions,
+  context: ContextSpecs,
+  options: GeneratorOptions,
+  props: GetterProps,
+  route: string,
+  isVue: boolean,
+  isRequestOptions: boolean,
+  isFormData: boolean,
+  isFormUrlEncoded: boolean,
+  hasSignal: boolean,
+  isExactOptionalPropertyTypes: boolean,
+  bodyForm: string,
+) => {
+  if (options.context.output.httpClient === OutputHttpClient.AXIOS) {
+    return generateAxiosRequestFunction(
+      verbOptions,
+      context,
+      props,
+      route,
+      isVue,
+      isRequestOptions,
+      isFormData,
+      isFormUrlEncoded,
+      hasSignal,
+      isExactOptionalPropertyTypes,
+      bodyForm,
+    );
+  } else {
+    return generateFetchRequestFunction(verbOptions, options);
+  }
+};
+
+export const generateAxiosRequestFunction = (
   {
     headers,
     queryParams,

--- a/packages/query/src/client.ts
+++ b/packages/query/src/client.ts
@@ -274,7 +274,9 @@ export const getQueryOptions = ({
       return 'requestOptions';
     }
 
-    return 'requestOptions, signal';
+    return httpClient === OutputHttpClient.AXIOS
+      ? 'requestOptions, signal'
+      : '{ signal, ...requestOptions }';
   }
 
   if (hasSignal) {

--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -1333,6 +1333,7 @@ const generateQueryHook = async (
 
     const hooksOptionImplementation = getHooksOptionImplementation(
       isRequestOptions,
+      httpClient,
       mutator,
     );
     const mutationOptionsFn = `export const ${mutationOptionsFnName} = <TError = ${errorType},
@@ -1353,6 +1354,7 @@ ${hooksOptionImplementation}
 
           return  ${operationName}(${properties}${properties ? ',' : ''}${getMutationRequestArgs(
             isRequestOptions,
+            httpClient,
             mutator,
           )})
         }

--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -33,6 +33,7 @@ import {
   compareVersions,
   getRouteAsArray,
   NormalizedOutputOptions,
+  OutputHttpClient,
 } from '@orval/core';
 import omitBy from 'lodash.omitby';
 import {
@@ -138,11 +139,14 @@ export const getSvelteQueryDependencies: ClientDependenciesBuilder = (
   hasGlobalMutator,
   hasParamsSerializerOptions,
   packageJson,
+  httpClient?: OutputHttpClient,
 ) => {
   const hasSvelteQueryV3 = isSvelteQueryV3(packageJson);
 
   return [
-    ...(!hasGlobalMutator ? AXIOS_DEPENDENCIES : []),
+    ...(!hasGlobalMutator && httpClient === OutputHttpClient.AXIOS
+      ? AXIOS_DEPENDENCIES
+      : []),
     ...(hasParamsSerializerOptions ? PARAMS_SERIALIZER_DEPENDENCIES : []),
     ...(hasSvelteQueryV3
       ? SVELTE_QUERY_DEPENDENCIES_V3
@@ -202,6 +206,7 @@ export const getReactQueryDependencies: ClientDependenciesBuilder = (
   hasGlobalMutator,
   hasParamsSerializerOptions,
   packageJson,
+  httpClient,
 ) => {
   const hasReactQuery =
     packageJson?.dependencies?.['react-query'] ??
@@ -212,7 +217,9 @@ export const getReactQueryDependencies: ClientDependenciesBuilder = (
 
   return [
     ...(hasGlobalMutator ? REACT_DEPENDENCIES : []),
-    ...(!hasGlobalMutator ? AXIOS_DEPENDENCIES : []),
+    ...(!hasGlobalMutator && httpClient === OutputHttpClient.AXIOS
+      ? AXIOS_DEPENDENCIES
+      : []),
     ...(hasParamsSerializerOptions ? PARAMS_SERIALIZER_DEPENDENCIES : []),
     ...(hasReactQuery && !hasReactQueryV4
       ? REACT_QUERY_DEPENDENCIES_V3
@@ -300,11 +307,14 @@ export const getVueQueryDependencies: ClientDependenciesBuilder = (
   hasGlobalMutator: boolean,
   hasParamsSerializerOptions: boolean,
   packageJson,
+  httpClient?: OutputHttpClient,
 ) => {
   const hasVueQueryV3 = isVueQueryV3(packageJson);
 
   return [
-    ...(!hasGlobalMutator ? AXIOS_DEPENDENCIES : []),
+    ...(!hasGlobalMutator && httpClient === OutputHttpClient.AXIOS
+      ? AXIOS_DEPENDENCIES
+      : []),
     ...(hasParamsSerializerOptions ? PARAMS_SERIALIZER_DEPENDENCIES : []),
     ...(hasVueQueryV3 ? VUE_QUERY_DEPENDENCIES_V3 : VUE_QUERY_DEPENDENCIES),
   ];
@@ -353,7 +363,7 @@ const getPackageByQueryClient = (
 
 const generateQueryRequestFunction = (
   verbOptions: GeneratorVerbOptions,
-  { route: _route, context }: GeneratorOptions,
+  options: GeneratorOptions,
   isVue: boolean,
   output?: NormalizedOutputOptions,
 ) => {
@@ -370,6 +380,7 @@ const generateQueryRequestFunction = (
     formUrlEncoded,
     override,
   } = verbOptions;
+  const { route: _route, context } = options;
 
   let props = _props;
   let route = _route;
@@ -471,6 +482,7 @@ const generateQueryRequestFunction = (
   const httpRequestFunctionImplementation = generateQueryHttpRequestFunction(
     verbOptions,
     context,
+    options,
     props,
     route,
     isVue,

--- a/yarn.lock
+++ b/yarn.lock
@@ -969,6 +969,7 @@ __metadata:
   resolution: "@orval/query@workspace:packages/query"
   dependencies:
     "@orval/core": "npm:6.31.0"
+    "@orval/fetch": "npm:6.31.0"
     "@types/lodash.omitby": "npm:^4.6.7"
     lodash.omitby: "npm:^4.6.0"
     vitest: "npm:^0.34.6"


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

follow up #1387 
I made the `query` client to be able to use `fetch` as an http client.
I gonna add those sample apps ans tests with other PR.

## Related PRs

none

## Todos

- [x] Tests
- [x] Documentation
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce

You can check by setting  `fetch` to `httpClient` along with query clients.

```ts
import { defineConfig } from 'orval';

export default defineConfig({
  petstoreFile: {
    input: {
      target: './petstore.yaml',
    },
    output: {
      mode: 'tags-split',
      client: 'react-query',
      httpClient: 'fetch',
      target: 'src/gen/endpoints',
      schemas: 'src/gen/model',
      baseUrl: 'http://localhost:8000',
    },
  },
});
```