### PR TITLE
fix(fetch): remove unnecessary question mark in `fetch` query params

### DIFF
--- a/packages/fetch/src/index.ts
+++ b/packages/fetch/src/index.ts
@@ -58,7 +58,11 @@ ${
     : ''
 }
 
-  return \`${route}${queryParams ? '?${normalizedParams.toString()}' : ''}\`
+  ${
+    queryParams
+      ? `return normalizedParams.size ? \`${route}${'?${normalizedParams.toString()}'}\` : \`${route}\``
+      : `return \`${route}\``
+  }
 }\n`;
 
   const responseTypeName = fetchResponseTypeName(operationName);

--- a/samples/next-app-with-fetch/app/gen/pets/pets.ts
+++ b/samples/next-app-with-fetch/app/gen/pets/pets.ts
@@ -59,7 +59,9 @@ export const getListPetsUrl = (params?: ListPetsParams) => {
     }
   });
 
-  return `http://localhost:3000/pets?${normalizedParams.toString()}`;
+  return normalizedParams.size
+    ? `http://localhost:3000/pets?${normalizedParams.toString()}`
+    : `http://localhost:3000/pets`;
 };
 
 export const listPets = async (

--- a/samples/react-query/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/react-query/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -12,10 +12,14 @@ import {
   useSuspenseQuery,
 } from '@tanstack/react-query';
 import type {
+  DefinedInitialDataOptions,
+  DefinedUseInfiniteQueryResult,
+  DefinedUseQueryResult,
   InfiniteData,
   MutationFunction,
   QueryFunction,
   QueryKey,
+  UndefinedInitialDataOptions,
   UseInfiniteQueryOptions,
   UseInfiniteQueryResult,
   UseMutationOptions,
@@ -124,10 +128,95 @@ export type ListPetsInfiniteQueryResult = NonNullable<
 >;
 export type ListPetsInfiniteQueryError = ErrorType<Error>;
 
+export function useListPetsInfinite<
+  TData = InfiniteData<
+    Awaited<ReturnType<typeof listPets>>,
+    ListPetsParams['limit']
+  >,
+  TError = ErrorType<Error>,
+>(
+  params: undefined | ListPetsParams,
+  version: undefined | number,
+  options: {
+    query: Partial<
+      UseInfiniteQueryOptions<
+        Awaited<ReturnType<typeof listPets>>,
+        TError,
+        TData,
+        Awaited<ReturnType<typeof listPets>>,
+        QueryKey,
+        ListPetsParams['limit']
+      >
+    > &
+      Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof listPets>>,
+          TError,
+          TData,
+          QueryKey
+        >,
+        'initialData'
+      >;
+  },
+): DefinedUseInfiniteQueryResult<TData, TError> & { queryKey: QueryKey };
+export function useListPetsInfinite<
+  TData = InfiniteData<
+    Awaited<ReturnType<typeof listPets>>,
+    ListPetsParams['limit']
+  >,
+  TError = ErrorType<Error>,
+>(
+  params?: ListPetsParams,
+  version?: number,
+  options?: {
+    query?: Partial<
+      UseInfiniteQueryOptions<
+        Awaited<ReturnType<typeof listPets>>,
+        TError,
+        TData,
+        Awaited<ReturnType<typeof listPets>>,
+        QueryKey,
+        ListPetsParams['limit']
+      >
+    > &
+      Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof listPets>>,
+          TError,
+          TData,
+          QueryKey
+        >,
+        'initialData'
+      >;
+  },
+): UseInfiniteQueryResult<TData, TError> & { queryKey: QueryKey };
+export function useListPetsInfinite<
+  TData = InfiniteData<
+    Awaited<ReturnType<typeof listPets>>,
+    ListPetsParams['limit']
+  >,
+  TError = ErrorType<Error>,
+>(
+  params?: ListPetsParams,
+  version?: number,
+  options?: {
+    query?: Partial<
+      UseInfiniteQueryOptions<
+        Awaited<ReturnType<typeof listPets>>,
+        TError,
+        TData,
+        Awaited<ReturnType<typeof listPets>>,
+        QueryKey,
+        ListPetsParams['limit']
+      >
+    >;
+  },
+): UseInfiniteQueryResult<TData, TError> & { queryKey: QueryKey };
 /**
  * @summary List all pets
  */
-export const useListPetsInfinite = <
+
+export function useListPetsInfinite<
   TData = InfiniteData<
     Awaited<ReturnType<typeof listPets>>,
     ListPetsParams['limit']
@@ -148,7 +237,7 @@ export const useListPetsInfinite = <
       >
     >;
   },
-): UseInfiniteQueryResult<TData, TError> & { queryKey: QueryKey } => {
+): UseInfiniteQueryResult<TData, TError> & { queryKey: QueryKey } {
   const queryOptions = getListPetsInfiniteQueryOptions(
     params,
     version,
@@ -163,7 +252,7 @@ export const useListPetsInfinite = <
   query.queryKey = queryOptions.queryKey;
 
   return query;
-};
+}
 
 export const getListPetsQueryOptions = <
   TData = Awaited<ReturnType<typeof listPets>>,
@@ -201,10 +290,63 @@ export type ListPetsQueryResult = NonNullable<
 >;
 export type ListPetsQueryError = ErrorType<Error>;
 
+export function useListPets<
+  TData = Awaited<ReturnType<typeof listPets>>,
+  TError = ErrorType<Error>,
+>(
+  params: undefined | ListPetsParams,
+  version: undefined | number,
+  options: {
+    query: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof listPets>>, TError, TData>
+    > &
+      Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof listPets>>,
+          TError,
+          TData
+        >,
+        'initialData'
+      >;
+  },
+): DefinedUseQueryResult<TData, TError> & { queryKey: QueryKey };
+export function useListPets<
+  TData = Awaited<ReturnType<typeof listPets>>,
+  TError = ErrorType<Error>,
+>(
+  params?: ListPetsParams,
+  version?: number,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof listPets>>, TError, TData>
+    > &
+      Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof listPets>>,
+          TError,
+          TData
+        >,
+        'initialData'
+      >;
+  },
+): UseQueryResult<TData, TError> & { queryKey: QueryKey };
+export function useListPets<
+  TData = Awaited<ReturnType<typeof listPets>>,
+  TError = ErrorType<Error>,
+>(
+  params?: ListPetsParams,
+  version?: number,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof listPets>>, TError, TData>
+    >;
+  },
+): UseQueryResult<TData, TError> & { queryKey: QueryKey };
 /**
  * @summary List all pets
  */
