### PR TITLE
feat(fetch): support form data and form url encoded request

### DIFF
--- a/packages/fetch/src/index.ts
+++ b/packages/fetch/src/index.ts
@@ -94,7 +94,9 @@ ${
     ? `${stringify(override?.requestOptions)?.slice(1, -1)?.trim()}`
     : '';
   const fetchMethodOption = `method: '${verb.toUpperCase()}'`;
-
+  const fetchHeadersOption = body.contentType
+    ? `headers: { 'Content-Type': '${body.contentType}' }`
+    : '';
   const requestBodyParams = generateBodyOptions(
     body,
     isFormData,
@@ -109,7 +111,8 @@ ${
   const fetchFnOptions = `${getUrlFnName}(${getUrlFnProperties}),
   {${globalFetchOptions ? '\n' : ''}      ${globalFetchOptions}
     ${isRequestOptions ? '...options,' : ''}
-    ${fetchMethodOption}${fetchBodyOption ? ',' : ''}
+    ${fetchMethodOption}${fetchHeadersOption ? ',' : ''}
+    ${fetchHeadersOption}${fetchBodyOption ? ',' : ''}
     ${fetchBodyOption}
   }
 `;

--- a/packages/fetch/src/index.ts
+++ b/packages/fetch/src/index.ts
@@ -101,7 +101,9 @@ ${
     isFormUrlEncoded,
   );
   const fetchBodyOption = requestBodyParams
-    ? `body: JSON.stringify(${requestBodyParams})`
+    ? isFormData || isFormUrlEncoded
+      ? `body: ${requestBodyParams}`
+      : `body: JSON.stringify(${requestBodyParams})`
     : '';
 
   const fetchFnOptions = `${getUrlFnName}(${getUrlFnProperties}),

--- a/packages/fetch/src/index.ts
+++ b/packages/fetch/src/index.ts
@@ -131,9 +131,12 @@ ${
 
   const fetchImplementationBody = mutator
     ? customFetchResponseImplementation
-    : `${bodyForm ? `  ${bodyForm}\n` : ''}` +
-      `  ${fetchResponseImplementation}`;
-  const fetchImplementation = `export const ${operationName} = async (${args}): ${retrunType} => {\n${fetchImplementationBody}}`;
+    : fetchResponseImplementation;
+
+  const fetchImplementation = `export const ${operationName} = async (${args}): ${retrunType} => {
+  ${bodyForm ? `  ${bodyForm}` : ''}
+  ${fetchImplementationBody}}
+`;
 
   const implementation =
     `${responseTypeImplementation}\n\n` +

--- a/packages/fetch/src/index.ts
+++ b/packages/fetch/src/index.ts
@@ -101,7 +101,7 @@ ${
     isFormUrlEncoded,
   );
   const fetchBodyOption = requestBodyParams
-    ? isFormData || isFormUrlEncoded
+    ? (isFormData && body.formData) || (isFormUrlEncoded && body.formUrlEncoded)
       ? `body: ${requestBodyParams}`
       : `body: JSON.stringify(${requestBodyParams})`
     : '';

--- a/samples/next-app-with-fetch/app/gen/pets/pets.ts
+++ b/samples/next-app-with-fetch/app/gen/pets/pets.ts
@@ -93,6 +93,7 @@ export const createPets = async (
   return customFetch<Promise<createPetsResponse>>(getCreatePetsUrl(), {
     ...options,
     method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(createPetsBodyItem),
   });
 };
@@ -116,6 +117,7 @@ export const updatePets = async (
   return customFetch<Promise<updatePetsResponse>>(getUpdatePetsUrl(), {
     ...options,
     method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(pet),
   });
 };

--- a/samples/react-query/custom-fetch/src/gen/pets/pets.ts
+++ b/samples/react-query/custom-fetch/src/gen/pets/pets.ts
@@ -224,6 +224,7 @@ export const createPets = async (
   return customFetch<Promise<createPetsResponse>>(getCreatePetsUrl(), {
     ...options,
     method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(createPetsBodyItem),
   });
 };
@@ -305,6 +306,7 @@ export const updatePets = async (
   return customFetch<Promise<updatePetsResponse>>(getUpdatePetsUrl(), {
     ...options,
     method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(pet),
   });
 };

--- a/samples/svelte-query/custom-fetch/src/gen/pets/pets.ts
+++ b/samples/svelte-query/custom-fetch/src/gen/pets/pets.ts
@@ -174,6 +174,7 @@ export const createPets = async (
   return customFetch<Promise<createPetsResponse>>(getCreatePetsUrl(), {
     ...options,
     method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(createPetsBodyItem),
   });
 };
@@ -255,6 +256,7 @@ export const updatePets = async (
   return customFetch<Promise<updatePetsResponse>>(getUpdatePetsUrl(), {
     ...options,
     method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(pet),
   });
 };

--- a/samples/vue-query/custom-fetch/src/gen/pets/pets.ts
+++ b/samples/vue-query/custom-fetch/src/gen/pets/pets.ts
@@ -176,6 +176,7 @@ export const createPets = async (
   return customFetch<Promise<createPetsResponse>>(getCreatePetsUrl(), {
     ...options,
     method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(createPetsBodyItem),
   });
 };
@@ -257,6 +258,7 @@ export const updatePets = async (
   return customFetch<Promise<updatePetsResponse>>(getUpdatePetsUrl(), {
     ...options,
     method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(pet),
   });
 };

--- a/tests/configs/fetch.config.ts
+++ b/tests/configs/fetch.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
       target: '../generated/fetch/petstore/endpoints.ts',
       schemas: '../generated/fetch/petstore/model',
       mock: true,
-      client: 'axios',
+      client: 'fetch',
     },
     input: {
       target: '../specifications/petstore.yaml',
@@ -87,6 +87,69 @@ export default defineConfig({
     },
     input: {
       target: '../specifications/petstore.yaml',
+    },
+  },
+  formData: {
+    output: {
+      target: '../generated/fetch/form-data-optional-request/endpoints.ts',
+      schemas: '../generated/fetch/form-data-optional-request/model',
+      client: 'swr',
+      mock: true,
+    },
+    input: {
+      target: '../specifications/form-data-optional-request.yaml',
+      override: {
+        transformer: '../transformers/add-version.js',
+      },
+    },
+  },
+  formDataWithCustomFetch: {
+    output: {
+      target: '../generated/fetch/form-data-with-custom-fetch/endpoints.ts',
+      schemas: '../generated/fetch/form-data-with-custom-fetch/model',
+      client: 'fetch',
+      mock: true,
+      override: {
+        mutator: {
+          path: '../mutators/custom-fetch.ts',
+          name: 'customFetch',
+        },
+      },
+    },
+    input: {
+      target: '../specifications/form-data-optional-request.yaml',
+      override: {
+        transformer: '../transformers/add-version.js',
+      },
+    },
+  },
+  formUrlEncoded: {
+    output: {
+      target: '../generated/fetch/form-url-encoded/endpoints.ts',
+      schemas: '../generated/fetch/form-url-encoded/model',
+      client: 'fetch',
+      mock: true,
+    },
+    input: {
+      target: '../specifications/form-url-encoded.yaml',
+    },
+  },
+  formUrlEncodedCustomFetch: {
+    output: {
+      target:
+        '../generated/fetch/form-url-encoded-with-custom-fetch/endpoints.ts',
+      schemas: '../generated/fetch/form-url-encoded-with-custom-fetch/model',
+      client: 'fetch',
+      mock: true,
+      override: {
+        mutator: {
+          path: '../mutators/custom-fetch.ts',
+          name: 'customFetch',
+        },
+      },
+    },
+    input: {
+      target: '../specifications/form-url-encoded.yaml',
     },
   },
 });

--- a/tests/configs/fetch.config.ts
+++ b/tests/configs/fetch.config.ts
@@ -93,7 +93,7 @@ export default defineConfig({
     output: {
       target: '../generated/fetch/form-data-optional-request/endpoints.ts',
       schemas: '../generated/fetch/form-data-optional-request/model',
-      client: 'swr',
+      client: 'fetch',
       mock: true,
     },
     input: {


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

follow up #1387 
fix #1525 

I made the `fetch` client support cases other than `application/json`, such as `multipart/form-data` and `application/x-www-form-urlencoded`. And, if input `OpenAPI` have `content-type`, add `Content-Type` header to fetch request options.

## Related PRs

none

## Todos

- [x] Tests
- [x] Documentation
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce

You can check from the test case I added