### PR TITLE
docs: added using `fetch` as an http client

### DIFF
--- a/docs/src/manifests/manifest.json
+++ b/docs/src/manifests/manifest.json
@@ -46,6 +46,11 @@
           "editUrl": "/guides/basics.md"
         },
         {
+          "title": "Fetch client",
+          "path": "/guides/fetch-client",
+          "editUrl": "/guides/fetch-client.md"
+        },
+        {
           "title": "Fetch API",
           "path": "/guides/fetch",
           "editUrl": "/guides/fetch.md"

--- a/docs/src/pages/guides/custom-client.md
+++ b/docs/src/pages/guides/custom-client.md
@@ -55,3 +55,5 @@ export type ErrorType<Error> = AxiosError<Error>;
 // (if the custom instance is processing data before sending it, like changing the case for example)
 export type BodyType<BodyData> = CamelCase<BodyType>;
 ```
+
+Or, Please refer to the using custom fetch with Next.js sample app [here](https://github.com/anymaniax/orval/blob/master/samples/next-app-with-fetch/custom-fetch.ts).

--- a/docs/src/pages/guides/fetch-client.md
+++ b/docs/src/pages/guides/fetch-client.md
@@ -1,0 +1,115 @@
+### Fetch client
+
+If you want to use to the `fetch` API as an http client with `swr` or `TanStack Query` clients, you can change the http client from `axios` to `fetch` API by setting the `httpClient` option.
+
+```js
+module.exports = {
+  petstore: {
+    output: {
+      ...
+      client: 'swr',
+      httpClinet: 'fetch'
+      ...
+    },
+  },
+};
+```
+
+```ts
+/**
+ * @summary List all pets
+ */
+export type listPetsResponse = {
+  data: Pets;
+  status: number;
+};
+
+export const getListPetsUrl = (params?: ListPetsParams) => {
+  const normalizedParams = new URLSearchParams();
+
+  Object.entries(params || {}).forEach(([key, value]) => {
+    if (value === null) {
+      normalizedParams.append(key, 'null');
+    } else if (value !== undefined) {
+      normalizedParams.append(key, value.toString());
+    }
+  });
+
+  return normalizedParams.size
+    ? `http://localhost:8000/pets?${normalizedParams.toString()}`
+    : `http://localhost:8000/pets`;
+};
+
+export const listPets = async (
+  params?: ListPetsParams,
+  options?: RequestInit,
+): Promise<listPetsResponse> => {
+  const res = await fetch(getListPetsUrl(params), {
+    ...options,
+    method: 'GET',
+  });
+  const data = await res.json();
+
+  return { status: res.status, data };
+};
+
+export const getListPetsKey = (params?: ListPetsParams) =>
+  [`http://localhost:8000/pets`, ...(params ? [params] : [])] as const;
+
+export type ListPetsQueryResult = NonNullable<
+  Awaited<ReturnType<typeof listPets>>
+>;
+export type ListPetsQueryError = Promise<Pets | Error>;
+
+/**
+ * @summary List all pets
+ */
+export const useListPets = <TError = Promise<Pets | Error>>(
+  params?: ListPetsParams,
+  options?: {
+    swr?: SWRConfiguration<Awaited<ReturnType<typeof listPets>>, TError> & {
+      swrKey?: Key;
+      enabled?: boolean;
+    };
+    fetch?: RequestInit;
+  },
+) => {
+  const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
+
+  const isEnabled = swrOptions?.enabled !== false;
+  const swrKey =
+    swrOptions?.swrKey ?? (() => (isEnabled ? getListPetsKey(params) : null));
+  const swrFn = () => listPets(params, fetchOptions);
+
+  const query = useSwr<Awaited<ReturnType<typeof swrFn>>, TError>(
+    swrKey,
+    swrFn,
+    swrOptions,
+  );
+
+  return {
+    swrKey,
+    ...query,
+  };
+};
+```
+
+Also, if you want to use to the custom fetch client, you can set in the override option.
+
+```js
+module.exports = {
+  petstore: {
+    output: {
+      ...
+      client: 'swr',
+      httpClinet: 'fetch'
+      override: {
+        mutator: {
+          path: './src/mutator.ts',
+          name: 'customFetch',
+        },
+      },
+    },
+  },
+};
+```

--- a/docs/src/pages/guides/fetch.md
+++ b/docs/src/pages/guides/fetch.md
@@ -3,7 +3,7 @@ id: fetch
 title: Fetch
 ---
 
-<a href="https://developer.mozilla.org/en-US/docs/Web/API/fetch" target="_blank">The `fetch` API</a> has the advantage of reducing the bundle size of the application compared to using `Axios`. It can also act as an `http client` in server-side frameworks and edge computing runtimes such as `Cloudflare`, `Vercel Edge` and `Deno`.
+The `fetch` API has the advantage of reducing the bundle size of the application compared to using `Axios`. It can also act as an `http client` in server-side frameworks and edge computing runtimes such as `Cloudflare`, `Vercel Edge` and `Deno`.
 
 You should have an `OpenAPI` specification and an `Orval` config where you define the mode as `fetch`.
 
@@ -77,7 +77,7 @@ The `fetch` client will generate an implementation file with following per path 
 
 Checkout <a href="https://github.com/anymaniax/orval/blob/master/samples/next-app-with-fetch" target="_blank">here</a> the full example
 
-#### Custom instance
+#### Custom function
 
 You can add a custom `fetch` function to your config.
 

--- a/docs/src/pages/guides/set-base-url.md
+++ b/docs/src/pages/guides/set-base-url.md
@@ -41,6 +41,44 @@ There is also the possibility to create a custom axios instance. Check the [full
 const AXIOS_INSTANCE = axios.create({ baseURL: '<BACKEND URL>' }); // use your own URL here or environment variable
 ```
 
+### Fetch client
+
+Also, if you are using the `fetch` client, you can still set the request URL with the custom fetch client.
+
+```ts
+const getUrl = (contextUrl: string): string => {
+  const url = new URL(contextUrl);
+  const pathname = url.pathname;
+  const search = url.search;
+  const baseUrl =
+    process.env.NODE_ENV === 'production'
+      ? 'productionBaseUrl'
+      : 'http://localhost:3000';
+
+  const requestUrl = new URL(`${baseUrl}${pathname}${search}`);
+
+  return requestUrl.toString();
+};
+
+export const customFetch = async <T>(
+  url: string,
+  options: RequestInit,
+): Promise<T> => {
+  const requestUrl = getUrl(url);
+  const requestInit: RequestInit = {
+    ...options,
+  };
+
+  const request = new Request(requestUrl, requestInit);
+  const response = await fetch(request);
+  const data = await getBody<T>(response);
+
+  return { status: response.status, data } as T;
+};
+```
+
+Please refer to the complete sample [here](https://github.com/anymaniax/orval/blob/master/samples/next-app-with-fetch/custom-fetch.ts)
+
 ### Angular http client
 
 You can use an interceptor to automatically add the url of your API. Like you would do to add an authorization header.

--- a/docs/src/pages/overview.md
+++ b/docs/src/pages/overview.md
@@ -15,7 +15,7 @@ Main goals:
 - Generate HTTP Calls
 - Generate Mocks with <a href="https://mswjs.io/" target="_blank">MSW</a>
 
-The default generated client use axios and can be used by your favourite Javascript framework like Angular, React or Vue. It's just a function who takes an instance of axios in argument and return an object where each key is a function who setup a call HTTP. [Learn more](./guides/basics)
+The default generated client use axios and can be used by fetch API or your favourite Javascript framework like Angular, React or Vue. It's just a function who takes an instance of axios or function of fetch API in argument and return an object where each key is a function who setup a call HTTP. [Learn more](./guides/basics)
 
 Orval can also generate the following client:
 


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

follow up #1387 
I added docs for using `fetch` as an http client.

## Related PRs

none

## Todos

- [x] Tests
- [x] Documentation
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce

none