-export const useListPets = <
+
+export function useListPets<
   TData = Awaited<ReturnType<typeof listPets>>,
   TError = ErrorType<Error>,
 >(
@@ -215,7 +357,7 @@ export const useListPets = <
       UseQueryOptions<Awaited<ReturnType<typeof listPets>>, TError, TData>
     >;
   },
-): UseQueryResult<TData, TError> & { queryKey: QueryKey } => {
+): UseQueryResult<TData, TError> & { queryKey: QueryKey } {
   const queryOptions = getListPetsQueryOptions(params, version, options);
 
   const query = useQuery(queryOptions) as UseQueryResult<TData, TError> & {
@@ -225,7 +367,7 @@ export const useListPets = <
   query.queryKey = queryOptions.queryKey;
 
   return query;
-};
+}
 
 export const getListPetsSuspenseQueryOptions = <
   TData = Awaited<ReturnType<typeof listPets>>,
@@ -269,10 +411,59 @@ export type ListPetsSuspenseQueryResult = NonNullable<
 >;
 export type ListPetsSuspenseQueryError = ErrorType<Error>;
 
+export function useListPetsSuspense<
+  TData = Awaited<ReturnType<typeof listPets>>,
+  TError = ErrorType<Error>,
+>(
+  params: undefined | ListPetsParams,
+  version: undefined | number,
+  options: {
+    query: Partial<
+      UseSuspenseQueryOptions<
+        Awaited<ReturnType<typeof listPets>>,
+        TError,
+        TData
+      >
+    >;
+  },
+): UseSuspenseQueryResult<TData, TError> & { queryKey: QueryKey };
+export function useListPetsSuspense<
+  TData = Awaited<ReturnType<typeof listPets>>,
+  TError = ErrorType<Error>,
+>(
+  params?: ListPetsParams,
+  version?: number,
+  options?: {
+    query?: Partial<
+      UseSuspenseQueryOptions<
+        Awaited<ReturnType<typeof listPets>>,
+        TError,
+        TData
+      >
+    >;
+  },
+): UseSuspenseQueryResult<TData, TError> & { queryKey: QueryKey };
+export function useListPetsSuspense<
+  TData = Awaited<ReturnType<typeof listPets>>,
+  TError = ErrorType<Error>,
+>(
+  params?: ListPetsParams,
+  version?: number,
+  options?: {
+    query?: Partial<
+      UseSuspenseQueryOptions<
+        Awaited<ReturnType<typeof listPets>>,
+        TError,
+        TData
+      >
+    >;
+  },
+): UseSuspenseQueryResult<TData, TError> & { queryKey: QueryKey };
 /**
  * @summary List all pets
  */
-export const useListPetsSuspense = <
+
+export function useListPetsSuspense<
   TData = Awaited<ReturnType<typeof listPets>>,
   TError = ErrorType<Error>,
 >(
@@ -287,7 +478,7 @@ export const useListPetsSuspense = <
       >
     >;
   },
-): UseSuspenseQueryResult<TData, TError> & { queryKey: QueryKey } => {
+): UseSuspenseQueryResult<TData, TError> & { queryKey: QueryKey } {
   const queryOptions = getListPetsSuspenseQueryOptions(
     params,
     version,
@@ -302,7 +493,7 @@ export const useListPetsSuspense = <
   query.queryKey = queryOptions.queryKey;
 
   return query;
-};
+}
 
 export const getListPetsSuspenseInfiniteQueryOptions = <
   TData = InfiniteData<
@@ -362,10 +553,77 @@ export type ListPetsSuspenseInfiniteQueryResult = NonNullable<
 >;
 export type ListPetsSuspenseInfiniteQueryError = ErrorType<Error>;
 
+export function useListPetsSuspenseInfinite<
+  TData = InfiniteData<
+    Awaited<ReturnType<typeof listPets>>,
+    ListPetsParams['limit']
+  >,
+  TError = ErrorType<Error>,
+>(
+  params: undefined | ListPetsParams,
+  version: undefined | number,
+  options: {
+    query: Partial<
+      UseSuspenseInfiniteQueryOptions<
+        Awaited<ReturnType<typeof listPets>>,
+        TError,
+        TData,
+        Awaited<ReturnType<typeof listPets>>,
+        QueryKey,
+        ListPetsParams['limit']
+      >
+    >;
+  },
+): UseSuspenseInfiniteQueryResult<TData, TError> & { queryKey: QueryKey };
+export function useListPetsSuspenseInfinite<
+  TData = InfiniteData<
+    Awaited<ReturnType<typeof listPets>>,
+    ListPetsParams['limit']
+  >,
+  TError = ErrorType<Error>,
+>(
+  params?: ListPetsParams,
+  version?: number,
+  options?: {
+    query?: Partial<
+      UseSuspenseInfiniteQueryOptions<
+        Awaited<ReturnType<typeof listPets>>,
+        TError,
+        TData,
+        Awaited<ReturnType<typeof listPets>>,
+        QueryKey,
+        ListPetsParams['limit']
+      >
+    >;
+  },
+): UseSuspenseInfiniteQueryResult<TData, TError> & { queryKey: QueryKey };
+export function useListPetsSuspenseInfinite<
+  TData = InfiniteData<
+    Awaited<ReturnType<typeof listPets>>,
+    ListPetsParams['limit']
+  >,
+  TError = ErrorType<Error>,
+>(
+  params?: ListPetsParams,
+  version?: number,
+  options?: {
+    query?: Partial<
+      UseSuspenseInfiniteQueryOptions<
+        Awaited<ReturnType<typeof listPets>>,
+        TError,
+        TData,
+        Awaited<ReturnType<typeof listPets>>,
+        QueryKey,
+        ListPetsParams['limit']
+      >
+    >;
+  },
+): UseSuspenseInfiniteQueryResult<TData, TError> & { queryKey: QueryKey };
 /**
  * @summary List all pets
  */
-export const useListPetsSuspenseInfinite = <
+
+export function useListPetsSuspenseInfinite<
   TData = InfiniteData<
     Awaited<ReturnType<typeof listPets>>,
     ListPetsParams['limit']
@@ -386,7 +644,7 @@ export const useListPetsSuspenseInfinite = <
       >
     >;
   },
-): UseSuspenseInfiniteQueryResult<TData, TError> & { queryKey: QueryKey } => {
+): UseSuspenseInfiniteQueryResult<TData, TError> & { queryKey: QueryKey } {
   const queryOptions = getListPetsSuspenseInfiniteQueryOptions(
     params,
     version,
@@ -400,7 +658,7 @@ export const useListPetsSuspenseInfinite = <
   query.queryKey = queryOptions.queryKey;
 
   return query;
-};
+}
 
 /**
  * @summary Create a pet
@@ -545,10 +803,75 @@ export type ListPetsNestedArrayQueryResult = NonNullable<
 >;
 export type ListPetsNestedArrayQueryError = ErrorType<Error>;
 
+export function useListPetsNestedArray<
+  TData = Awaited<ReturnType<typeof listPetsNestedArray>>,
+  TError = ErrorType<Error>,
+>(
+  params: undefined | ListPetsNestedArrayParams,
+  version: undefined | number,
+  options: {
+    query: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof listPetsNestedArray>>,
+        TError,
+        TData
+      >
+    > &
+      Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof listPetsNestedArray>>,
+          TError,
+          TData
+        >,
+        'initialData'
+      >;
+  },
+): DefinedUseQueryResult<TData, TError> & { queryKey: QueryKey };
+export function useListPetsNestedArray<
+  TData = Awaited<ReturnType<typeof listPetsNestedArray>>,
+  TError = ErrorType<Error>,
+>(
+  params?: ListPetsNestedArrayParams,
+  version?: number,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof listPetsNestedArray>>,
+        TError,
+        TData
+      >
+    > &
+      Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof listPetsNestedArray>>,
+          TError,
+          TData
+        >,
+        'initialData'
+      >;
+  },
+): UseQueryResult<TData, TError> & { queryKey: QueryKey };
+export function useListPetsNestedArray<
+  TData = Awaited<ReturnType<typeof listPetsNestedArray>>,
+  TError = ErrorType<Error>,
+>(
+  params?: ListPetsNestedArrayParams,
+  version?: number,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof listPetsNestedArray>>,
+        TError,
+        TData
+      >
+    >;
+  },
+): UseQueryResult<TData, TError> & { queryKey: QueryKey };
 /**
  * @summary List all pets as nested array
  */
-export const useListPetsNestedArray = <
+
+export function useListPetsNestedArray<
   TData = Awaited<ReturnType<typeof listPetsNestedArray>>,
   TError = ErrorType<Error>,
 >(
@@ -563,7 +886,7 @@ export const useListPetsNestedArray = <
       >
     >;
   },
-): UseQueryResult<TData, TError> & { queryKey: QueryKey } => {
+): UseQueryResult<TData, TError> & { queryKey: QueryKey } {
   const queryOptions = getListPetsNestedArrayQueryOptions(
     params,
     version,
@@ -577,7 +900,7 @@ export const useListPetsNestedArray = <
   query.queryKey = queryOptions.queryKey;
 
   return query;
-};
+}
 
 /**
  * @summary Info for a specific pet
@@ -636,10 +959,63 @@ export type ShowPetByIdQueryResult = NonNullable<
 >;
 export type ShowPetByIdQueryError = ErrorType<Error>;
 
+export function useShowPetById<
+  TData = Awaited<ReturnType<typeof showPetById>>,
+  TError = ErrorType<Error>,
+>(
+  petId: string,
+  version: undefined | number,
+  options: {
+    query: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof showPetById>>, TError, TData>
+    > &
+      Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof showPetById>>,
+          TError,
+          TData
+        >,
+        'initialData'
+      >;
+  },
+): DefinedUseQueryResult<TData, TError> & { queryKey: QueryKey };
+export function useShowPetById<
+  TData = Awaited<ReturnType<typeof showPetById>>,
+  TError = ErrorType<Error>,
+>(
+  petId: string,
+  version?: number,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof showPetById>>, TError, TData>
+    > &
+      Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof showPetById>>,
+          TError,
+          TData
+        >,
+        'initialData'
+      >;
+  },
+): UseQueryResult<TData, TError> & { queryKey: QueryKey };
+export function useShowPetById<
+  TData = Awaited<ReturnType<typeof showPetById>>,
+  TError = ErrorType<Error>,
+>(
+  petId: string,
+  version?: number,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof showPetById>>, TError, TData>
+    >;
+  },
+): UseQueryResult<TData, TError> & { queryKey: QueryKey };
 /**
  * @summary Info for a specific pet
  */
-export const useShowPetById = <
+
+export function useShowPetById<
   TData = Awaited<ReturnType<typeof showPetById>>,
   TError = ErrorType<Error>,
 >(
@@ -650,7 +1026,7 @@ export const useShowPetById = <
       UseQueryOptions<Awaited<ReturnType<typeof showPetById>>, TError, TData>
     >;
   },
-): UseQueryResult<TData, TError> & { queryKey: QueryKey } => {
+): UseQueryResult<TData, TError> & { queryKey: QueryKey } {
   const queryOptions = getShowPetByIdQueryOptions(petId, version, options);
 
   const query = useQuery(queryOptions) as UseQueryResult<TData, TError> & {
@@ -660,4 +1036,4 @@ export const useShowPetById = <
   query.queryKey = queryOptions.queryKey;
 
   return query;
-};
+}

--- a/samples/react-query/custom-client/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/react-query/custom-client/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -102,7 +102,8 @@ export type ListPetsQueryError = ErrorType<Error>;
 /**
  * @summary List all pets
  */
-export const useListPets = <
+
+export function useListPets<
   TData = Awaited<ReturnType<ReturnType<typeof useListPetsHook>>>,
   TError = ErrorType<Error>,
 >(
@@ -115,7 +116,7 @@ export const useListPets = <
       TData
     >;
   },
-): UseQueryResult<TData, TError> & { queryKey: QueryKey } => {
+): UseQueryResult<TData, TError> & { queryKey: QueryKey } {
   const queryOptions = useListPetsQueryOptions(params, version, options);
 
   const query = useQuery(queryOptions) as UseQueryResult<TData, TError> & {
@@ -125,7 +126,7 @@ export const useListPets = <
   query.queryKey = queryOptions.queryKey;
 
   return query;
-};
+}
 
 /**
  * @summary Create a pet
@@ -286,7 +287,8 @@ export type ListPetsNestedArrayQueryError = ErrorType<Error>;
 /**
  * @summary List all pets as nested array
  */
-export const useListPetsNestedArray = <
+
+export function useListPetsNestedArray<
   TData = Awaited<ReturnType<ReturnType<typeof useListPetsNestedArrayHook>>>,
   TError = ErrorType<Error>,
 >(
@@ -299,7 +301,7 @@ export const useListPetsNestedArray = <
       TData
     >;
   },
-): UseQueryResult<TData, TError> & { queryKey: QueryKey } => {
+): UseQueryResult<TData, TError> & { queryKey: QueryKey } {
   const queryOptions = useListPetsNestedArrayQueryOptions(
     params,
     version,
@@ -313,7 +315,7 @@ export const useListPetsNestedArray = <
   query.queryKey = queryOptions.queryKey;
 
   return query;
-};
+}
 
 /**
  * @summary Info for a specific pet
@@ -382,7 +384,8 @@ export type ShowPetByIdQueryError = ErrorType<Error>;
 /**
  * @summary Info for a specific pet
  */
-export const useShowPetById = <
+
+export function useShowPetById<
   TData = Awaited<ReturnType<ReturnType<typeof useShowPetByIdHook>>>,
   TError = ErrorType<Error>,
 >(
@@ -395,7 +398,7 @@ export const useShowPetById = <
       TData
     >;
   },
-): UseQueryResult<TData, TError> & { queryKey: QueryKey } => {
+): UseQueryResult<TData, TError> & { queryKey: QueryKey } {
   const queryOptions = useShowPetByIdQueryOptions(petId, version, options);
 
   const query = useQuery(queryOptions) as UseQueryResult<TData, TError> & {
@@ -405,4 +408,4 @@ export const useShowPetById = <
   query.queryKey = queryOptions.queryKey;
 
   return query;
-};
+}

--- a/samples/react-query/custom-fetch/src/gen/pets/pets.ts
+++ b/samples/react-query/custom-fetch/src/gen/pets/pets.ts
@@ -6,9 +6,12 @@
  */
 import { useMutation, useQuery } from '@tanstack/react-query';
 import type {
+  DefinedInitialDataOptions,
+  DefinedUseQueryResult,
   MutationFunction,
   QueryFunction,
   QueryKey,
+  UndefinedInitialDataOptions,
   UseMutationOptions,
   UseMutationResult,
   UseQueryOptions,
@@ -72,7 +75,9 @@ export const getListPetsUrl = (params?: ListPetsParams) => {
     }
   });
 
-  return `http://localhost:8000/pets?${normalizedParams.toString()}`;
+  return normalizedParams.size
+    ? `http://localhost:8000/pets?${normalizedParams.toString()}`
+    : `http://localhost:8000/pets`;
 };
 
 export const listPets = async (
@@ -121,10 +126,47 @@ export type ListPetsQueryResult = NonNullable<
 >;
 export type ListPetsQueryError = unknown;
 
-/**
- * @summary List all pets
- */
-export const useListPets = <
+export function useListPets<
+  TData = Awaited<ReturnType<typeof listPets>>,
+  TError = unknown,
+>(
+  params: undefined | ListPetsParams,
+  options: {
+    query: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof listPets>>, TError, TData>
+    > &
+      Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof listPets>>,
+          TError,
+          TData
+        >,
+        'initialData'
+      >;
+    request?: SecondParameter<typeof customFetch>;
+  },
+): DefinedUseQueryResult<TData, TError> & { queryKey: QueryKey };
+export function useListPets<
+  TData = Awaited<ReturnType<typeof listPets>>,
+  TError = unknown,
+>(
+  params?: ListPetsParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof listPets>>, TError, TData>
+    > &
+      Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof listPets>>,
+          TError,
+          TData
+        >,
+        'initialData'
+      >;
+    request?: SecondParameter<typeof customFetch>;
+  },
+): UseQueryResult<TData, TError> & { queryKey: QueryKey };
+export function useListPets<
   TData = Awaited<ReturnType<typeof listPets>>,
   TError = unknown,
 >(
@@ -135,7 +177,23 @@ export const useListPets = <
     >;
     request?: SecondParameter<typeof customFetch>;
   },
-): UseQueryResult<TData, TError> & { queryKey: QueryKey } => {
+): UseQueryResult<TData, TError> & { queryKey: QueryKey };
+/**
+ * @summary List all pets
+ */
+
+export function useListPets<
+  TData = Awaited<ReturnType<typeof listPets>>,
+  TError = unknown,
+>(
+  params?: ListPetsParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof listPets>>, TError, TData>
+    >;
+    request?: SecondParameter<typeof customFetch>;
+  },
+): UseQueryResult<TData, TError> & { queryKey: QueryKey } {
   const queryOptions = getListPetsQueryOptions(params, options);
 
   const query = useQuery(queryOptions) as UseQueryResult<TData, TError> & {
@@ -145,7 +203,7 @@ export const useListPets = <
   query.queryKey = queryOptions.queryKey;
 
   return query;
-};
+}
 
 /**
  * @summary Create a pet
@@ -372,10 +430,47 @@ export type ShowPetByIdQueryResult = NonNullable<
 >;
 export type ShowPetByIdQueryError = Error;
 
-/**
- * @summary Info for a specific pet
- */
-export const useShowPetById = <
+export function useShowPetById<
+  TData = Awaited<ReturnType<typeof showPetById>>,
+  TError = Error,
+>(
+  petId: string,
+  options: {
+    query: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof showPetById>>, TError, TData>
+    > &
+      Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof showPetById>>,
+          TError,
+          TData
+        >,
+        'initialData'
+      >;
+    request?: SecondParameter<typeof customFetch>;
+  },
+): DefinedUseQueryResult<TData, TError> & { queryKey: QueryKey };
+export function useShowPetById<
+  TData = Awaited<ReturnType<typeof showPetById>>,
+  TError = Error,
+>(
+  petId: string,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof showPetById>>, TError, TData>
+    > &
+      Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof showPetById>>,
+          TError,
+          TData
+        >,
+        'initialData'
+      >;
+    request?: SecondParameter<typeof customFetch>;
+  },
+): UseQueryResult<TData, TError> & { queryKey: QueryKey };
+export function useShowPetById<
   TData = Awaited<ReturnType<typeof showPetById>>,
   TError = Error,
 >(
@@ -386,7 +481,23 @@ export const useShowPetById = <
     >;
     request?: SecondParameter<typeof customFetch>;
   },
-): UseQueryResult<TData, TError> & { queryKey: QueryKey } => {
+): UseQueryResult<TData, TError> & { queryKey: QueryKey };
+/**
+ * @summary Info for a specific pet
+ */
+
+export function useShowPetById<
+  TData = Awaited<ReturnType<typeof showPetById>>,
+  TError = Error,
+>(
+  petId: string,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof showPetById>>, TError, TData>
+    >;
+    request?: SecondParameter<typeof customFetch>;
+  },
+): UseQueryResult<TData, TError> & { queryKey: QueryKey } {
   const queryOptions = getShowPetByIdQueryOptions(petId, options);
 
   const query = useQuery(queryOptions) as UseQueryResult<TData, TError> & {
@@ -396,4 +507,4 @@ export const useShowPetById = <
   query.queryKey = queryOptions.queryKey;
 
   return query;
-};
+}

--- a/samples/react-query/form-data-mutator/endpoints.ts
+++ b/samples/react-query/form-data-mutator/endpoints.ts
@@ -81,7 +81,8 @@ export type ListPetsQueryError = Error;
 /**
  * @summary List all pets
  */
-export const useListPets = <
+
+export function useListPets<
   TData = Awaited<ReturnType<typeof listPets>>,
   TError = Error,
 >(
@@ -93,7 +94,7 @@ export const useListPets = <
       TData
     >;
   },
-): UseQueryResult<TData, TError> & { queryKey: QueryKey } => {
+): UseQueryResult<TData, TError> & { queryKey: QueryKey } {
   const queryOptions = getListPetsQueryOptions(params, options);
 
   const query = useQuery(queryOptions) as UseQueryResult<TData, TError> & {
@@ -103,7 +104,7 @@ export const useListPets = <
   query.queryKey = queryOptions.queryKey;
 
   return query;
-};
+}
 
 /**
  * @summary Create a pet
@@ -232,7 +233,8 @@ export type ListPetsNestedArrayQueryError = Error;
 /**
  * @summary List all pets as nested array
  */
-export const useListPetsNestedArray = <
+
+export function useListPetsNestedArray<
   TData = Awaited<ReturnType<typeof listPetsNestedArray>>,
   TError = Error,
 >(
@@ -244,7 +246,7 @@ export const useListPetsNestedArray = <
       TData
     >;
   },
-): UseQueryResult<TData, TError> & { queryKey: QueryKey } => {
+): UseQueryResult<TData, TError> & { queryKey: QueryKey } {
   const queryOptions = getListPetsNestedArrayQueryOptions(params, options);
 
   const query = useQuery(queryOptions) as UseQueryResult<TData, TError> & {
@@ -254,7 +256,7 @@ export const useListPetsNestedArray = <
   query.queryKey = queryOptions.queryKey;
 
   return query;
-};
+}
 
 /**
  * @summary Info for a specific pet
@@ -308,7 +310,8 @@ export type ShowPetByIdQueryError = Error;
 /**
  * @summary Info for a specific pet
  */
-export const useShowPetById = <
+
+export function useShowPetById<
   TData = Awaited<ReturnType<typeof showPetById>>,
   TError = Error,
 >(
@@ -320,7 +323,7 @@ export const useShowPetById = <
       TData
     >;
   },
-): UseQueryResult<TData, TError> & { queryKey: QueryKey } => {
+): UseQueryResult<TData, TError> & { queryKey: QueryKey } {
   const queryOptions = getShowPetByIdQueryOptions(petId, options);
 
   const query = useQuery(queryOptions) as UseQueryResult<TData, TError> & {
@@ -330,4 +333,4 @@ export const useShowPetById = <
   query.queryKey = queryOptions.queryKey;
 
   return query;
-};
+}

--- a/samples/react-query/form-data/endpoints.ts
+++ b/samples/react-query/form-data/endpoints.ts
@@ -81,7 +81,8 @@ export type ListPetsQueryError = Error;
 /**
  * @summary List all pets
  */
-export const useListPets = <
+
+export function useListPets<
   TData = Awaited<ReturnType<typeof listPets>>,
   TError = Error,
 >(
@@ -93,7 +94,7 @@ export const useListPets = <
       TData
     >;
   },
-): UseQueryResult<TData, TError> & { queryKey: QueryKey } => {
+): UseQueryResult<TData, TError> & { queryKey: QueryKey } {
   const queryOptions = getListPetsQueryOptions(params, options);
 
   const query = useQuery(queryOptions) as UseQueryResult<TData, TError> & {
@@ -103,7 +104,7 @@ export const useListPets = <
   query.queryKey = queryOptions.queryKey;
 
   return query;
-};
+}
 
 /**
  * @summary Create a pet
@@ -232,7 +233,8 @@ export type ListPetsNestedArrayQueryError = Error;
 /**
  * @summary List all pets as nested array
  */
-export const useListPetsNestedArray = <
+
+export function useListPetsNestedArray<
   TData = Awaited<ReturnType<typeof listPetsNestedArray>>,
   TError = Error,
 >(
@@ -244,7 +246,7 @@ export const useListPetsNestedArray = <
       TData
     >;
   },
-): UseQueryResult<TData, TError> & { queryKey: QueryKey } => {
+): UseQueryResult<TData, TError> & { queryKey: QueryKey } {
   const queryOptions = getListPetsNestedArrayQueryOptions(params, options);
 
   const query = useQuery(queryOptions) as UseQueryResult<TData, TError> & {
@@ -254,7 +256,7 @@ export const useListPetsNestedArray = <
   query.queryKey = queryOptions.queryKey;
 
   return query;
-};
+}
 
 /**
  * @summary Info for a specific pet
@@ -308,7 +310,8 @@ export type ShowPetByIdQueryError = Error;
 /**
  * @summary Info for a specific pet
  */
-export const useShowPetById = <
+
+export function useShowPetById<
   TData = Awaited<ReturnType<typeof showPetById>>,
   TError = Error,
 >(
@@ -320,7 +323,7 @@ export const useShowPetById = <
       TData
     >;
   },
-): UseQueryResult<TData, TError> & { queryKey: QueryKey } => {
+): UseQueryResult<TData, TError> & { queryKey: QueryKey } {
   const queryOptions = getShowPetByIdQueryOptions(petId, options);
 
   const query = useQuery(queryOptions) as UseQueryResult<TData, TError> & {
@@ -330,4 +333,4 @@ export const useShowPetById = <
   query.queryKey = queryOptions.queryKey;
 
   return query;
-};
+}

--- a/samples/react-query/form-url-encoded-mutator/endpoints.ts
+++ b/samples/react-query/form-url-encoded-mutator/endpoints.ts
@@ -82,7 +82,8 @@ export type ListPetsQueryError = Error;
 /**
  * @summary List all pets
  */
-export const useListPets = <
+
+export function useListPets<
   TData = Awaited<ReturnType<typeof listPets>>,
   TError = Error,
 >(
@@ -94,7 +95,7 @@ export const useListPets = <
       TData
     >;
   },
-): UseQueryResult<TData, TError> & { queryKey: QueryKey } => {
+): UseQueryResult<TData, TError> & { queryKey: QueryKey } {
   const queryOptions = getListPetsQueryOptions(params, options);
 
   const query = useQuery(queryOptions) as UseQueryResult<TData, TError> & {
@@ -104,7 +105,7 @@ export const useListPets = <
   query.queryKey = queryOptions.queryKey;
 
   return query;
-};
+}
 
 /**
  * @summary Create a pet
@@ -233,7 +234,8 @@ export type ListPetsNestedArrayQueryError = Error;
 /**
  * @summary List all pets as nested array
  */
-export const useListPetsNestedArray = <
+
+export function useListPetsNestedArray<
   TData = Awaited<ReturnType<typeof listPetsNestedArray>>,
   TError = Error,
 >(
@@ -245,7 +247,7 @@ export const useListPetsNestedArray = <
       TData
     >;
   },
-): UseQueryResult<TData, TError> & { queryKey: QueryKey } => {
+): UseQueryResult<TData, TError> & { queryKey: QueryKey } {
   const queryOptions = getListPetsNestedArrayQueryOptions(params, options);
 
   const query = useQuery(queryOptions) as UseQueryResult<TData, TError> & {
@@ -255,7 +257,7 @@ export const useListPetsNestedArray = <
   query.queryKey = queryOptions.queryKey;
 
   return query;
-};
+}
 
 /**
  * @summary Info for a specific pet
@@ -309,7 +311,8 @@ export type ShowPetByIdQueryError = Error;
 /**
  * @summary Info for a specific pet
  */
-export const useShowPetById = <
+
+export function useShowPetById<
   TData = Awaited<ReturnType<typeof showPetById>>,
   TError = Error,
 >(
@@ -321,7 +324,7 @@ export const useShowPetById = <
       TData
     >;
   },
-): UseQueryResult<TData, TError> & { queryKey: QueryKey } => {
+): UseQueryResult<TData, TError> & { queryKey: QueryKey } {
   const queryOptions = getShowPetByIdQueryOptions(petId, options);
 
   const query = useQuery(queryOptions) as UseQueryResult<TData, TError> & {
@@ -331,4 +334,4 @@ export const useShowPetById = <
   query.queryKey = queryOptions.queryKey;
 
   return query;
-};
+}

--- a/samples/react-query/form-url-encoded/endpoints.ts
+++ b/samples/react-query/form-url-encoded/endpoints.ts
@@ -81,7 +81,8 @@ export type ListPetsQueryError = Error;
 /**
  * @summary List all pets
  */
-export const useListPets = <
+
+export function useListPets<
   TData = Awaited<ReturnType<typeof listPets>>,
   TError = Error,
 >(
@@ -93,7 +94,7 @@ export const useListPets = <
       TData
     >;
   },
-): UseQueryResult<TData, TError> & { queryKey: QueryKey } => {
+): UseQueryResult<TData, TError> & { queryKey: QueryKey } {
   const queryOptions = getListPetsQueryOptions(params, options);
 
   const query = useQuery(queryOptions) as UseQueryResult<TData, TError> & {
@@ -103,7 +104,7 @@ export const useListPets = <
   query.queryKey = queryOptions.queryKey;
 
   return query;
-};
+}
 
 /**
  * @summary Create a pet
@@ -232,7 +233,8 @@ export type ListPetsNestedArrayQueryError = Error;
 /**
  * @summary List all pets as nested array
  */
-export const useListPetsNestedArray = <
+
+export function useListPetsNestedArray<
   TData = Awaited<ReturnType<typeof listPetsNestedArray>>,
   TError = Error,
 >(
@@ -244,7 +246,7 @@ export const useListPetsNestedArray = <
       TData
     >;
   },
-): UseQueryResult<TData, TError> & { queryKey: QueryKey } => {
+): UseQueryResult<TData, TError> & { queryKey: QueryKey } {
   const queryOptions = getListPetsNestedArrayQueryOptions(params, options);
 
   const query = useQuery(queryOptions) as UseQueryResult<TData, TError> & {
@@ -254,7 +256,7 @@ export const useListPetsNestedArray = <
   query.queryKey = queryOptions.queryKey;
 
   return query;
-};
+}
 
 /**
  * @summary Info for a specific pet
@@ -308,7 +310,8 @@ export type ShowPetByIdQueryError = Error;
 /**
  * @summary Info for a specific pet
  */
-export const useShowPetById = <
+
+export function useShowPetById<
   TData = Awaited<ReturnType<typeof showPetById>>,
   TError = Error,
 >(
@@ -320,7 +323,7 @@ export const useShowPetById = <
       TData
     >;
   },
-): UseQueryResult<TData, TError> & { queryKey: QueryKey } => {
+): UseQueryResult<TData, TError> & { queryKey: QueryKey } {
   const queryOptions = getShowPetByIdQueryOptions(petId, options);
 
   const query = useQuery(queryOptions) as UseQueryResult<TData, TError> & {
@@ -330,4 +333,4 @@ export const useShowPetById = <
   query.queryKey = queryOptions.queryKey;
 
   return query;
-};
+}

--- a/samples/react-query/hook-mutator/endpoints.ts
+++ b/samples/react-query/hook-mutator/endpoints.ts
@@ -86,7 +86,8 @@ export type ListPetsQueryError = Error;
 /**
  * @summary List all pets
  */
-export const useListPets = <
+
+export function useListPets<
   TData = Awaited<ReturnType<ReturnType<typeof useListPetsHook>>>,
   TError = Error,
 >(
@@ -98,7 +99,7 @@ export const useListPets = <
       TData
     >;
   },
-): UseQueryResult<TData, TError> & { queryKey: QueryKey } => {
+): UseQueryResult<TData, TError> & { queryKey: QueryKey } {
   const queryOptions = useListPetsQueryOptions(params, options);
 
   const query = useQuery(queryOptions) as UseQueryResult<TData, TError> & {
@@ -108,7 +109,7 @@ export const useListPets = <
   query.queryKey = queryOptions.queryKey;
 
   return query;
-};
+}
 
 /**
  * @summary Create a pet
@@ -252,7 +253,8 @@ export type ListPetsNestedArrayQueryError = Error;
 /**
  * @summary List all pets as nested array
  */
-export const useListPetsNestedArray = <
+
+export function useListPetsNestedArray<
   TData = Awaited<ReturnType<ReturnType<typeof useListPetsNestedArrayHook>>>,
   TError = Error,
 >(
@@ -264,7 +266,7 @@ export const useListPetsNestedArray = <
       TData
     >;
   },
-): UseQueryResult<TData, TError> & { queryKey: QueryKey } => {
+): UseQueryResult<TData, TError> & { queryKey: QueryKey } {
   const queryOptions = useListPetsNestedArrayQueryOptions(params, options);
 
   const query = useQuery(queryOptions) as UseQueryResult<TData, TError> & {
@@ -274,7 +276,7 @@ export const useListPetsNestedArray = <
   query.queryKey = queryOptions.queryKey;
 
   return query;
-};
+}
 
 /**
  * @summary Info for a specific pet
@@ -337,7 +339,8 @@ export type ShowPetByIdQueryError = Error;
 /**
  * @summary Info for a specific pet
  */
-export const useShowPetById = <
+
+export function useShowPetById<
   TData = Awaited<ReturnType<ReturnType<typeof useShowPetByIdHook>>>,
   TError = Error,
 >(
@@ -349,7 +352,7 @@ export const useShowPetById = <
       TData
     >;
   },
-): UseQueryResult<TData, TError> & { queryKey: QueryKey } => {
+): UseQueryResult<TData, TError> & { queryKey: QueryKey } {
   const queryOptions = useShowPetByIdQueryOptions(petId, options);
 
   const query = useQuery(queryOptions) as UseQueryResult<TData, TError> & {
@@ -359,4 +362,4 @@ export const useShowPetById = <
   query.queryKey = queryOptions.queryKey;
 
   return query;
-};
+}

--- a/samples/svelte-query/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/svelte-query/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -89,7 +89,8 @@ export type ListPetsQueryError = Error;
 /**
  * @summary List all pets
  */
-export const createListPets = <
+
+export function createListPets<
   TData = Awaited<ReturnType<typeof listPets>>,
   TError = Error,
 >(
@@ -102,7 +103,7 @@ export const createListPets = <
       TData
     >;
   },
-): CreateQueryResult<TData, TError> & { queryKey: QueryKey } => {
+): CreateQueryResult<TData, TError> & { queryKey: QueryKey } {
   const queryOptions = getListPetsQueryOptions(params, version, options);
 
   const query = createQuery(queryOptions) as CreateQueryResult<
@@ -113,7 +114,7 @@ export const createListPets = <
   query.queryKey = queryOptions.queryKey;
 
   return query;
-};
+}
 
 /**
  * @summary Create a pet
@@ -249,7 +250,8 @@ export type ShowPetByIdQueryError = Error;
 /**
  * @summary Info for a specific pet
  */
-export const createShowPetById = <
+
+export function createShowPetById<
   TData = Awaited<ReturnType<typeof showPetById>>,
   TError = Error,
 >(
@@ -262,7 +264,7 @@ export const createShowPetById = <
       TData
     >;
   },
-): CreateQueryResult<TData, TError> & { queryKey: QueryKey } => {
+): CreateQueryResult<TData, TError> & { queryKey: QueryKey } {
   const queryOptions = getShowPetByIdQueryOptions(petId, version, options);
 
   const query = createQuery(queryOptions) as CreateQueryResult<
@@ -273,4 +275,4 @@ export const createShowPetById = <
   query.queryKey = queryOptions.queryKey;
 
   return query;
-};
+}

--- a/samples/svelte-query/custom-fetch/src/gen/pets/pets.ts
+++ b/samples/svelte-query/custom-fetch/src/gen/pets/pets.ts
@@ -72,7 +72,9 @@ export const getListPetsUrl = (params?: ListPetsParams) => {
     }
   });
 
-  return `http://localhost:8000/pets?${normalizedParams.toString()}`;
+  return normalizedParams.size
+    ? `http://localhost:8000/pets?${normalizedParams.toString()}`
+    : `http://localhost:8000/pets`;
 };
 
 export const listPets = async (
@@ -126,7 +128,8 @@ export type ListPetsQueryError = unknown;
 /**
  * @summary List all pets
  */
-export const createListPets = <
+
+export function createListPets<
   TData = Awaited<ReturnType<typeof listPets>>,
   TError = unknown,
 >(
@@ -139,7 +142,7 @@ export const createListPets = <
     >;
     request?: SecondParameter<typeof customFetch>;
   },
-): CreateQueryResult<TData, TError> & { queryKey: QueryKey } => {
+): CreateQueryResult<TData, TError> & { queryKey: QueryKey } {
   const queryOptions = getListPetsQueryOptions(params, options);
 
   const query = createQuery(queryOptions) as CreateQueryResult<
@@ -150,7 +153,7 @@ export const createListPets = <
   query.queryKey = queryOptions.queryKey;
 
   return query;
-};
+}
 
 /**
  * @summary Create a pet
@@ -382,7 +385,8 @@ export type ShowPetByIdQueryError = Error;
 /**
  * @summary Info for a specific pet
  */
-export const createShowPetById = <
+
+export function createShowPetById<
   TData = Awaited<ReturnType<typeof showPetById>>,
   TError = Error,
 >(
@@ -395,7 +399,7 @@ export const createShowPetById = <
     >;
     request?: SecondParameter<typeof customFetch>;
   },
-): CreateQueryResult<TData, TError> & { queryKey: QueryKey } => {
+): CreateQueryResult<TData, TError> & { queryKey: QueryKey } {
   const queryOptions = getShowPetByIdQueryOptions(petId, options);
 
   const query = createQuery(queryOptions) as CreateQueryResult<
@@ -406,4 +410,4 @@ export const createShowPetById = <
   query.queryKey = queryOptions.queryKey;
 
   return query;
-};
+}

--- a/samples/vue-query/custom-fetch/src/gen/pets/pets.ts
+++ b/samples/vue-query/custom-fetch/src/gen/pets/pets.ts
@@ -74,7 +74,9 @@ export const getListPetsUrl = (params?: ListPetsParams) => {
     }
   });
 
-  return `http://localhost:8000/pets?${normalizedParams.toString()}`;
+  return normalizedParams.size
+    ? `http://localhost:8000/pets?${normalizedParams.toString()}`
+    : `http://localhost:8000/pets`;
 };
 
 export const listPets = async (

--- a/samples/vue-query/vue-query-basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/vue-query/vue-query-basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -114,7 +114,8 @@ export type ListPetsInfiniteQueryError = Error;
 /**
  * @summary List all pets
  */
-export const useListPetsInfinite = <
+
+export function useListPetsInfinite<
   TData = InfiniteData<
     Awaited<ReturnType<typeof listPets>>,
     ListPetsParams['limit']
@@ -135,7 +136,7 @@ export const useListPetsInfinite = <
       >
     >;
   },
-): UseInfiniteQueryReturnType<TData, TError> & { queryKey: QueryKey } => {
+): UseInfiniteQueryReturnType<TData, TError> & { queryKey: QueryKey } {
   const queryOptions = getListPetsInfiniteQueryOptions(
     params,
     version,
@@ -150,7 +151,7 @@ export const useListPetsInfinite = <
   query.queryKey = unref(queryOptions).queryKey as QueryKey;
 
   return query;
-};
+}
 
 export const getListPetsQueryOptions = <
   TData = Awaited<ReturnType<typeof listPets>>,
@@ -188,7 +189,8 @@ export type ListPetsQueryError = Error;
 /**
  * @summary List all pets
  */
-export const useListPets = <
+
+export function useListPets<
   TData = Awaited<ReturnType<typeof listPets>>,
   TError = Error,
 >(
@@ -199,7 +201,7 @@ export const useListPets = <
       UseQueryOptions<Awaited<ReturnType<typeof listPets>>, TError, TData>
     >;
   },
-): UseQueryReturnType<TData, TError> & { queryKey: QueryKey } => {
+): UseQueryReturnType<TData, TError> & { queryKey: QueryKey } {
   const queryOptions = getListPetsQueryOptions(params, version, options);
 
   const query = useQuery(queryOptions) as UseQueryReturnType<TData, TError> & {
@@ -209,7 +211,7 @@ export const useListPets = <
   query.queryKey = unref(queryOptions).queryKey as QueryKey;
 
   return query;
-};
+}
 
 /**
  * @summary Create a pet
@@ -355,7 +357,8 @@ export type ShowPetByIdInfiniteQueryError = Error;
 /**
  * @summary Info for a specific pet
  */
-export const useShowPetByIdInfinite = <
+
+export function useShowPetByIdInfinite<
   TData = InfiniteData<Awaited<ReturnType<typeof showPetById>>>,
   TError = Error,
 >(
@@ -370,7 +373,7 @@ export const useShowPetByIdInfinite = <
       >
     >;
   },
-): UseInfiniteQueryReturnType<TData, TError> & { queryKey: QueryKey } => {
+): UseInfiniteQueryReturnType<TData, TError> & { queryKey: QueryKey } {
   const queryOptions = getShowPetByIdInfiniteQueryOptions(
     petId,
     version,
@@ -385,7 +388,7 @@ export const useShowPetByIdInfinite = <
   query.queryKey = unref(queryOptions).queryKey as QueryKey;
 
   return query;
-};
+}
 
 export const getShowPetByIdQueryOptions = <
   TData = Awaited<ReturnType<typeof showPetById>>,
@@ -423,7 +426,8 @@ export type ShowPetByIdQueryError = Error;
 /**
  * @summary Info for a specific pet
  */
-export const useShowPetById = <
+
+export function useShowPetById<
   TData = Awaited<ReturnType<typeof showPetById>>,
   TError = Error,
 >(
@@ -434,7 +438,7 @@ export const useShowPetById = <
       UseQueryOptions<Awaited<ReturnType<typeof showPetById>>, TError, TData>
     >;
   },
-): UseQueryReturnType<TData, TError> & { queryKey: QueryKey } => {
+): UseQueryReturnType<TData, TError> & { queryKey: QueryKey } {
   const queryOptions = getShowPetByIdQueryOptions(petId, version, options);
 
   const query = useQuery(queryOptions) as UseQueryReturnType<TData, TError> & {
@@ -444,7 +448,7 @@ export const useShowPetById = <
   query.queryKey = unref(queryOptions).queryKey as QueryKey;
 
   return query;
-};
+}
 
 /**
  * @summary This is required to test case when there are no parameters (this path is ignored in add-version transformer), see https://github.com/anymaniax/orval/issues/857#issuecomment-1835317990


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

I extracted from #1504 what removes the unnecessary question mark in the "fetch" query parameter

## Related PRs

#1504 

## Todos

- [x] Tests
- [x] Documentation
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce

I test in the `next-app-with-fetch` sample app.

```ts
import { listPets } from './gen/pets/pets';

export default async function Pets() {
  // input blank object
  const { data: pets, status } = await listPets({});
```

### Before

request to `http://localhost:3000/pets?`

### After

request to `http://localhost:3000/pets`